### PR TITLE
Fix out-of-place double quotes, change default string delimiter and remove weird chars

### DIFF
--- a/redbot/trivia/lists/2015.yaml
+++ b/redbot/trivia/lists/2015.yaml
@@ -1,9 +1,9 @@
-'"Dismaland" was the temporary theme park/exhibition of which famous "anonymous" artist?':
-- Banksy
-'"Egoportrait" (a Quebecois word) was added to the 2015 French dictionary, meaning what more popular new English word?':
-- Selfie
-'"L.A. Love (La La)" is the title of a January 2015 Top Ten Smash hit for which singer?':
+"\"L.A. Love (La La)\" is the title of a January 2015 Top Ten Smash hit for which singer?":
 - fergie
+"'Dismaland' was the temporary theme park/exhibition of which famous 'anonymous' artist?":
+- Banksy
+"'Egoportrait' (a Quebecois word) was added to the 2015 French dictionary, meaning what more popular new English word?":
+- Selfie
 A 2015 intensive listening study discovered that giraffes actually?:
 - Hum
 A 2015 study found that what percentage of former American Football players had degenerative brain damage?:
@@ -13,9 +13,9 @@ A 2015 study found that what percentage of former American Football players had 
 According to 2015 survey what fruit was most popular among USA children?:
 - Apples
 - apple
-At auction in 2015, $1.2m was paid for Don McLean"s original handrwitten lyrics for which 1971 big hit song?:
+At auction in 2015, $1.2m was paid for Don McLean's original handrwitten lyrics for which 1971 big hit song?:
 - American Pie
-Blackberry"s new phone for 2015 was called the...?:
+Blackberry's new phone for 2015 was called the...?:
 - Priv
 Brazil began to nationalise its (What?) in 2015?:
 - Rainforest
@@ -32,13 +32,13 @@ Due to a 2015 contamination scandal in India/Afica, which corporation destroyed 
 Eddie Jones was appointed head coach of which English sporting team in 2015?:
 - Rugby Union
 - rugby
-Facebook"s new music sharing/streaming feature launched in 2015 was called "Music... "?:
+Facebook's new music sharing/streaming feature launched in 2015 was called "Music... "?:
 - Stories
-Facebook"s news service launched in 2015 was called?:
+Facebook's news service launched in 2015 was called?:
 - Notify
 Finance minister Yanis Yaroufakis caused comment for not wearing a tie in February 2015 when negotiating the debts for which nation?:
 - Greece
-Ford claimed to launch the first "e-(What?)" at the 2015 Mobile World Congress Show?:
+Ford claimed to launch the first 'e-(What?)' at the 2015 Mobile World Congress Show?:
 - Bike
 Frank Sinatra would have celebrated which birthday in 2015?:
 - 100
@@ -79,7 +79,7 @@ It was announced in 2015 that Alexander Hamilton would be replaced on?:
 - ten dollar
 Jay Z and Beyonce launched a music streaming service in 2015 called?:
 - Tidal
-Jon Snow was killed off in what TV series in 2015, adapted from GRR Martin"s "A Song of Ice and Fire"?:
+Jon Snow was killed off in what TV series in 2015, adapted from GRR Martin's 'A Song of Ice and Fire'?:
 - Game of Thrones
 Lars Lokke led his centre-right party to 2015 government election victory in what country?:
 - Denmark
@@ -92,9 +92,9 @@ Mauricio Marci was elected president of which South American nation in 2015?:
 - Argentina
 Microsoft announced which new operating system in January 2015?:
 - windows 10
-Name Adele"s record-breaking 2015 album?:
+Name Adele's record-breaking 2015 album?:
 - 25
-Name the Princess born 4th in succession to the British throne in 2015, to Britain"s Duke and Duchess of Cambridge?:
+Name the Princess born 4th in succession to the British throne in 2015, to Britain's Duke and Duchess of Cambridge?:
 - Charlotte
 Name the head of FIFA subject to criminal process in 2015?:
 - Sepp Blatter
@@ -110,7 +110,7 @@ Published in 2015, Go Set a Watchman, written before her only prior and enduring
 - Harper Lee
 The 2015 Mad Max movie is sub-titled?:
 - Fury Road
-- 'mad max: fury road'
+- "mad max: fury road"
 - mad max fury road
 The 2015 Tour de France began in what country?:
 - The Netherlands
@@ -143,13 +143,13 @@ What is the title of the animated superhero Disney film released in January 2015
 - big hero six
 What is the year 2015 in Roman numerals?:
 - MMXV
-What nation hosted the 2015 Women"s World (soccer) Cup?:
+What nation hosted the 2015 Women's World (soccer) Cup?:
 - Canada
-Which "BRIC" country launched the Astrosat space lab in 2015?:
+Which 'BRIC' country launched the Astrosat space lab in 2015?:
 - India
 Which car company launched the Avensis model in 2015?:
 - Toyota
-Which company suffered a major scandal in 2015 for widescale unethical "inertia" charging for its "Prime" service?:
+Which company suffered a major scandal in 2015 for widescale unethical 'inertia' charging for its 'Prime' service?:
 - Amazon
 Which country won the 2015 Davis Cup (world team tennis)?:
 - Great Britain
@@ -158,7 +158,7 @@ Which leading professional networking tech corporation, whose main revenue is se
 - linked in
 Which singer surpassed Elvis in 2015 in terms of all time US album sales?:
 - garth brooks
-Which vast tech corporation opened its first "Nest" branded intelligent home store in Palo Alto California in 2015?:
+Which vast tech corporation opened its first 'Nest' branded intelligent home store in Palo Alto California in 2015?:
 - Google
 Who had the most liked Instagram photo of 2015?:
 - Kendall Jenner
@@ -171,7 +171,7 @@ Who won the 2015 Superbowl?:
 - New England Patriots
 - Patriots
 - the patriots
-Who won the 2015 men"s tennis French Open?:
+Who won the 2015 men's tennis French Open?:
 - Stan Warwinka
 - warwinka
 Who won the Premier League in 2015?:
@@ -179,9 +179,9 @@ Who won the Premier League in 2015?:
 - chelsea f.c.
 Who won the Rugby World Cup in 2015?:
 - New zealand
-Who won the men"s World Ice Hockey Championship in 2015?:
+Who won the men's World Ice Hockey Championship in 2015?:
 - Canada
-Whose 2015 album is "Purpose"?:
+Whose 2015 album is 'Purpose'?:
 - Justin Bieber
 - bieber
 Whose controversial US presidential campaigning greatly increased his popularity within his party in 2015, yet increased party fears that it would unelectable should he lead it?:

--- a/redbot/trivia/lists/2016.yaml
+++ b/redbot/trivia/lists/2016.yaml
@@ -1,4 +1,4 @@
-'"Twilight" author Stephenie Meyer released an adult novel in 2016 called...?':
+"'Twilight' author Stephenie Meyer released an adult novel in 2016 called...?":
 - The Chemist
 After which primary did Jeb Bush drop out of the presidential race?:
 - South Carolina
@@ -36,7 +36,7 @@ How many new original series did Netflix premiere this year?:
 How many seasonal red cups did Starbucks introduce for the 2016 holidays?:
 - 13
 - thirteen
-How many seasons of "Fuller House" did Netflix release in 2016?:
+How many seasons of 'Fuller House' did Netflix release in 2016?:
 - 2
 - two
 How much did Estee Lauder buy Too Faced for in November 2016?:
@@ -53,20 +53,20 @@ In which city did Uber launch self-driving cars?:
 - Pittsburgh
 In which month did the U.K. vote to leave the EU?:
 - June
-Instagram Stories are most like which social media app"s signature characteristic?:
+Instagram Stories are most like which social media app's signature characteristic?:
 - Snapchat
 Making its 32nd season debut in February of 2016, Survivor was filmed in Koh Rong, which is located in which country?:
 - Cambodia
 Making its debut in January of 2016, Jennifer Lopez plays the role of New York detective Harlee Santos on which crime drama TV show?:
 - Shades of Blue
-NASA"s "Juno" became the second craft to orbit which planet in 2016?:
+NASA's "Juno" became the second craft to orbit which planet in 2016?:
 - Jupiter
 Often referred to as the "Fifth Beatle", which English record producer, that worked with the Beatles, died on March 8th, 2016?:
 - George Martin
 On January 28th, 2016, what virus outbreak was announced by the World Health Organization?:
 - Zika Virus
 - Zika
-Released in February of 2016, name British singer-songwriter Elton John"s 32nd studio album.:
+Released in February of 2016, name British singer-songwriter Elton John's 32nd studio album.:
 - Wonderful Crazy Night
 Rihanna hit number one on the Billboard 200 in March of 2016 with what album?:
 - Anti
@@ -75,32 +75,32 @@ Taking place from March 28 to April 3, which female skater won the gold medal at
 - Medvedeva
 The 2016 Summer Olympics will took place in which South American city?:
 - Rio de Janeiro
-The Rolling Stones made rock "n" roll history with a free concert in which country in March of 2016?:
+The Rolling Stones made rock 'n' roll history with a free concert in which country in March of 2016?:
 - Cuba
-The movie "Fantastic Beasts and Where To Find Them" was inspired by a Harry Potter textbook written by which fictional character?:
+The movie 'Fantastic Beasts and Where To Find Them' was inspired by a Harry Potter textbook written by which fictional character?:
 - Newt Scamander
-This 2016 hit by Tim McGraw opens with the lyric - "You know there"s a light that glows by the front door. Don"t forget the key"s under the mat".:
+This 2016 hit by Tim McGraw opens with the lyric - "You know there's a light that glows by the front door. Don't forget the key's under the mat".:
 - Humble and Kind
 This 2016 superhero film sees our hero Wade Wilson hunting down the man who gave him a scarred physical appearance.:
 - Deadpool
 This heavy metal band had a hit with a cover of the 1964 Simon and Garfunkel hit song "The Sound of Silence".:
 - Disturbed
-To whom was Donald Trump referring when he said "I like people who weren"t captured"?:
+To whom was Donald Trump referring when he said "I like people who weren't captured"?:
 - John McCain
-What Broadway star wrote the music for "Moana"?:
+What Broadway star wrote the music for 'Moana'?:
 - Lin-Manuel Miranda
 - Lin Manuel Miranda
 - Miranda
-What Star Wars movie is "Rogue One" set before?:
+What Star Wars movie is 'Rogue One' set before?:
 - A New Hope
 - Episode iv
-What actor plays Grindelwald in "Fantastic Beasts and Where to Find Them"?:
+What actor plays Grindelwald in 'Fantastic Beasts and Where to Find Them'?:
 - Johnny Depp
-What animal is Blake Lively fighting in "The Shallows"?:
+What animal is Blake Lively fighting in 'The Shallows'?:
 - Shark
-What anniversary of Shakespeare"s death was widely celebrated in 2016?:
+What anniversary of Shakespeare's death was widely celebrated in 2016?:
 - 400
-What color was Ryan Lochte"s hair at the Rio Olympics?:
+What color was Ryan Lochte's hair at the Rio Olympics?:
 - Blue
 What did John Oliver christen Donald Trump?:
 - Donald Drumpf
@@ -112,40 +112,40 @@ What did Obama and Raul Castro watch together in Cuba?:
 - Baseball
 What did Rob Kardashian and Blac Chyna name their daughter?:
 - Dream
-What do they call the robots on "Westworld"?:
+What do they call the robots on 'Westworld'?:
 - Hosts
 What fast food place announced it will start delivering soon?:
-- Mcdonald"s
+- Mcdonald's
 - Mcdonalds
 What iconic cartoon character did Colourpop do a collaboration with in 2016?:
 - Hello Kitty
-What is Hermione Granger"s job in "Harry Potter and The Cursed Child"?:
+What is Hermione Granger's job in 'Harry Potter and The Cursed Child'?:
 - Minister of Magic
 What is it called when an ex or former crush pops back up?:
 - zombieing
 What is the Mannequin Challenge song?:
 - Black Beatles
-What is the name of Beyoncé"s athleisure line at Topshop?:
+What is the name of Beyoncé's athleisure line at Topshop?:
 - Ivy Park
 What is the name of the 2015 best-selling book about the Clinton Foundation?:
 - Clinton Cash
-What kind of shoes did the "Damn Daniel" guy wear?:
+What kind of shoes did the 'Damn Daniel' guy wear?:
 - White Vans
 - Vans
 What month were the Panama Papers leaked?:
 - April
 What popular social media app announced that it was shutting down in 2016?:
 - Vine
-What type of product are MAC"s Shadescents?:
+What type of product are MAC's Shadescents?:
 - Perfume
-What villain joined "The Walking Dead," along with his signature baseball bat weapon?:
+What villain joined 'The Walking Dead,' along with his signature baseball bat weapon?:
 - Negan
-What was Amazon"s best-selling book of 2016?:
+What was Amazon's best-selling book of 2016?:
 - Harry Potter and the Cursed Child
 What was the most-searched meme of 2016?:
 - Harambe
-What was the name of the hashtag that went viral after Brock Turner"s trial?:
-- '#thingslongerthanbrockturnerrapes'
+What was the name of the hashtag that went viral after Brock Turner's trial?:
+- "#thingslongerthanbrockturnerrapes"
 - thingslongerthanbrockturnerrapes
 What was the record-setting Powerball jackpot amount in January 2016?:
 - 1.5 billion
@@ -153,26 +153,26 @@ What was the theme of the 2016 Met Gala?:
 - Manus x machina
 What was the top Google search for 2016?:
 - Powerball
-What"s Deadpool"s real name?:
+What's Deadpool's real name?:
 - Wade Wilson
-What"s Jennifer Lawrence"s character"s name in "Passengers"?:
+What's Jennifer Lawrence's character's name in 'Passengers'?:
 - Aurora
-What"s the name of the rapper at the center of "Atlanta"?:
+What's the name of the rapper at the center of 'Atlanta'?:
 - Paper Boi
 When was the last time the Cubs had won the World Series before 2016?:
 - 1908
 Where did Chewbacca Mom buy her mask?:
-- Kohl"s
+- Kohl's
 - Kohls
 Where did the Democratic National Convention take place?:
 - Philadelphia
-'Where is Black Panther from in "Captain America: Civil War"?':
+"Where is Black Panther from in 'Captain America: Civil War'?":
 - Wakanda
-Where was Hillary Clinton"s campaign headquarters?:
+Where was Hillary Clinton's campaign headquarters?:
 - Brooklyn
-Where was the 2016 Victoria"s Secret Fashion Show held?:
+Where was the 2016 Victoria's Secret Fashion Show held?:
 - Paris
-Which "Hamilton" star addressed Mike Pence after a show?:
+Which 'Hamilton' star addressed Mike Pence after a show?:
 - Brandon Dixon
 - Dixon
 Which American reality competition came to an end in 2016?:
@@ -185,7 +185,7 @@ Which TV show won "Outstanding Drama Series" at the 2016 Emmys?:
 Which actor won Best Male Performance for his role as Hugh Glass in the film "The Revenant" at the 2016 MTV Movie Awards?:
 - Leonardo DiCaprio
 - Dicaprio
-Which animal was the star of "Zootopia"?:
+Which animal was the star of 'Zootopia'?:
 - Bunny
 - Rabbit
 Which artist won Female Vocalist of the Year at the 2016 Academy of Country Music Awards?:
@@ -197,24 +197,24 @@ Which author became the first American to win the Man Booker Award?:
 - Beatty
 Which author became the first black woman to write for Marvel in 2016?:
 - Roxane Gay
-Which author topped Forbes" list of the World"s Highest Paid Authors in 2016?:
+Which author topped Forbes' list of the World's Highest Paid Authors in 2016?:
 - James Patterson
 - Patterson
 Which book sold 2 million copies in the two days after its release?:
 - Harry Potter and the Cursed Child
-Which book won the National Book Award for young people"s literature?:
-- 'March: Book Three'
+Which book won the National Book Award for young people's literature?:
+- "March: Book Three"
 - march:book three
 - march book three
-- 'march: book 3'
+- "march: book 3"
 - march book 3
 Which book won the Pulitzer Prize for fiction in 2016?:
 - The Sympathizer
-Which book, written by Stephen King"s son, won a 2016 Goodreads Choice Award for Best Horror Novel?:
+Which book, written by Stephen King's son, won a 2016 Goodreads Choice Award for Best Horror Novel?:
 - The Fireman
 Which celebrity had the most Instagram followers in 2016?:
 - Selena Gomez
-Which celebrity interviewed El Chapo for "Rolling Stone"?:
+Which celebrity interviewed El Chapo for 'Rolling Stone'?:
 - Sean Penn
 Which country announced its decision to withdraw from the Commonwealth of Nations on October 13th, 2016?:
 - The Maldives
@@ -222,7 +222,7 @@ Which country announced its decision to withdraw from the Commonwealth of Nation
 - republic of maldives
 Which country carried out its fifth and biggest nuclear test in September of 2016?:
 - North Korea
-Which country"s president did Donald Trump meet with during his campaign?:
+Which country's president did Donald Trump meet with during his campaign?:
 - Mexico
 Which dating app added a feature to help you find a BFF?:
 - Bumble
@@ -242,15 +242,15 @@ Which famed fashion street style photographer died in 2016?:
 Which famous British author would have celebrated their 100th birthday in September 2016?:
 - Roald Dahl
 - Dahl
-Which famous children"s author surprised everyone by joining Tumblr in 2016?:
+Which famous children's author surprised everyone by joining Tumblr in 2016?:
 - Judy Blume
 Which fast-food brand saw sales tank after an E. coli crisis?:
 - Chipotle
 Which film won the most Oscars at the 2016 Academy Awards with six?:
 - Mad Max - Fury Road
 - Mad max fury road
-- 'mad max: fury road'
-Which first generation Pokémon wasn"t initially able to be caught in "Pokémon Go," but has since been added?:
+- "mad max: fury road"
+Which first generation Pokémon wasn't initially able to be caught in 'Pokémon Go,' but has since been added?:
 - Ditto
 Which fruit did Too Faced feature in their most popular eyeshadow palette of 2016?:
 - Peach
@@ -258,11 +258,11 @@ Which group won Vocal Group of the Year at the 2016 Academy of Country Music Awa
 - Little Big Town
 Which luxury fashion brand held a major fashion show in Cuba in 2016?:
 - Chanel
-Which main character was shot in the "Pretty Little Liars" Season 7 summer finale?:
+Which main character was shot in the 'Pretty Little Liars' Season 7 summer finale?:
 - Spencer
 Which movie won the Oscar for Best Picture at the 2016 Academy Awards ceremony?:
 - Spotlight
-Which network premiered Beyoncé"s "Lemonade"?:
+Which network premiered Beyoncé's 'Lemonade'?:
 - HBO
 Which novel won the 2016 National Book Award for fiction?:
 - The Underground Railroad
@@ -275,12 +275,12 @@ Which popular dating app added a Super Like feature?:
 Which season of Yeezy did Kanye show at New York Fashion Week in September 2016?:
 - 4
 - Four
-Which singer"s merch sold more than $1 million in two days at a single pop-up shop?:
+Which singer's merch sold more than $1 million in two days at a single pop-up shop?:
 - Kanye West
 - Kanye
 Which symbolic color did Hillary Clinton and her allies wear during her concession speech?:
 - Purple
-Which team took gold in Women"s Hockey at the Rio 2016 Olympic Games?:
+Which team took gold in Women's Hockey at the Rio 2016 Olympic Games?:
 - Great Britain
 Which team won the CFL Grey Cup in November of 2016?:
 - Ottawa Redblacks
@@ -290,7 +290,7 @@ Which team won the MLB (Major League Baseball) 2016 World Series?:
 - Cubs
 Which team won the UEFA European Championships in 2016?:
 - Portugal
-Which woman"s name made Batman and Superman stop fighting in "Batman v Superman"?:
+Which woman's name made Batman and Superman stop fighting in 'Batman v Superman'?:
 - Martha
 Who did Obama nominate to replace Antonin Scalia?:
 - Merrick Garland
@@ -300,12 +300,12 @@ Who endorsed Trump after Trump called his wife ugly and his father a murderer?:
 - Cruz
 Who finished second in the medals table to USA at the Rio 2016 Olympic Games?:
 - Great Britain
-Who is Emma Stone"s co-star in "La La Land"?:
+Who is Emma Stone's co-star in 'La La Land'?:
 - Ryan Gosling
-Who is Harley Quinn in love with in "Suicide Squad"?:
+Who is Harley Quinn in love with in 'Suicide Squad'?:
 - The Joker
 - Joker
-'Who played Apocalypse In "X-Men: Apocalypse"?':
+"Who played Apocalypse In 'X-Men: Apocalypse'?":
 - Oscar Isaac
 Who was Jennifer Lawrence reportedly dating in 2016?:
 - Darren Aronofsky

--- a/redbot/trivia/lists/anime.yaml
+++ b/redbot/trivia/lists/anime.yaml
@@ -1,4 +1,4 @@
-(Attack on Titan) "I just don"t want those charred bones I saw to be disappointed in me. I... I know what I have to do now." Who said this?:
+(Attack on Titan) "I just don't want those charred bones I saw to be disappointed in me. I... I know what I have to do now." Who said this?:
 - Jean
 (Attack on Titan) "Only the victors are allowed to live. This world is merciless like that." Who said this?:
 - Mikasa
@@ -12,16 +12,16 @@
 (Attack on Titan) What is the name of the newspaper in the Stohess district?:
 - Berg Newspaper
 - Berg
-(Attack on Titan) What is the name of the wall in Wall Sina"s northern district?:
+(Attack on Titan) What is the name of the wall in Wall Sina's northern district?:
 - Orvud
 (Attack on Titan) What is the outer wall named (The one taken by the titans)?:
 - Wall Maria
 - Maria
 (Attack on Titan) What protects the Colossal titan?:
 - Steam
-(Attack on Titan) What was the name of Historia"s mother?:
+(Attack on Titan) What was the name of Historia's mother?:
 - Alma
-(Attack on Titan) What was the name of Levi"s mother?:
+(Attack on Titan) What was the name of Levi's mother?:
 - Kuchel
 (Attack on Titan) Which character loves to eat?:
 - Sasha Blouse
@@ -34,7 +34,7 @@
 - Eren
 (Attack on Titan) Who killed Rod Reiss?:
 - Historia
-(Attack on Titan) Who ruined Eren"s equipment when they were trainees?:
+(Attack on Titan) Who ruined Eren's equipment when they were trainees?:
 - Keith Shadis
 - Keith
 - Shadis
@@ -43,15 +43,15 @@
 - Father
 (Attack on Titan) Who would become the commander of the Scouting Legion if something were to happen to Erwin?:
 - Hange
-(Beyblade) What is the name of Emily"s bitbeast?:
+(Beyblade) What is the name of Emily's bitbeast?:
 - Trygator
-(Black Butler) Who is the British monarch in Black Butler"s time period?:
+(Black Butler) Who is the British monarch in Black Butler's time period?:
 - Victoria I
 - Queen Victoria I
 (Black Cat) How many members of Chronos were there originally?:
 - 13
 - thirteen
-(Black Cat) Out of which material are Train Heartnet"s gun and bullets mainly made of?:
+(Black Cat) Out of which material are Train Heartnet's gun and bullets mainly made of?:
 - orichalcum
 (Black Cat) Who is the main character?:
 - Train Heartnet
@@ -66,15 +66,15 @@
 - Gigai
 (Bleach) What is a Hollow that has removed its mask and has gained Shinigami-like powers?:
 - Arrancar
-(Bleach) What is the name of Hitsugaya Toshirou"s Zanpakutou?:
+(Bleach) What is the name of Hitsugaya Toshirou's Zanpakutou?:
 - Hyourinmaru
-(Bleach) What is the name of Ichigo"s Zanpakutou?:
+(Bleach) What is the name of Ichigo's Zanpakutou?:
 - Zangetsu
-(Bleach) What is the name of Karin"s twin?:
+(Bleach) What is the name of Karin's twin?:
 - Yuzu
-(Bleach) What is the name of Orihime"s power which is manifested through her hairpins?:
+(Bleach) What is the name of Orihime's power which is manifested through her hairpins?:
 - Shun Shun Rikka
-(Bleach) What is the name of Urahara"s Zanpakutou?:
+(Bleach) What is the name of Urahara's Zanpakutou?:
 - Benihime
 (Bleach) What is the ritual performed by Shinigami to send Pluses to Soul Society?:
 - Konso
@@ -93,7 +93,7 @@
 - cow
 (Code Geass) Aside from Britannia and the Chinese Federation, what is the third major superpower in the world?:
 - Europia United
-(Code Geass) At the very end, how many characters were aware of Lelouch"s true intentions?:
+(Code Geass) At the very end, how many characters were aware of Lelouch's true intentions?:
 - 4
 - four
 (Code Geass) The character Li Xingke is a member of which group?:
@@ -107,22 +107,22 @@
 (Code Geass) Wat was the name of the academy Lelouch went to?:
 - Ashford Academy
 - Ashford
-(Code Geass) What are the structures associated with Geass that work through a person"s memories?:
+(Code Geass) What are the structures associated with Geass that work through a person's memories?:
 - Thought Elevator
 (Code Geass) What game does Lelouch skip school to play?:
 - chess
-(Code Geass) What is Villetta Nu"s Japanese name?:
+(Code Geass) What is Villetta Nu's Japanese name?:
 - Chigusa
 (Code Geass) What is also known as the "Power of Kings"?:
 - Geass
 (Code Geass) What is the capitol of the Holy Britannian Empire?:
 - Pendragon
-(Code Geass) What is the name of Lelouch and Nunnally"s maid?:
+(Code Geass) What is the name of Lelouch and Nunnally's maid?:
 - Sayoko Shinozaki
 - Sayoko
-(Code Geass) What is the name of Suzaku"s cat?:
+(Code Geass) What is the name of Suzaku's cat?:
 - Arthur
-(Code Geass) What is the name of the Indian scientist and the head of the Black Knights" research and development team?:
+(Code Geass) What is the name of the Indian scientist and the head of the Black Knights' research and development team?:
 - Rakshata Chawla
 - Rakshata
 (Code Geass) What is the name of the Knightmare Frame custom built for Kyoshiro Tohdoh by the Militarized Zone of India?:
@@ -143,7 +143,7 @@
 - FLEIJA
 (Code Geass) What was the white Knightmare Frame piloted by Suzaku called?:
 - Lancelot
-(Code Geass) Who becomes mentally unstable after Euphemia"s death?:
+(Code Geass) Who becomes mentally unstable after Euphemia's death?:
 - Nina Einstein
 - Nina
 (Code Geass) Who did Marianne vi Britannia transfer her consciousness into?:
@@ -158,7 +158,7 @@
 - Kallen Kozuki
 - Kallen Stadtfeld
 - Kallen
-(Code Geass) Who is Suzaku"s cousin?:
+(Code Geass) Who is Suzaku's cousin?:
 - Kaguya Sumeragi
 - Kaguya
 (Code Geass) Who is in love with Tohdoh?:
@@ -214,11 +214,11 @@
 (Code Geass) Who rescues Villetta Nu after her amnesia?:
 - Kaname Ohgi
 - Ohgi
-(Code Geass) Who unknowingly killed Shirley"s father?:
+(Code Geass) Who unknowingly killed Shirley's father?:
 - Kallen Kozuki
 - Kallen Stadtfeld
 - Kallen
-(Cowboy Bebop) What is the villan Vicious"s weapon of choice?:
+(Cowboy Bebop) What is the villan Vicious's weapon of choice?:
 - katana
 (Cowboy Bebop) Who dies?:
 - Spike
@@ -231,11 +231,11 @@
 - Socks
 (Death Note) What does SPK stand for?:
 - Special Provision for Kira
-(Death Note) What is L"s real name?:
+(Death Note) What is L's real name?:
 - L Lawliet
-(Death Note) What is Light"s last name?:
+(Death Note) What is Light's last name?:
 - Yagami
-(Death Note) What is Ryuuku"s favorite food?:
+(Death Note) What is Ryuuku's favorite food?:
 - Apple
 (Death Note) What is the character Mello (Mihael Keehl) addicted to eating?:
 - Chocolate
@@ -264,18 +264,18 @@
 (Death Note) Who is the third Kira?:
 - Kyosuke Higuchi
 - Kyosuke
-(Death Note) Who was L"s butler/caregiver/handler?:
+(Death Note) Who was L's butler/caregiver/handler?:
 - Watari
 (Death Note) Who was the first person that Light killed?:
 - Kurou Otoharada
 - Kurou
 - Otoharada
-(Detective Conan) What is Shinichi Kudo"s best sport?:
+(Detective Conan) What is Shinichi Kudo's best sport?:
 - soccer
 - football
-(Digimon) What was Taichi Kamiya"s first Digimon?:
+(Digimon) What was Taichi Kamiya's first Digimon?:
 - Botamon
-'(Digimon) Which year was the American adaptation of Digimon: The Movie released?':
+"(Digimon) Which year was the American adaptation of Digimon: The Movie released?":
 - 2000
 (Dragon Ball Z) How many dragon balls are there?:
 - 7
@@ -296,15 +296,15 @@
 - Shizuo
 (Fairy Tail) Aside from Wendy, who is the other Sky Sister?:
 - Sherria
-(Fairy Tail) What are Laxus" followers called?:
+(Fairy Tail) What are Laxus' followers called?:
 - Thunder God Tribe
-(Fairy Tail) What is Erza"s favorite brand of armor?:
+(Fairy Tail) What is Erza's favorite brand of armor?:
 - Heart Kreuz
-(Fairy Tail) What is Gray"s last name?:
+(Fairy Tail) What is Gray's last name?:
 - Fullbuster
-(Fairy Tail) What is Lucy"s last name?:
+(Fairy Tail) What is Lucy's last name?:
 - Heartfilia
-(Fairy Tail) What is the brand of Erza"s casual armor?:
+(Fairy Tail) What is the brand of Erza's casual armor?:
 - Heart Kreuz
 (Fairy Tail) What is the name of the dragon that raised Natsu in Fairy Tail?:
 - Igneel
@@ -313,7 +313,7 @@
 - Earth
 (Fairy Tail) Where did Lucy get her guild mark?:
 - Right hand
-(Fairy Tail) Where is Natsu"s guild mark?:
+(Fairy Tail) Where is Natsu's guild mark?:
 - Right shoulder
 (Fairy Tail) Where is the holy ground for the guild Fairy Tail?:
 - Tenrou Island
@@ -324,7 +324,7 @@
 - Ishgar
 (Fairy Tail) Who has the power "Satan Soul"?:
 - Mirajane
-(Fairy Tail) Who is Cana"s father?:
+(Fairy Tail) Who is Cana's father?:
 - Gildarts
 (Fairy Tail) Who is Evergreen romantically involved with?:
 - Elfman
@@ -345,7 +345,7 @@
 (Fooly Cooly) How many manga-like (comic-like) scenes are there in total?:
 - 2
 - two
-(Fooly Cooly) There are a couple of scenes where you see the commander getting a haircut. What popular show"s animation resembles the special animation in this scene?:
+(Fooly Cooly) There are a couple of scenes where you see the commander getting a haircut. What popular show's animation resembles the special animation in this scene?:
 - South Park
 (Fruits Basket) What Zodiac animal is Kyo Sohma?:
 - cat
@@ -356,7 +356,7 @@
 - Sohma
 (Fruits Basket) What spirit is Akito possessed by?:
 - God
-(Fullmetal Alchemist) According To Fuhrer Bradley What Is Roy"s Weakness?:
+(Fullmetal Alchemist) According To Fuhrer Bradley What Is Roy's Weakness?:
 - Riza
 - Riza Hawkeye
 (Fullmetal Alchemist) Alex Louis Armstrong is also known as the __ Alchemist?:
@@ -376,11 +376,11 @@
 - 12
 - twelve
 (Fullmetal Alchemist) How tall is Edward?:
-- 4"6"
+- 4'6"
 - four and a half feet
 - four foot six inches
 - four foot 6
-(Fullmetal Alchemist) In the manga what is the date in Ed"s pocket watch?:
+(Fullmetal Alchemist) In the manga what is the date in Ed's pocket watch?:
 - 3.Oct.10
 (Fullmetal Alchemist) Shou Tucker was known as the __ Alchemist?:
 - Sewing Life
@@ -388,15 +388,15 @@
 - Crimson
 (Fullmetal Alchemist) The Father of the Homunculi can stop which style of alchemy?:
 - Western Armestris
-(Fullmetal Alchemist) What Language is Riza"s Tattoo Writen In?:
+(Fullmetal Alchemist) What Language is Riza's Tattoo Writen In?:
 - Latin
-(Fullmetal Alchemist) What are Colonel Mustang"s gloves made of?:
+(Fullmetal Alchemist) What are Colonel Mustang's gloves made of?:
 - ignition cloth
 (Fullmetal Alchemist) What are Winry and Pinako Rockbell best known for making?:
 - Automail
 (Fullmetal Alchemist) What did Ed give up to revive his mother?:
 - left leg
-(Fullmetal Alchemist) What did Ed sacrifice in order to seal his brother"s soul into a suit of armour?:
+(Fullmetal Alchemist) What did Ed sacrifice in order to seal his brother's soul into a suit of armour?:
 - right arm
 - arm
 (Fullmetal Alchemist) What does Edward hate to drink?:
@@ -408,44 +408,44 @@
 - sight
 (Fullmetal Alchemist) What does Winry do for a living?:
 - mechanic
-(Fullmetal Alchemist) What is Edward"s and Alphonse"s last name?:
+(Fullmetal Alchemist) What is Edward's and Alphonse's last name?:
 - Elric
-(Fullmetal Alchemist) What is Envy"s nickname for Edward?:
+(Fullmetal Alchemist) What is Envy's nickname for Edward?:
 - Fullmetal pipsqueak
-(Fullmetal Alchemist) What is King Bradley aka Pride"s son called?:
+(Fullmetal Alchemist) What is King Bradley aka Pride's son called?:
 - Selim
-(Fullmetal Alchemist) What is Winry"s last name?:
+(Fullmetal Alchemist) What is Winry's last name?:
 - Rockbell
 (Fullmetal Alchemist) What is the automotive armored prostheses?:
 - automail
-(Fullmetal Alchemist) What is the name of Ed and Al"s mother?:
+(Fullmetal Alchemist) What is the name of Ed and Al's mother?:
 - Trisha Elric
 - Trisha
-(Fullmetal Alchemist) What is the name of the Ishbalan people"s god?:
+(Fullmetal Alchemist) What is the name of the Ishbalan people's god?:
 - Ishbala
 (Fullmetal Alchemist) What is the name of the Ishbalan who hates State Alchemists and murders them because he thinks it is an act of God?:
 - Scar
 (Fullmetal Alchemist) What is the name of transmutation circle used to make the Philosopher Stone?:
 - Grand Arcanum
-(Fullmetal Alchemist) What is the symbol on the back of Edward"s red coat called?:
+(Fullmetal Alchemist) What is the symbol on the back of Edward's red coat called?:
 - flammel
-(Fullmetal Alchemist) What room number is the Fuhrer"s?:
+(Fullmetal Alchemist) What room number is the Fuhrer's?:
 - 103
-(Fullmetal Alchemist) What"s Hughes"s daughter"s name?:
+(Fullmetal Alchemist) What's Hughes's daughter's name?:
 - Elicia
-'(Fullmetal Alchemist) When Mustang was forced to do human transmutation in fma: brotherhood what did he loose?':
+"(Fullmetal Alchemist) When Mustang was forced to do human transmutation in fma: brotherhood what did he loose?":
 - eyesight
 - vision
 (Fullmetal Alchemist) Which Homunculus uses carbon as their power?:
 - Greed
 (Fullmetal Alchemist) Which homunculus was the Fuhrer?:
 - Pride
-"(Fullmetal Alchemist) Who Says This â\x80\x9CI have no desire to live a carefree, happy life alone...\"?":
+(Fullmetal Alchemist) Who Says This â€œI have no desire to live a carefree, happy life alone..."?:
 - Riza
-(Fullmetal Alchemist) Who is Colonel Mustang"s best friend?:
+(Fullmetal Alchemist) Who is Colonel Mustang's best friend?:
 - Maes Hughes
 - Hughes
-(Fullmetal Alchemist) Who is Ed"s father?:
+(Fullmetal Alchemist) Who is Ed's father?:
 - Hohenheim
 (Fullmetal Alchemist) Who is a pseudo Gate of Truth?:
 - Gluttony
@@ -475,7 +475,7 @@
 - Suzaku
 (Fushigi Yuugi) The world of Fushigi Yuugi is based on the ancient form of what country?:
 - China
-(Gundam) How many rounds of ammunition does Gundam Wing Zero Custom"s Buster Rifle have?:
+(Gundam) How many rounds of ammunition does Gundam Wing Zero Custom's Buster Rifle have?:
 - 3
 - three
 (Gundam) What is the name of the final Gundam used by Shiro in 08th MS Team?:
@@ -488,11 +488,11 @@
 - England
 (Hetalia) Who does Holy Rome have a crush on?:
 - Italy
-(Highschool Of The Dead) What are zombie"s sensitive to?:
+(Highschool Of The Dead) What are zombie's sensitive to?:
 - sound
 (InuYasha) InuYasha is half __ demon?:
 - dog
-(InuYasha) Inuyasha"s sword is called what?:
+(InuYasha) Inuyasha's sword is called what?:
 - Tessaiga
 - Tetsusaiga
 (InuYasha) What is the name of the baby that Naraku holds his human heart in?:
@@ -504,12 +504,12 @@
 - kouga
 (InuYasha) Who was the demon of hair?:
 - Yura
-(Inuyasha) What is the name of Sango"s demon cat?:
+(Inuyasha) What is the name of Sango's demon cat?:
 - kirara
 (Love Hina) In the Christmas special, what did Keitarou buy Naru?:
 - Coat
 - jacket
-(Love Hina) What was the samurai girl"s name?:
+(Love Hina) What was the samurai girl's name?:
 - Aoyama
 - Aoyama Motoko
 (Magic Knight Rayearth) Thee three heroines, Hikaru, Umi and Fuu, have powers associated with different elements. What kind of elemental spells does Umi use?:
@@ -520,7 +520,7 @@
 - Akatsuki
 (Naruto) D-rank missions are usually given to what level of shinobi?:
 - Genin
-(Naruto) Name one of Sarutobi"s disciples?:
+(Naruto) Name one of Sarutobi's disciples?:
 - Orochimaru
 - Jiraiya
 - Tsunade
@@ -532,21 +532,21 @@
 - Tanuki
 - Japanese Raccoon Dog
 - Raccoon
-(Naruto) What does the symbol on Gaara"s forehead mean?:
+(Naruto) What does the symbol on Gaara's forehead mean?:
 - Love
-(Naruto) What is Naruto"s favorite food?:
+(Naruto) What is Naruto's favorite food?:
 - Ramen
 (Naruto) What is involved to use most summoning techniques?:
 - blood
-(Naruto) What is the Third Hokage"s first name?:
+(Naruto) What is the Third Hokage's first name?:
 - Hiruzen
-(Naruto) What is the Third Hokage"s last name?:
+(Naruto) What is the Third Hokage's last name?:
 - Sarutobi
 (Naruto) What is the forbidden technique used by Rock Lee that he used on Dosu and Gaara?:
 - Primary Lotus
-'(Naruto) What is the last hand sign for the Uchiha Clan"s Katon: Gokakyu no Jutsu?':
+"(Naruto) What is the last hand sign for the Uchiha Clan's Katon: Gokakyu no Jutsu?":
 - Tiger
-(Naruto) What is the name of Naruto"s son?:
+(Naruto) What is the name of Naruto's son?:
 - Boruto Uzumaki
 - Boruto
 (Naruto) What is the name of the Biju inside Gaara?:
@@ -562,13 +562,13 @@
 - Byakugan
 (Naruto) What is the word for a female ninja?:
 - Kunoichi
-(Naruto) What legendary ninja was known as "Konoha"s White Fang?":
+(Naruto) What legendary ninja was known as "Konoha's White Fang?":
 - Sakumo Hatake
 - Sakumo
 - Hatake Sakumo
 (Naruto) What village does Naruto belong to?:
 - Konohagakure
-(Naruto) What"s the name of Shizune"s pet pig?:
+(Naruto) What's the name of Shizune's pet pig?:
 - Tonton
 (Naruto) When in The Forest Of Death, Orochimaru disguises himself as a ninja from what village?:
 - Grass
@@ -588,14 +588,14 @@
 - Iron
 (Naruto) Which jutsu does Rock Lee use?:
 - taijutsu
-(Naruto) Who cut Sakura"s hair off?:
+(Naruto) Who cut Sakura's hair off?:
 - Sakura
 (Naruto) Who gave Kakashi his Sharingan eye?:
 - Obito Uchiha
 - Obito
 (Naruto) Who has had amnesia when the person was a child?:
 - Kabuto
-(Naruto) Who is Negi"s cousin?:
+(Naruto) Who is Negi's cousin?:
 - Hinata Hyuga
 - Hinata
 (Naruto) Who is officially the Sixth Hokage at the end of the manga series?:
@@ -615,7 +615,7 @@
 (Naruto) Who uses the Yin Seal?:
 - Tsunade
 - sakura
-(Naruto) Who was Naruto"s teacher at the ninja academy?:
+(Naruto) Who was Naruto's teacher at the ninja academy?:
 - Iruka
 (Naruto) Who was suggested as hokage while Tsunade was in a coma?:
 - Kakashi
@@ -632,7 +632,7 @@
 (One Piece) According to the northblue fairytales, who is known as the trickster/liar telling the people about a golden city in jaya?:
 - Montblanc Norland
 - noland
-(One Piece) During the marineford arc, who opened Marco"s cuffs?:
+(One Piece) During the marineford arc, who opened Marco's cuffs?:
 - Mr.3
 - 3
 - mr3
@@ -672,41 +672,41 @@
 - sabi sabi no mi
 (One Piece) What is A water spirit (or fairy) that dwells on ships called?:
 - Klabautermann
-(One Piece) What is Croccus" zodiac sign?:
+(One Piece) What is Croccus' zodiac sign?:
 - Gemini
-(One Piece) What is Igaram"s wife"s name?:
+(One Piece) What is Igaram's wife's name?:
 - Teracotta
-(One Piece) What is Nami"s village called?:
+(One Piece) What is Nami's village called?:
 - Cocoyashi village
 - cocoyashi
-(One Piece) What is Wiper"s weapon called?:
+(One Piece) What is Wiper's weapon called?:
 - Burn bazooka
-(One Piece) What is chopper"s godfather"s name?:
+(One Piece) What is chopper's godfather's name?:
 - Dr. Hiluluk
 - hiluluk
-(One Piece) What is franky"s real name?:
+(One Piece) What is franky's real name?:
 - Cutty flam
-(One Piece) What is robin"s mother"s name?:
+(One Piece) What is robin's mother's name?:
 - Nico Olivia
 - olivia
 (One Piece) What is the 1st chapter named?:
 - Romance dawn
 (One Piece) What is the Birthplace of robin called?:
 - Ohara
-(One Piece) What is the name of Dracule Mihawk"s black sword?:
+(One Piece) What is the name of Dracule Mihawk's black sword?:
 - yoru
-(One Piece) What is the name of Tsuru"s devilfruit?:
+(One Piece) What is the name of Tsuru's devilfruit?:
 - Woshu woshu fruit
 - Wash wash fruit
 - wash wash
 - woshu woshu
-(One Piece) What is the name of Whitebeard"s flag ship?:
+(One Piece) What is the name of Whitebeard's flag ship?:
 - Moby dick
-(One Piece) What is the name of Zoro"s teacher and Kuina"s father?:
+(One Piece) What is the name of Zoro's teacher and Kuina's father?:
 - Koshiro
 (One Piece) What is the name of character from sabaody+fishman island arc who is always ignored?:
 - Pappagu
-(One Piece) What is the name of the Vice Admiral to whom Ace had to deliver a message during Ace"s Great Blackbeard Search?:
+(One Piece) What is the name of the Vice Admiral to whom Ace had to deliver a message during Ace's Great Blackbeard Search?:
 - Comil
 (One Piece) What is the name of the cigarette brand Sanji smokes?:
 - king grand
@@ -722,13 +722,13 @@
 - Eternal pose
 (One Piece) What is the name of the plant shown in the film Strong World which is toxic to animals?:
 - Daft green
-(One Piece) What is the name of ussop"s current weapon?:
+(One Piece) What is the name of ussop's current weapon?:
 - Kuro kabuto
 - black kabuto
 - kabuto
-(One Piece) What is the name of zombie which had Zoro"s shadow?:
+(One Piece) What is the name of zombie which had Zoro's shadow?:
 - Jigoro
-(One Piece) What is the name of zoro"s sword which was destroyed by Shu?:
+(One Piece) What is the name of zoro's sword which was destroyed by Shu?:
 - Yubashiri
 (One Piece) What is the real name of Mr. 2,Bon kurei?:
 - Bentham
@@ -736,9 +736,9 @@
 - Okama kenpo
 (One Piece) What year was the manga created?:
 - 1997
-(One Piece) What"s the name of Rob Lucci"s pet pidgeon?:
+(One Piece) What's the name of Rob Lucci's pet pidgeon?:
 - Hattori
-(One Piece) What"s the nickname that Sanji always uses for Zorro?:
+(One Piece) What's the nickname that Sanji always uses for Zorro?:
 - Marimo (mosshead)
 - marimo
 - mosshead
@@ -789,7 +789,7 @@
 - Nami
 (One Piece) Who has a goal of wanting to discover the true history of the world?:
 - Robin
-(One Piece) Who has a natural weakness to Luffy"s power?:
+(One Piece) Who has a natural weakness to Luffy's power?:
 - Enel
 (One Piece) Who in the fleet was the first to faint after meeting Dorry and Brogy?:
 - Karoo
@@ -835,9 +835,9 @@
 - Dalton
 (One Piece) Who was the fleet admiral before sengoku?:
 - Kong
-(One Piece) Whose crew did Nami work for before joining Luffy"s crew?:
+(One Piece) Whose crew did Nami work for before joining Luffy's crew?:
 - Arlong
-- Arlong"s
+- Arlong's
 (One Piece) Whose laughing style is this :"chapapapapapa"?:
 - Fukurou
 - fukuro
@@ -854,7 +854,7 @@
 (One Punch Man) How old is Saitama?:
 - 25
 - twentyfive
-(One Punch Man) What are Genos" tears made of?:
+(One Punch Man) What are Genos' tears made of?:
 - oil
 (One Punch Man) What city does Saitama live in?:
 - Z-city
@@ -864,21 +864,21 @@
 - A-city
 - A city
 - A
-(One Punch Man) What is Bang"s brother"s fighting style?:
+(One Punch Man) What is Bang's brother's fighting style?:
 - Whirlwind Iron Cutting Fist
-(One Punch Man) What is Bang"s fighting style?:
+(One Punch Man) What is Bang's fighting style?:
 - Water Stream Rock Smashing Fist
-(One Punch Man) What is Bang"s older brother"s name?:
+(One Punch Man) What is Bang's older brother's name?:
 - Bomb
-(One Punch Man) What is Dr. Bofoi"s hero name?:
+(One Punch Man) What is Dr. Bofoi's hero name?:
 - Metal Knight
-(One Punch Man) What is Genos" hero name?:
+(One Punch Man) What is Genos' hero name?:
 - Demon Cyborg
-(One Punch Man) What is Metal Knight"s real name?:
+(One Punch Man) What is Metal Knight's real name?:
 - Bofoi
 (One Punch Man) What is Saitama also known as?:
 - Caped Baldy
-(One Punch Man) What is Saitama"s hero profile number?:
+(One Punch Man) What is Saitama's hero profile number?:
 - 3402
 (One Punch Man) What is Tsumaki also known as?:
 - Tornado of Terror
@@ -887,12 +887,12 @@
 (One Punch Man) What is the group headed by Fubuki?:
 - The Blizzard Group
 - blizzard group
-(One Punch Man) What is the name of Mumen Rider"s bicycle?:
+(One Punch Man) What is the name of Mumen Rider's bicycle?:
 - Bicycle of Justice
 - Justice
 (One Punch Man) Where did Saitama work before becoming a hero?:
 - convenience store
-(One Punch Man) Where is Child Emperor"s lab located?:
+(One Punch Man) Where is Child Emperor's lab located?:
 - Y-city
 - Y city
 - y
@@ -900,7 +900,7 @@
 - King
 (One Punch Man) Who created the Hero Association?:
 - Agoni
-(One Punch Man) Who is Tsumaki"s younger sister?:
+(One Punch Man) Who is Tsumaki's younger sister?:
 - Fubuki
 (One Punch Man) Who is also known as the "Human Monster"?:
 - Garou
@@ -926,7 +926,7 @@
 - Deep Sea King
 (Ouran High School Host Club) Who is mistaken for a boy in the anime?:
 - Haruhi
-(Pokemon) In the original Japanese version, what is Ash Ketchum"s name?:
+(Pokemon) In the original Japanese version, what is Ash Ketchum's name?:
 - Satoshi
 (Pokemon) Pokemon was created by Stoshi Tajiri in which year?:
 - 1996
@@ -937,11 +937,11 @@
 (Pokemon) What did May enjoy competing in?:
 - Pokemon Contests
 - Pokemon Contest
-(Pokemon) What is the name of Brock"s father?:
+(Pokemon) What is the name of Brock's father?:
 - Flint
-(Pokemon) What is the name of May"s younger brother?:
+(Pokemon) What is the name of May's younger brother?:
 - Max
-(Pokemon) What is the name of Ritchie"s Pikachu?:
+(Pokemon) What is the name of Ritchie's Pikachu?:
 - Sparky
 (Pokemon) What is the name of the friend who travels with Ash during only the Orange Islands arc?:
 - Tracey Sketchit
@@ -969,11 +969,11 @@
 (Ranma 1/2) What is Ranma most afraid of?:
 - cats
 - cat
-(Rave Master) What is Haru"s last name?:
+(Rave Master) What is Haru's last name?:
 - Glory
-(Rave Master) What was Elie"s old name?:
+(Rave Master) What was Elie's old name?:
 - Resha
-(Rave Master) What"s 3713 real name?:
+(Rave Master) What's 3713 real name?:
 - Elie
 (Rave Master) Who is a known pervert?:
 - Griffon Kato
@@ -1001,11 +1001,11 @@
 - Shinai
 (Rurouni Kenshin) What illegal drug did Takani Megumi make?:
 - Opium
-(Rurouni Kenshin) What is the name of Kenshin"s master?:
+(Rurouni Kenshin) What is the name of Kenshin's master?:
 - Hiko
-(Rurouni Kenshin) What is the name of Kenshin"s son?:
+(Rurouni Kenshin) What is the name of Kenshin's son?:
 - Kenji
-(Rurouni Kenshin) What is the name of Kenshin"s sword style?:
+(Rurouni Kenshin) What is the name of Kenshin's sword style?:
 - Hiten Mitsurugi
 (Rurouni Kenshin) What is the name of the girl Kenshin accidentally killed?:
 - Tomoe Yukishiro
@@ -1016,13 +1016,13 @@
 - satsujinken
 (Rurouni Kenshin) What type of sword does Kenshin use (japanese for reverse blade sword)?:
 - Sabakou
-(Rurouni Kenshin) What was Kenshin"s nickname during the Meji Revolution?:
+(Rurouni Kenshin) What was Kenshin's nickname during the Meji Revolution?:
 - Hitokiri Battousai
 - Battousai the Manslayer
 - Battousai
 (Rurouni Kenshin) What was Yahiko before he was rescued?:
 - Pickpocket
-(Rurouni Kenshin) Who is Kaoru"s pupil?:
+(Rurouni Kenshin) Who is Kaoru's pupil?:
 - Myojin Yahiko
 - Yahiko
 (Rurouni Kenshin) Who is in love with Kenshin Himura?:
@@ -1035,17 +1035,17 @@
 - Mamoru Chiba
 - Mamoru
 - Endymion
-(Sailor Moon) Who was Minako"s crime-fighting alter ego before she became Sailor Venus?:
+(Sailor Moon) Who was Minako's crime-fighting alter ego before she became Sailor Venus?:
 - sailor v
 (Samurai Champloo) What does the samurai who Fuu is looking for smell like?:
 - Sunflowers
 - Sunflower
-(Samurai Champloo) What is Jin"s totem?:
+(Samurai Champloo) What is Jin's totem?:
 - Koi Fish
 - Koi
-(Samurai Champloo) What is Mugen"s totem?:
+(Samurai Champloo) What is Mugen's totem?:
 - Rooster
-(Samurai Champloo) What is the name of Fuu"s flying squirrel?:
+(Samurai Champloo) What is the name of Fuu's flying squirrel?:
 - Momo
 (Shokugeki No Soma) What is the graduation rate at Totsuki Culinary Academy?:
 - 1%
@@ -1056,7 +1056,7 @@
 - Totsuki
 (Shokugeki No Soma) What is the term referring to a cooking duel allows students to settle debates and arguments?:
 - shokugeki
-(Shokugeki no Soma) What was Joichiro Yukihira"s original name?:
+(Shokugeki no Soma) What was Joichiro Yukihira's original name?:
 - Joichiro Saiba
 - Saiba Joichiro
 - Saiba
@@ -1076,20 +1076,20 @@
 - Akihabara
 (Steins;Gate) Steins;Gate is a collaboration work between 5pb. and who?:
 - Nitro+
-(Steins;Gate) What anime does Kurisu"s online name reference?:
+(Steins;Gate) What anime does Kurisu's online name reference?:
 - Dragon Ball Z
 - DBZ
 (Steins;Gate) What does the team call the text messages sent to the past?:
 - Dmail
 - d-mail
-(Steins;Gate) What is Mayuri"s favorite hobby?:
+(Steins;Gate) What is Mayuri's favorite hobby?:
 - Cosplay
-(Steins;Gate) What is Okabe"s favorite drink?:
+(Steins;Gate) What is Okabe's favorite drink?:
 - Dk Pepper
-(Steins;Gate) What is Rintaro"s landlord"s name?:
+(Steins;Gate) What is Rintaro's landlord's name?:
 - Yugo
 - Mr Braun
-(Steins;Gate) What is the name of Okabe"s Laboratory?:
+(Steins;Gate) What is the name of Okabe's Laboratory?:
 - Future Gadget Laboratory
 (Steins;Gate) What is the name of the ability to retain memories across world lines?:
 - Reading Steiner
@@ -1099,12 +1099,12 @@
 - Christina
 (Steins;Gate) What nickname does Rintaro give to Moeka?:
 - Shining Finger
-(Steins;Gate) What will happen to Mayuri when Mayuri"s pocket watch stops working?:
+(Steins;Gate) What will happen to Mayuri when Mayuri's pocket watch stops working?:
 - Death
 - Dies
 - die
 - She dies
-(Steins;Gate) Who ate Kurisu"s pudding?:
+(Steins;Gate) Who ate Kurisu's pudding?:
 - Rintaro Okabe
 - Rintaro
 - Okabe
@@ -1115,29 +1115,29 @@
 - Rintaro
 - Okabe
 (Steins;Gate) Why does Mayuri stay with Okabe?:
-- She"s his hostage
+- She's his hostage
 - Hostage
 (Sword Art Online) What is the second game Kirito goes into?:
 - Alfheim Online
 - Alfheim
-(The Last Airbender) What is the name of Aang"s flying bison?:
+(The Last Airbender) What is the name of Aang's flying bison?:
 - Appa
 (The Last Airbender) What is the name of the evil prince that tries to capture Aang?:
 - prince zuko
 - zuko
-(Trigun) What was Vash"s brother called?:
+(Trigun) What was Vash's brother called?:
 - Knife
 (Tsubasa Chronicle) What does the gang needed to collect?:
-- Princess Sakura"s feathers
+- Princess Sakura's feathers
 - feathers
-(Yu Yu Hakasho) What is Yuskey"s close advisor and ghost friend?:
+(Yu Yu Hakasho) What is Yuskey's close advisor and ghost friend?:
 - Botan
-(Yu Yu Hakusho) What level computer does Mitari have to fight in Game Master"s territory?:
+(Yu Yu Hakusho) What level computer does Mitari have to fight in Game Master's territory?:
 - 7
 - seven
-(Zatch Bell) What color is Kyo"s spell book?:
+(Zatch Bell) What color is Kyo's spell book?:
 - red
-After Watase Yuu"s creation of "Fushigi Yuugi", which famous shoujo anime did she make?:
+After Watase Yuu's creation of "Fushigi Yuugi", which famous shoujo anime did she make?:
 - Ayashi no Ceres
 As of 2015, among all the 17 long anime movies Hayao Miyazaki participated in, how many did he direct?:
 - 11
@@ -1146,7 +1146,7 @@ Basketball Anime that came out in 2012?:
 - Kuroko No Basket
 English name of Kuroshitsuji?:
 - Black Butler
-'For which anime were these songs written: "Cha La Head Cha La" and "Boku-tachi wa Tenshi Datta"?':
+"For which anime were these songs written: \"Cha La Head Cha La\" and \"Boku-tachi wa Tenshi Datta\"?":
 - Dragon Ball Z
 In what CLAMP anime is there a little Persocon named Chii?:
 - Chobits
@@ -1154,12 +1154,12 @@ In yaoi pairing, what is the "receiving", "bottom", or passive partner known as?
 - uke
 In yaoi pairing, what is the "top" or dominant partner known as?:
 - seme
-It"s common in anime for a character to pull their lower eyelid down to taunt someone. What is this called?:
+It's common in anime for a character to pull their lower eyelid down to taunt someone. What is this called?:
 - akanabe
 Maka Albarn is from what anime?:
 - soul eater
-Sakura Kinamoto is the heroine of "Cardcaptor Sakura". In which CLAMP manga/anime does she also appear?:
-- 'Tsubasa: Reservoir Chronicle'
+Sakura Kinamoto is the heroine of 'Cardcaptor Sakura'. In which CLAMP manga/anime does she also appear?:
+- "Tsubasa: Reservoir Chronicle"
 - Tsubasa
 - Tsubasa Reservoir Chronicle
 - Tsubasa - Reservoir Chronicle
@@ -1177,7 +1177,7 @@ Type of anime aimed at young boys under the age of fifteen?:
 - shonen
 Type of anime aimed at young men between the ages of 15-24?:
 - seinen
-'Type of anime largely focused on one distinct aspect: pilotable robots?':
+"Type of anime largely focused on one distinct aspect: pilotable robots?":
 - mecha
 - robot
 Type of anime where one male character, the protagonist, at the center of a group of female characters who are all vying for his romantic affections?:
@@ -1203,7 +1203,7 @@ What is Kazuki Takahashi best known as the creator of?:
 - yu-gi-oh!
 What is a Japanese term for a character development process that describes a person who is initially cold and even hostile towards another person before gradually showing their warm side over time?:
 - tsundere
-What is a popular anime/manga character archetype that derives from the Japanese pronunciation of the English word "cool"?:
+What is a popular anime/manga character archetype that derives from the Japanese pronunciation of the English word 'cool'?:
 - kuudere
 - coodere
 What is name for the rabbit-like creatures from CLAMP?:

--- a/redbot/trivia/lists/artandliterature.yaml
+++ b/redbot/trivia/lists/artandliterature.yaml
@@ -1,7 +1,7 @@
-'"Our Town" is a play by whom?':
+"\"Our Town\" is a play by whom?":
 - Thornton Wilder
 - Wilder
-'"The Diary of Anne Frank" was first published in English under what title?':
+"\"The Diary of Anne Frank\" was first published in English under what title?":
 - The diary of a young girl
 A European movement of the late eighteenth to mid-nineteenth century. In reaction to neoclassicism, it focused on emotion over reason, and on spontaneous expression?:
 - Romanticism
@@ -80,7 +80,7 @@ According To "The Hitchhikers Guide To The Galaxy" what number is the answer to 
 - 42
 An Italian movement c.1909-1919. It attempted to integrate the dynamism of the machine age into art?:
 - Futurism
-An abstract movement in Europe and the United States, begun in the mid-1950"s and based on the effect of optical patterns?:
+An abstract movement in Europe and the United States, begun in the mid-1950's and based on the effect of optical patterns?:
 - Op art
 An artwork humoously excaggerating the qualities, defects, or pecularities of a person or idea?:
 - Caricature
@@ -90,30 +90,30 @@ An etching tecnique in which a solution of asphalt or resin is used on the plate
 - Aquatint
 Artwork, usually paintings, characterized by a simplified style, nonscientific perspective, and bold colors. The artists are generally not professionally trained?:
 - Naive art
-At which railway station does Harry Potter catch the Hogwart"s Express at Platform 9 and 3 Quarters?:
-- King"s Cross
+At which railway station does Harry Potter catch the Hogwart's Express at Platform 9 and 3 Quarters?:
+- King's Cross
 - kings cross
 Author of "The Lighthouse" and "Eminent Victorians"?:
 - Virginia Woolf
 - woolf
-Author of such works as "Gravity"s Rainbow", "V", "The Crying of Lot 49" and most recently, "Mason & Dixon"?:
+Author of such works as 'Gravity's Rainbow', 'V', 'The Crying of Lot 49' and most recently, 'Mason & Dixon'?:
 - Thomas Pynchon
 - pynchon
 Bob Kane created who?:
 - Batman
 By what name is the great Italian sculptor & artist Buonarroti better knownÂ as?:
-- MichelangeloÂ
+- Michelangelo
 Captain Hook, Tiger Lily, and Tinker Bell are characters in what story?:
 - Peter Pan
 Design style prevalent during the 1920s and 1930s, characterized by a sleek use of straight lines and slender forms?:
 - Art deco
 Douglas Adams is famous for writing what?:
-- The hitchhiker"s guide to the galaxy
-'Dr. Seuss wrote this book: The Cat in the______?':
+- The hitchhiker's guide to the galaxy
+"Dr. Seuss wrote this book: The Cat in the______?":
 - Hat
 Edgar Allen Poe wrote a famous poem about this animal?:
 - Raven
-'Faulkner penned this book with 4 distinctive sections: Benjy, Quentin, Jason, and Dilsey sections?':
+"Faulkner penned this book with 4 distinctive sections: Benjy, Quentin, Jason, and Dilsey sections?":
 - The Sound and the Fury
 For what is Dame Margott Fonteyn famous?:
 - Ballet Dancing
@@ -125,23 +125,23 @@ French impressionist Claude _____?:
 - Monet
 Frodo is chosen to deliver The Ring into the heart of what?:
 - Mount doom
-From the Hebrew word for "prophet". A group of French painters active in the 1890s who worked in a subjective, sometimes mystical style, stressing flat areas of color and pattern?:
+From the Hebrew word for 'prophet'. A group of French painters active in the 1890s who worked in a subjective, sometimes mystical style, stressing flat areas of color and pattern?:
 - Nabis
-From the french word "fauve", meaning "wild beast". A style adopted by artists associated with Matisse, c. 1905-1908. They painted in a spontaneous manner, using bold colors?:
+From the french word 'fauve', meaning 'wild beast'. A style adopted by artists associated with Matisse, c. 1905-1908. They painted in a spontaneous manner, using bold colors?:
 - Fauvism
-'From which Shakespeare play is this line taken: "Double, double"?':
-- Macbeth
-'From which Shakespeare play is this line taken: "To be or not to be"?':
+"From which Shakespeare play is this line taken: \"To be or not to be\"?":
 - Hamlet
-'From which Shakespeare play is this line taken: "What in a name that which we call a rose, by any other name would smell as sweet"?':
+"From which Shakespeare play is this line taken: 'Double, double'?":
+- Macbeth
+"From which Shakespeare play is this line taken: 'What in a name that which we call a rose, by any other name would smell as sweet'?":
 - Romeo and juliet
-From which Shakespeare play is this line taken? "Goodnight, goodnight! parting is such sweet sorrow, That I should say goodnight till it be morrow"?:
+From which Shakespeare play is this line taken? 'Goodnight, goodnight! parting is such sweet sorrow, That I should say goodnight till it be morrow'?:
 - Romeo and Juliet
-'From which of Shakespeare"s plays is this line: "All the world"s a stage___"?':
+"From which of Shakespeare's plays is this line: \"All the world's a stage___\"?":
 - As You Like It
 From whom did Bilbo obtain The Ring?:
 - Gollum
-Gandalf"s elven name.?:
+Gandalf's elven name.?:
 - Mithrandir
 Ground chalk or plaster mixed with glue, used as a base coat for tempera and oil painting?:
 - Gesso
@@ -152,17 +152,17 @@ H.G. Wells novel where Earth is invaded by Martians?:
 He penned the founding novel of the utopian genre, "Utopia"?:
 - Sir Thomas More
 - More
-He wrote "Ulysses", "Giacomo Joyce", "Dubliners", and "Finnegan"s Wake", among others?:
+He wrote 'Ulysses', 'Giacomo Joyce', 'Dubliners', and 'Finnegan's Wake', among others?:
 - James Joyce
 - joyce
-His many Romantic odes include "Ode to Melancholy" and "Ode to a Graecian Urn"?:
+His many Romantic odes include 'Ode to Melancholy' and 'Ode to a Graecian Urn'?:
 - Keats
 Homer wrote this account of the Trojan War?:
 - Iliad
-How many books are there in Anne Rice"s vampire series?:
+How many books are there in Anne Rice's vampire series?:
 - Five
 - 5
-How many holes are there on a traditional artist"s palette?:
+How many holes are there on a traditional artist's palette?:
 - One
 - 1
 How many lines are in a sonnet?:
@@ -174,40 +174,40 @@ How many plays is Shakespeare generally credited with today?:
 How many stories did Enid Blyton publish in 1959?:
 - Fifty nine
 - 59
-How many tales are there in Chaucer"s "Canterbury Tales"?:
+How many tales are there in Chaucer's 'Canterbury Tales'?:
 - 23
 - twenty three
-In "A Christmas Carol", how many ghosts visited Scrooge?:
+In 'A Christmas Carol', how many ghosts visited Scrooge?:
 - Four
 - 4
-In "A Christmas Carol", what was the name of the miser?:
+In 'A Christmas Carol', what was the name of the miser?:
 - Ebenezer Scrooge
 - scrooge
-In "Alice In Wonderland", who never stopped sobbing?:
+In 'Alice In Wonderland', who never stopped sobbing?:
 - Mock Turtle
-In "Romeo and Juliet", who gave a long monologue about Queen Mab?:
+In 'Romeo and Juliet', who gave a long monologue about Queen Mab?:
 - Mercutio
-In "Romeo and Juliet", who said "I have a faint cold, fear thrills through my veins"?:
+In 'Romeo and Juliet', who said 'I have a faint cold, fear thrills through my veins'?:
 - Juliet
-In "Romeo and Juliet", who says "make the bridal bed in that dim monument where Tybalt lies"?:
+In 'Romeo and Juliet', who says 'make the bridal bed in that dim monument where Tybalt lies'?:
 - Juliet
-In "Romeo and Juliet", who says "what must be must be"?:
+In 'Romeo and Juliet', who says 'what must be must be'?:
 - Juliet
-In "Romeo and Juliet", who was Mercutio"s long monologue about?:
+In 'Romeo and Juliet', who was Mercutio's long monologue about?:
 - Queen Mab
 In 1526 Hans Holbein became the officiaal portrait painter of which English king?:
-- Henry VIIIÂ
-In 2007 who topped the best sellers non fiction list with "Born To Be Riled"?:
+- Henry VIII
+In 2007 who topped the best sellers non fiction list with 'Born To Be Riled'?:
 - Jeremy Clarkson
 - Clarkson
-In Swift"s Gulliver"s Travels, what is Gulliver"s profession?:
-- SurgeonÂ
+In Swift's Gulliver's Travels, what is Gulliver's profession?:
+- Surgeon
 In The Canterbury Tales at which tavern do the story tellers assemble?:
 - The Tabard
 - tabard
 In a general sense, refers to objective representation. More specifically, a nineteenth century movement, especially in France, that rejected idealized academic styles in favor of everyday subjects?:
 - Realism
-In one of Donald Horne"s novels, what was Australia dubbed?:
+In one of Donald Horne's novels, what was Australia dubbed?:
 - The Lucky Country
 In painting, a thin layer of translucent color?:
 - Wash
@@ -219,13 +219,13 @@ In sculpting, the cutting of a form from a solid, hard material such as stone or
 - Carving
 In sculpture, the building up of form using a soft medium such as clay or wax, as distinguished from carving. In painting and drawing, using color and lighting variations to produce a three-dimensional effect?:
 - Modeling
-In the "Rhyme Of The Ancient Mariner" which bird is shot?:
+In the 'Rhyme Of The Ancient Mariner' which bird is shot?:
 - An Albatross
 - albatross
 In the Dr Seuss books, which elephant hatched an egg?:
 - Horton
-In the book "The Secret Diary Of Adrian Mole", what was the name of Adrian"s girlfriend?:
-- PandoraÂ
+In the book 'The Secret Diary Of Adrian Mole', what was the name of Adrian's girlfriend?:
+- Pandora
 In what book would you find a Hefalump?:
 - Winnie the Pooh
 In what city will you find the Museum of Modern Art?:
@@ -238,18 +238,18 @@ In what work does the HAL 9000 appear?:
 - 2001, A Space Odyssey
 - 2001 a space odyssey
 In which British national daily newspaper does Rupert The Bear appearÂ ?:
-- The Daily ExpressÂ
+- The Daily Express
 In which English county was John Constable born?:
 - Suffolk
 In which Gilbert & Sullivan Operetta does Nakipoo appear?:
-- The MikadoÂ
+- The Mikado
 In which John Steinbeck story features the slow-witted Lennie and his friend GeorgeÂ ?:
 - Of Mice and Men
 In which Shakespearean Play would you find the clown Costard?:
-- Love"s Labour Lost
+- Love's Labour Lost
 - love labour lost
 In which Shakespearean tragedy does Laertes appear?:
-- HamletÂ
+- Hamlet
 In which book did four ghosts visit Scrooge?:
 - A Christmas Carol
 In which book is Scheherazade a story teller?:
@@ -261,37 +261,37 @@ In which century did artists first start painting on canvas?:
 - 15th
 - 15
 - fifteenth
-In which city is Leonardo da Vinci"s "Last Supper" displayed?:
-- MilanÂ
+In which city is Leonardo da Vinci's 'Last Supper' displayed?:
+- Milan
 In which city is the EncyclopÃ¦dia Britannica published?:
-- ChicagoÂ
+- Chicago
 In which city will you find the largest opera house in the world?:
 - New York City
 In which novel was it the job of the firemen to burn books?:
-- Fahrenheit 451Â
-Meaning "fool the eye" in french. In painting, the fine, detailed rendering of objects to convey the illusion that the painted forms are real and three-dimensional?:
-- Trompe l"oeil
-Meaning "fresh" in Italian. The technique of painting on moist lime plaster with colors ground in water?:
+- Fahrenheit 451
+Meaning 'fool the eye' in french. In painting, the fine, detailed rendering of objects to convey the illusion that the painted forms are real and three-dimensional?:
+- Trompe l'oeil
+Meaning 'fresh' in Italian. The technique of painting on moist lime plaster with colors ground in water?:
 - Fresco
-Meaning "rebirth" in french. Refers to Europe c. 1400-1600. The style began in Italy and stressed the forms of classical antiquity, a realistic representation of space based on scientific perspective, and secular subjects?:
+Meaning 'rebirth' in french. Refers to Europe c. 1400-1600. The style began in Italy and stressed the forms of classical antiquity, a realistic representation of space based on scientific perspective, and secular subjects?:
 - Renaissance
 Movement in painting, originating in New York City in the 1940s. It emphasized spontaneous personal expression, freedom from accepted artistic values, surface quallities of paint, and the act of painting itself?:
 - Abstract expressionism
 Name the Philadelphian artist who introduced the world to "Pop Art"?:
 - Andy Warhol
 - Warhol
-'Name the Shakespeare play from this ultra short plot summary: Urged on by his wife, a man murders his king in order to take his place?':
+"Name the Shakespeare play from this ultra short plot summary: Urged on by his wife, a man murders his king in order to take his place?":
 - Macbeth
-Name the author of "The Catcher in the Rye"?:
+Name the author of 'The Catcher in the Rye'?:
 - J.D. Salinger
 - JD Salinger
 - Salinger
-Name the author of the famous "Doctor Zhivago", which presents a panoramic view of Russian society at the time of the 1917 Revolution?:
+Name the author of the famous 'Doctor Zhivago', which presents a panoramic view of Russian society at the time of the 1917 Revolution?:
 - Boris Pasternak
 - Pasternak
 On a represented form, a point of most intense light?:
 - Highlight
-On what book was "Three Days Of The Condor" based?:
+On what book was 'Three Days Of The Condor' based?:
 - Six Days Of The Condor
 Paint applied very thickly. It often projects from the picture surface?:
 - Impasto
@@ -307,15 +307,15 @@ Sir Alfred Gilbert was the sculptorÂ of what famous landmark?:
 - Eros
 Spanish modernist and cubist Pablo _____?:
 - Picasso
-'Stephen King"s: "Pet ________"?':
+"Stephen King's: \"Pet ________\"?":
 - Semetary
-'Stephen King"s: "Salem"s _________"?':
+"Stephen King's: \"Salem's _________\"?":
 - Lot
-'Stephen King"s: "The Dead ________"?':
+"Stephen King's: \"The Dead ________\"?":
 - Zone
 The Royal Opera House in London is home to which branch of the arts other than Opera?:
 - Ballet
-The ____ ____ school of poetry includes poets such as Frank O"Hara, John Ashbery and Kenneth Koch?:
+The ____ ____ school of poetry includes poets such as Frank O'Hara, John Ashbery and Kenneth Koch?:
 - New York
 The ____ generation included such authors as Jack Kerouac, William S. Burroughs and Allen Ginsburg?:
 - Beat
@@ -325,11 +325,11 @@ The effect of the harmony of color and values in a work?:
 - Tone
 The fallacy of personifying inanimate objects, often in bad taste?:
 - Pathetic fallacy
-The famous lithograph "The Scream" was created by which artist?:
+The famous lithograph 'The Scream' was created by which artist?:
 - Edvard Munch
 - munch
 The play "Our Town" is set where?:
-- Grover"s Corners
+- Grover's Corners
 The rendering of light and shade in painting; the subtle graduations and marked variations of light and shade for dramatic effect?:
 - Chiaroscuro
 The representation of inanimate objects in painting, drawing or photography?:
@@ -343,13 +343,13 @@ The technique of producing printed designs through various methods of incising o
 The term Impressionism was first used about which artist?:
 - Claude Monet
 - Monet
-The two races in HG Well"s "The Time Machine" are the child-like Eloi and the subterannean ______?:
+The two races in HG Well's "The Time Machine" are the child-like Eloi and the subterannean ______?:
 - Morlocks
 The visual and tactile quality of a work based on the particular way the materials are handled; also, the distribution of tones or shades of a single color?:
 - Texture
 This Romantic poet and husband to Mary Shelley drowned in a boating accident?:
 - Percy Bysshe Shelley
-This book, Oscar Wilde"s only novel, was used as evidence in his sodomy trial?:
+This book, Oscar Wilde's only novel, was used as evidence in his sodomy trial?:
 - The Picture of Dorian Gray
 This early American statesman and inventor wrote the book, "Fart proudly"?:
 - Benjamin Franklin
@@ -362,7 +362,7 @@ This magazine chronicled the Man of Bronze and the Fabulous Five?:
 - Doc savage
 This magazine used to boast a circulation of 7,777,777?:
 - Better homes and gardens
-This man was Time magazine"s 1938 "Man of the Year"?:
+This man was Time magazine's 1938 "Man of the Year"?:
 - Adolf Hitler
 - Hitler
 This statue was found on the Greek island of Melos in 1820?:
@@ -372,10 +372,10 @@ Three main types of Greek columns are Doric, Ionic, and __________?:
 Tilly Trotter, Hannah Massey, and Maggie Rowan are all characters created by which novelist?:
 - Catherine Cookson
 - cookson
-To what was "The Hall Of Arts & Sciences" changedÂ to?:
-- The Royal Albert HallÂ
+To what was 'The Hall Of Arts & Sciences' changedÂ to?:
+- The Royal Albert Hall
 Under what pen name did Hector Hugh Munro write?:
-- SakiÂ
+- Saki
 Water-soluble paint made from pigments and a plastic binder?:
 - Acrylic
 What Dr Seuss character steals Christmas?:
@@ -385,9 +385,9 @@ What Dutch master painted 64 self-portraits?:
 What Irish playwright and author, wrote "The Importance of Being Ernest" and "A Picture of Dorian Grey" among others?:
 - Oscar Wilde
 - Wilde
-'What Shakespearean play features the line: "A plague on both your houses"?':
+"What Shakespearean play features the line: 'A plague on both your houses'?":
 - Romeo and Juliet
-'What Shakespearean play features the line: A plague on both your houses?':
+"What Shakespearean play features the line: A plague on both your houses?":
 - Romeo and Juliet
 What Shakespearean play refers to the date of epiphany?:
 - Twelfth Night
@@ -396,7 +396,7 @@ What are arranged in the Japanese art of Ikebana?:
 What book is the film Blade Runner based on?:
 - Do Androids Dream of Electric Sheep
 What colour is the Art and Literature wedge in Trivial Pursuit?:
-- BrownÂ
+- Brown
 What controversial book did Germaine Greer write?:
 - The Female Eunuch
 What dance is associated with vienna?:
@@ -404,19 +404,19 @@ What dance is associated with vienna?:
 What did Jeannie C. Riley describe as "a little Peyton Place"?:
 - Harper valley
 What did Winston encounter in Room 101?:
-- RatsÂ
+- Rats
 What do you call a picture that is made of various material stuck together?:
 - Collage
-What does A E Houseman"s initials stand for?:
-- Alfred EdwardÂ
+What does A E Houseman's initials stand for?:
+- Alfred Edward
 What famous character did Edgar Rice Burroughs create?:
 - Tarzan
 What famous gothic novel was written by Mary Shelley?:
-- FrankensteinÂ
+- Frankenstein
 What is Mrs William Heelis better knownÂ as?:
 - Beatrix Potter
-What is Picasso"s nationality?:
-- SpanishÂ
+What is Picasso's nationality?:
+- Spanish
 What is Samuel Clemens better known as?:
 - Mark Twain
 What is an Icelandic epic called?:
@@ -424,9 +424,9 @@ What is an Icelandic epic called?:
 What is the art of tracing designs and making impressions of them called?:
 - Lithography
 What is the ballet term for spinning on one foot?:
-- PiroutteÂ
+- Piroutte
 What is the earliest known drawing mediumÂ ?:
-- CharcoalÂ
+- Charcoal
 What is the fourth book in the Harry Potter series?:
 - Harry Potter and the Goblet of Fire
 - The Goblet Of Fire
@@ -434,25 +434,25 @@ What is the most performed opera in the UK?:
 - La Boheme
 What is the name given to the painting medium involving egg yolks?:
 - Tempera
-What is the name of Colin Dexter"s fictional detective?:
-- Inspector MorseÂ
-What is the name of Gandalf"s horse?:
+What is the name of Colin Dexter's fictional detective?:
+- Inspector Morse
+What is the name of Gandalf's horse?:
 - Shadowfax
-What is the name of Hamlet"s tragic admirer?:
+What is the name of Hamlet's tragic admirer?:
 - Ophelia
 What is the name of the 7th and final Harry Potter book?:
-- Harry Potter and the Deathly HallowsÂ
+- Harry Potter and the Deathly Hallows
 What is the name of the Russian National Ballet?:
 - The Kirov Ballet
 - Kirov
 What is the name of the bird in The Peanuts comic?:
-- WoodstockÂ
-What is the name of the main character in Homer"s Odyssey?:
+- Woodstock
+What is the name of the main character in Homer's Odyssey?:
 - Odysseus
 What is the opposite of an utopia?:
 - Dystopia
 What is the surname of Cathy in Wuthering Heights?:
-- EarnshawÂ
+- Earnshaw
 What nationality was Jospeh Conrad?:
 - Polish
 What nationality were most of the Impressionist painters?:
@@ -460,85 +460,85 @@ What nationality were most of the Impressionist painters?:
 - France
 What other name does Stephen King write under?:
 - Richard Bachman
-'What play by Shakespeare features the following characters: Cornwall, Gloucester, Regan, and Goneril?':
+"What play by Shakespeare features the following characters: Cornwall, Gloucester, Regan, and Goneril?":
 - King Lear
-What publication was subtitled "The What"s New Magazine"?:
+What publication was subtitled 'The What's New Magazine'?:
 - Popular Science
 What rank was Biggles?:
-- MajorÂ
+- Major
 What school of poets was John Donne attributed to?:
 - The Metaphysical Poets
 - metaphsical
 What science fiction novel features Duke Leto Atreidea & The Harkonnens?:
-- DuneÂ
+- Dune
 What series did Robert Jordan write?:
 - Wheel of Time
 What story features Flopsy, Mopsy and Cottontail?:
 - Peter Rabbit
-What type of animal is Rupert the Bear"s best friend Bill?:
+What type of animal is Rupert the Bear's best friend Bill?:
 - Badger
-What was Dante"s last name?:
+What was Dante's last name?:
 - Alighieri
-What was H.G Wells" first novel?:
+What was H.G Wells' first novel?:
 - The Time Machine
-What was Lestat"s last name?:
+What was Lestat's last name?:
 - De Lioncourt
-What was Picasso"s first name?:
-- PabloÂ
-What was Shakespeare"s first play?:
+What was Picasso's first name?:
+- Pablo
+What was Shakespeare's first play?:
 - Henry VI
-What was Shakespeare"s last completed play?:
+What was Shakespeare's last completed play?:
 - The Tempest
-What was Sherlock Holmes" 7% solution in "The Sign of Four"?:
+What was Sherlock Holmes' 7% solution in 'The Sign of Four'?:
 - Cocaine
 What was the famous novel written in gaol, by John Bunyan?:
-- Pilgim"s ProgressÂ
-What was the name of Charles Dickens" last novel which was unfinished at his death?:
-- The Mystery Of Edwin DroodÂ
-What was the name of Mother Goose"s son?:
+- Pilgim's Progress
+What was the name of Charles Dickens' last novel which was unfinished at his death?:
+- The Mystery Of Edwin Drood
+What was the name of Mother Goose's son?:
 - Jack
-What was the name of William Wordworth"s sister?:
-- DorothyÂ
-What was the name of the author who released "A Guide To Baby And Child Care" in 1946?:
+What was the name of William Wordworth's sister?:
+- Dorothy
+What was the name of the author who released 'A Guide To Baby And Child Care' in 1946?:
 - Dr. Spock
 - spock
 - dr spock
 What was the only novel to be written by Margaret Mitchell?:
-- Gone With The WindÂ
-What was the sequel to Louisa May Alcott"s "Little Women"?:
+- Gone With The Wind
+What was the sequel to Louisa May Alcott's "Little Women"?:
 - Little Men
 What was the title of the first James Bond novel?:
-- Casino RoyaleÂ
-What were the dolls in the novel "Valley Of The Dolls"?:
+- Casino Royale
+What were the dolls in the novel 'Valley Of The Dolls'?:
 - Pills
 What were the tree like creatures in The Lord Of The Rings called?:
-- EntsÂ
-What were the two cities in "A Tale Of Two Cities"?:
+- Ents
+What were the two cities in 'A Tale Of Two Cities'?:
 - London and Paris
 - paris and london
 What word is Isaac Asimov famous for coining?:
 - Robotics
-What"s Penthouse"s sister publication for women?:
+What's Penthouse's sister publication for women?:
 - Viva
 Where is the Louvre located?:
 - Paris
 Where is the Prado Gallery?:
-- MadridÂ
-Where is the world"s largest art gallery?:
+- Madrid
+Where is the world's largest art gallery?:
 - Paris
 Where was El Grecho born?:
-- CreteÂ
+- Crete
 Where would you find Poets Corner?:
 - Westminster Abbey
 Where would you find the Elgin Marbles?:
-- The British MuseumÂ
-Which Algerian born French author"s works included "L"Etranger" and "La Peste"?:
+- The British Museum
+Which Algerian born French author's works included 'L'Etranger' and 'La Peste'?:
 - Albert Camus
 - Camus
 Which American artist is known for a portrait of his mother?:
 - James Whistler
 - whistler
-Which American auther wrote the novel "Roots"?:
+Which American auther wrote the novel 'Roots'?:
 - Alex Haley
 - haley
 Which American author wrote Jaws?:
@@ -550,101 +550,101 @@ Which British artist is noted for his numerous paintings of horses?:
 Which British painter frequently uses a swimming pool as a theme?:
 - David Hockney
 - hockney
-Which English writer divided his novels into 3 categories, "Novels Of Character & Environment", "Romances & Fantasies", and "Novels Of Ingenuity"?:
+Which English writer divided his novels into 3 categories, 'Novels Of Character & Environment', 'Romances & Fantasies', and 'Novels Of Ingenuity'?:
 - Thomas Hardy
 - Hardy
-Which Nobel Prize winner wrote "A History Of The English Speaking Peoples"?:
+Which Nobel Prize winner wrote 'A History Of The English Speaking Peoples'?:
 - Winston Churchill
 - churchill
 Which Science Fiction story centers around alien children in a village?:
-- The Midwitch CuckoosÂ
-Which Shakespeare play contains the line "if music be the food of love play on"?:
-- Twelfth NightÂ
+- The Midwitch Cuckoos
+Which Shakespeare play contains the line 'if music be the food of love play on'?:
+- Twelfth Night
 Which Shakespeare play opens with the 3 Witches?:
-- MacbethÂ
+- Macbeth
 Which Shakespearean character has the most lines?:
-- HamletÂ
+- Hamlet
 Which Shakespearean play is set in the Forest Of Arden?:
-- As You Like ItÂ
+- As You Like It
 Which Shakesperean play features the line "Now is the winter of our discontent"?:
 - Richard III
 Which St. Louis born novelist & poet became a British subject in 1927?:
 - T.S. Eliot
-- ts eliotÂ
+- ts eliot
 Which Stephen King novel is set at The Overlook Hotel?:
-- The ShiningÂ
+- The Shining
 Which Tennesee Williams play is about a Sicilian-American woman?:
 - The Rose Tattoo
 Which US author penned the novels "Of Mice and Men" and "East Of Eden"?:
 - John Steinbeck
 - Steinbeck
-Which US clarinetist player"s real name was Arthur Jacob Shaw?:
-- Artie ShawÂ
+Which US clarinetist player's real name was Arthur Jacob Shaw?:
+- Artie Shaw
 Which US dramatist was once married to Marylin Monroe and penned the plays "Death Of A Salesman" and "The Crucible"?:
 - Arthur Miller
 - miller
 Which Welsh poet died of alcohol poisoning the year he publsihed his collected poems?:
 - Dylan Thomas
 - thomas
-Which antipodean opera singer sung at Prince Charles" wedding to Lady Diana Spencer?:
-- Kiri Te KanawaÂ
-Which artist"s name literally means "Little Barrel"?:
-- BotticelliÂ
-Which author described World War One as "The War To End All Wars"?:
+Which antipodean opera singer sung at Prince Charles' wedding to Lady Diana Spencer?:
+- Kiri Te Kanawa
+Which artist's name literally means 'Little Barrel'?:
+- Botticelli
+Which author described World War One as 'The War To End All Wars'?:
 - HG Wells
 - h.g. wells
 - wells
 Which author did Hitler acclaim as the Prophet of Right Wing Authoritarianism?:
-- NietzscheÂ
+- Nietzsche
 Which author penned the Disc-World series of sci-fi novels?:
 - Terry Pratchett
 - pratchett
-Which author wrote "The Sound & The Fury", "The Wild Palms", and "As I Lay Dying"?:
+Which author wrote 'The Sound & The Fury', 'The Wild Palms', and 'As I Lay Dying'?:
 - William Faulkner
-Which author wrote "The Spy That Came In From The Cold"?:
+Which author wrote 'The Spy That Came In From The Cold'?:
 - John Le Carre
 - le carre
-Which author wrote novels upon which the TV series "All Creatures Great & Small" was based?:
+Which author wrote novels upon which the TV series 'All Creatures Great & Small' was based?:
 - James Herriot
 - herriot
-Which author wrote the "Just So Stories"?:
+Which author wrote the 'Just So Stories'?:
 - Rudyard Kipling
 - kipling
-Which author wrote the book "Black Beauty"?:
+Which author wrote the book 'Black Beauty'?:
 - Anna Sewell
 - sewell
-Which author"s father was imprisoned for debt?:
+Which author's father was imprisoned for debt?:
 - Charles Dickens
 - Dickens
-Which book including the characters Pod, Arrietty, Homily & PeagreenÂ inspired the film "the Secret Life of Arrietty"?:
-- The BorrowersÂ
+Which book including the characters Pod, Arrietty, Homily & PeagreenÂ inspired the film 'the Secret Life of Arrietty'?:
+- The Borrowers
 Which celebration of the arts is held in wales?:
 - The Eisteddfod
 Which character created by Dodie Smith drove a black & white car and wore a black & white fur coat?:
 - Cruella De Vil
-Which colour followed Picasso"s Blue Period?:
+Which colour followed Picasso's Blue Period?:
 - Pink
-Which decorative style was popular in the 1920"s & 1930"s?:
-- Art DecoÂ
-Which famous book begins with the line "On January 6, 1482, the people of Paris were awakened by the tumultuous clanging of all the bells in the city"?:
-- The Hunchback Of Notre DammeÂ
-Which famous book begins with the line "The mole had been working very hard all the morning, spring-cleaning his little home"?:
-- The Wind In The WillowsÂ
-'Which famous book begins with the line: "Marley was dead, to begin with. There was no doubt about that"?':
+Which decorative style was popular in the 1920's & 1930's?:
+- Art Deco
+Which famous book begins with the line 'On January 6, 1482, the people of Paris were awakened by the tumultuous clanging of all the bells in the city'?:
+- The Hunchback Of Notre Damme
+Which famous book begins with the line 'The mole had been working very hard all the morning, spring-cleaning his little home'?:
+- The Wind In The Willows
+"Which famous book begins with the line: 'Marley was dead, to begin with. There was no doubt about that'?":
 - A Christmas Carol
-'Which famous book begins with the line: "Not long ago, there lived in London a young married couple of Dalmation dogs named Pongo and Misses Pongo"?':
-- 101 DalmationsÂ
-Which famous book contains the line "It is a truth universally acknowledged that a single man in possession of a good fortune must be in want of a wife"?:
+"Which famous book begins with the line: 'Not long ago, there lived in London a young married couple of Dalmation dogs named Pongo and Misses Pongo'?":
+- 101 Dalmations
+Which famous book contains the line 'It is a truth universally acknowledged that a single man in possession of a good fortune must be in want of a wife'?:
 - Pride & Prejudice
 - pride and prejudice
-Which famous book contains the line "It was the best of times it was the worst of times it was the age of wisdom"?:
+Which famous book contains the line 'It was the best of times it was the worst of times it was the age of wisdom'?:
 - A Tale of Two Cities
-Which famous book contains the line "Mr & Mrs Dursley of number 4 Privet Drive were proud to say that they were perfectly normal"?:
+Which famous book contains the line 'Mr & Mrs Dursley of number 4 Privet Drive were proud to say that they were perfectly normal'?:
 - Harry Potter And The Philosophers Stone
-Which famous book contains the line "Once upon a time there was a little chimney sweep and his name was tom"?:
-- The Water BabiesÂ
-'Which famous play begins with the line: "When shall we three meet again, in thunder, lightening, or in rain"?':
-- MacbethÂ
+Which famous book contains the line 'Once upon a time there was a little chimney sweep and his name was tom'?:
+- The Water Babies
+"Which famous play begins with the line: 'When shall we three meet again, in thunder, lightening, or in rain'?":
+- Macbeth
 Which famous sculptor was refused entry to the French Academy 3 times?:
 - August Rodin
 - Rodin
@@ -656,52 +656,52 @@ Which gallery has exhibitions in London & St Ives, Cornwall?:
 - tate
 Which is the largest museum in the world?:
 - Louvre
-Which member of the Monty Python Team wrote children"s books about "Erik The Viking"?:
+Which member of the Monty Python Team wrote children's books about 'Erik The Viking'?:
 - Terry Jones
 - jones
 Which movement spanned the period from the 17th Century to the early 18th?:
-- BaroqueÂ
-Which novel by Mary Shelley was subtitled "The Modern Prometheus"?:
+- Baroque
+Which novel by Mary Shelley was subtitled 'The Modern Prometheus'?:
 - Frankenstein
 Which novel by Michael Crichton was the best selling paperback in 1993?:
-- Jurassic ParkÂ
+- Jurassic Park
 Which novel deals with the events of one day in Dublin in June 1904?:
 - Ulysses
 Which novel features Perks the station porter?:
-- The Railway ChildrenÂ
+- The Railway Children
 Which novel was originally going to be titled Elinor And Marianne?:
-- Sense And SensibilityÂ
-Which of Jane Austen"s novels was published posthumously?:
+- Sense And Sensibility
+Which of Jane Austen's novels was published posthumously?:
 - Persuasion
 Which of the Bronte sisters married the Reverend A B Nicholls in 1854?:
 - Charlotte
 Which outlaw rode a horse called Black Bess?:
-- Dick TurpinÂ
+- Dick Turpin
 Which painter cut off his own ear?:
 - Vincent Van Gogh
 Which poet preceded Ted Hughes as Poet Laureate?:
 - Sir John Betjeman
 - betjeman
-Which poet wrote no verses during his time as Britain"s Poet Laureate?:
-- William WordsworthÂ
+Which poet wrote no verses during his time as Britain's Poet Laureate?:
+- William Wordsworth
 Which poet, in his "Elegy Written in a Country Churchyard" told us that "Full many a flower is born to blush unseen / And waste its sweetnes on the desert air"?:
 - Thomas Gray
 - Gray
 Which publishing company was founded in London in 1935 by Allen Lane?:
-- PenguinÂ
+- Penguin
 Which school did Billy Bunter attend?:
-- GreyfriarsÂ
-Which sculptor produced "A Lobster Telephone"?:
+- Greyfriars
+Which sculptor produced 'A Lobster Telephone'?:
 - Salvador Dali
 - Dali
 Which story involves the schoolboy Piggy?:
-- Lord Of The FliesÂ
-Which tavern was the favourite haunt of Falstaff in Shakespeare"s "Henry IV"?:
-- The Boar"s Head
+- Lord Of The Flies
+Which tavern was the favourite haunt of Falstaff in Shakespeare's 'Henry IV'?:
+- The Boar's Head
 - the boars head
-- boar"s head
+- boar's head
 - boars head
-Which thriller writer"s works include "The Dark Eyes Of London", "Four Just Men", and "Sanders Of The River"?:
+Which thriller writer's works include 'The Dark Eyes Of London', 'Four Just Men', and 'Sanders Of The River'?:
 - Edgar Wallace
 - Wallace
 Which woman had more potraits painted of her than anyone else?:
@@ -712,18 +712,18 @@ Which word created by JK Rowling gained entry into the Oxford English Dictionary
 Who Wrote "Brave New World"?:
 - Aldous Huxley
 - huxley
-Who co-wrote "Yeoman Of The Guard", "Lolanthe And The Mikado"?:
-- Gilbert & SullivanÂ
-Who composed the ballet "Romeo & Juliet"?:
-- ProkofievÂ
-Who composed the ballet "The Nutcracker"?:
+Who co-wrote 'Yeoman Of The Guard', 'Lolanthe And The Mikado'?:
+- Gilbert & Sullivan
+Who composed the ballet 'Romeo & Juliet'?:
+- Prokofiev
+Who composed the ballet 'The Nutcracker'?:
 - Tchaikovsky
-Who composed the opera "Oedipus Rex"?:
-- StravinskyÂ
-Who created "Maudie Frickett"?:
+Who composed the opera 'Oedipus Rex'?:
+- Stravinsky
+Who created 'Maudie Frickett'?:
 - Jonathan Winters
 - winters
-Who created "The Saint"?:
+Who created 'The Saint'?:
 - Leslie Charteris
 - Charteris
 Who created Lord Peter Wimsey?:
@@ -739,7 +739,7 @@ Who created Winnie the Pooh?:
 - aa milne
 - a a milne
 - Milne
-Who designed the album sleeve for the Rolling Stones LP "Sticky Fingers"?:
+Who designed the album sleeve for the Rolling Stones LP 'Sticky Fingers'?:
 - Andy Warhol
 - warhol
 Who did Macduff kill?:
@@ -751,13 +751,13 @@ Who had decieved the Lord of Rohan for a number of years?:
 - Wormtongue
 Who is Karen Blixen better known as?:
 - Isaak Dinesen
-Who is Pip"s benefactor in Dickens"s "Great Expectations"?:
+Who is Pip's benefactor in Dickens's 'Great Expectations'?:
 - Abel Magwitch
 - Magwitch
 Who is associated with the address 221B Baker Street, London?:
 - Sherlock Holmes
-Who is novelist Helen Fielding"s most famous character?:
-- Bridget JonesÂ
+Who is novelist Helen Fielding's most famous character?:
+- Bridget Jones
 Who is responsible for painting the Mona Lisa?:
 - Leonardo da Vinci
 - da vinci
@@ -768,42 +768,42 @@ Who is the author of "Harry Potter"?:
 - J.K. Rowling
 - JK Rowling
 - Joanne Rowling
-Who is the protagonist of Milton"s "Paradise Lost"?:
+Who is the protagonist of Milton's 'Paradise Lost'?:
 - Satan
 Who killed Macbeth?:
 - Macduff
-Who kills Nancy in Dicken"s novel "Oliver Twist"?:
-- Bill SykesÂ
-Who painted "Flatford Mill"?:
+Who kills Nancy in Dicken's novel 'Oliver Twist'?:
+- Bill Sykes
+Who painted 'Flatford Mill'?:
 - Constable
-Who painted "Irises"?:
+Who painted 'Irises'?:
 - Vincent Van Gogh
 - van gogh
-Who painted "The Blue Boy"?:
+Who painted 'The Blue Boy'?:
 - Gainsborough
-Who painted "The Last Supper"?:
+Who painted 'The Last Supper'?:
 - Leonardo da Vinci
 - da vinci
 Who painted the Creation Of Adam?:
-- MichelangeloÂ
+- Michelangelo
 Who painted the Mona Lisa?:
 - Leonardo da Vinci
 - da Vinci
 Who painted the ceiling of the Sistine Chapel?:
 - Michelangelo
-Who penned the 1999 autobiography "Managing My Life"?:
-- Alex FergusonÂ
-Who penned the novel "The Pelican Brief" which was made into a film starring Julia Roberts and Denzel Washington?:
-- John GrishamÂ
-Who said "But, soft! what light through yonder window breaks"?:
+Who penned the 1999 autobiography 'Managing My Life'?:
+- Alex Ferguson
+Who penned the novel 'The Pelican Brief' which was made into a film starring Julia Roberts and Denzel Washington?:
+- John Grisham
+Who said 'But, soft! what light through yonder window breaks'?:
 - Romeo
 Who told stories about Brer Rabbit & Brer Fox?:
 - Uncle Remus
-Who was William Shakespeare"s Wife?:
+Who was William Shakespeare's Wife?:
 - Anne Hathaway
-Who was Winnie the Pooh"s neighbour?:
+Who was Winnie the Pooh's neighbour?:
 - Piglet
-Who was the author of "Dracula"?:
+Who was the author of 'Dracula'?:
 - Bram Stoker
 - Stoker
 Who was the first person to be buried at Poets Corner?:
@@ -811,107 +811,107 @@ Who was the first person to be buried at Poets Corner?:
 - chaucer
 Who was the human companion of Willow?:
 - Mad Mardigan
-Who was the merchant in Shakespeare"s "The Merchant Of Venice"?:
-- AntonioÂ
-Who won a Pulitzer Prize for Angela"s Ashes?:
+Who was the merchant in Shakespeare's 'The Merchant Of Venice'?:
+- Antonio
+Who won a Pulitzer Prize for Angela's Ashes?:
 - Frank McCourt
 - mccourt
 Who writes the discworld novels?:
 - Terry Pratchett
 - Pratchett
-Who wrote "1984"?:
-- George Orwell
-- orwell
-Who wrote "A Christmas Carol"?:
-- Charles Dickens
-Who wrote "A Tale Of Two Cities"?:
-- Charles Dickens
-- dickens
-Who wrote "Alice In Wonderland"?:
-- Lewis Carroll
-- carroll
 Who wrote "Animal Farm"?:
 - George Orwell
 - Orwell
-Who wrote "Ender"s Game"?:
+Who wrote "Ender's Game"?:
 - Orson Scott Card
 - card
-Who wrote "Far From The Madding Crowd"?:
-- Thomas Hardy
-- hardy
-Who wrote "Gone With The Wind"?:
-- Margaret Mitchell
-- mitchell
-Who wrote "Gulliver"s Travels"?:
-- Jonathan Swift
-- swift
-Who wrote "Jurassic Park"?:
-- Michael Crichton
-- crichton
-Who wrote "Psycho"?:
-- Robert Bloch
-- bloch
-Who wrote "Rendezvous with Rama"?:
-- Sir Arthur C. Clarke
-- arthur clarke
-- clarke
-Who wrote "Robinson Crusoe"?:
-- Daniel Defoe
-- defoe
 Who wrote "Ten Little Indians"?:
 - Agatha Christie
 - christie
-Who wrote "The Adventures Of Huckleberry Finn"?:
-- Mark Twain
-- twain
-Who wrote "The Birds"?:
-- Daphne du Maurier
-- du maurier
-Who wrote "The Canterbury Tales"?:
-- Geoffrey Chaucer
 Who wrote "The Count of Monte-Christo"?:
 - Alexander Dumas
 - dumas
-Who wrote "The Female Eunuch"?:
-- Germaine Greer
-- greer
-Who wrote "The Great Gatsby"?:
-- F. Scott Fitzgerald
-- fitzgerald
-- f scott fitzgerald
-Who wrote "The Gulag Archipelago"?:
-- Alexander Solzhenitsyn
-- Solzhenitsyn
-Who wrote "The Hitchhikers Guide to the Galaxy"?:
-- Douglas AdamsÂ
-Who wrote "The Hobbit"?:
-- J.R.R. Tolkien
-- jrr tolkien
-- tolkien
-Who wrote "The Murder Of Roger Ackroyd"?:
-- Agatha Christie
-- christie
 Who wrote "The Rime of the Ancient Mariner"?:
 - Samuel Taylor Coleridge
 - coleridge
-Who wrote "The Rose Tattoo"?:
-- Tennessee Williams
-Who wrote "The Time Machine"?:
-- H.G. Wells
-- HG Wells
-- wells
 Who wrote "The Wind in the Willows"?:
 - Kenneth Grahame
 - grahame
-Who wrote "To Kill A Mockingbird"?:
+Who wrote '1984'?:
+- George Orwell
+- orwell
+Who wrote 'A Christmas Carol'?:
+- Charles Dickens
+Who wrote 'A Tale Of Two Cities'?:
+- Charles Dickens
+- dickens
+Who wrote 'Alice In Wonderland'?:
+- Lewis Carroll
+- carroll
+Who wrote 'Far From The Madding Crowd'?:
+- Thomas Hardy
+- hardy
+Who wrote 'Gone With The Wind'?:
+- Margaret Mitchell
+- mitchell
+Who wrote 'Gulliver's Travels'?:
+- Jonathan Swift
+- swift
+Who wrote 'Jurassic Park'?:
+- Michael Crichton
+- crichton
+Who wrote 'Psycho'?:
+- Robert Bloch
+- bloch
+Who wrote 'Rendezvous with Rama'?:
+- Sir Arthur C. Clarke
+- arthur clarke
+- clarke
+Who wrote 'Robinson Crusoe'?:
+- Daniel Defoe
+- defoe
+Who wrote 'The Adventures Of Huckleberry Finn'?:
+- Mark Twain
+- twain
+Who wrote 'The Birds'?:
+- Daphne du Maurier
+- du maurier
+Who wrote 'The Canterbury Tales'?:
+- Geoffrey Chaucer
+Who wrote 'The Female Eunuch'?:
+- Germaine Greer
+- greer
+Who wrote 'The Great Gatsby'?:
+- F. Scott Fitzgerald
+- fitzgerald
+- f scott fitzgerald
+Who wrote 'The Gulag Archipelago'?:
+- Alexander Solzhenitsyn
+- Solzhenitsyn
+Who wrote 'The Hitchhikers Guide to the Galaxy'?:
+- Douglas Adams
+Who wrote 'The Hobbit'?:
+- J.R.R. Tolkien
+- jrr tolkien
+- tolkien
+Who wrote 'The Murder Of Roger Ackroyd'?:
+- Agatha Christie
+- christie
+Who wrote 'The Rose Tattoo'?:
+- Tennessee Williams
+Who wrote 'The Time Machine'?:
+- H.G. Wells
+- HG Wells
+- wells
+Who wrote 'To Kill A Mockingbird'?:
 - Harper Lee
 - Lee
-Who wrote "Valley Of The Dolls"?:
+Who wrote 'Valley Of The Dolls'?:
 - Jacqueline Susann
 - susann
-Who wrote "Weird Harold and Fat Albert"?:
+Who wrote 'Weird Harold and Fat Albert'?:
 - Bill Cosby
-Who wrote "little lamb, who made thee"?:
+Who wrote 'little lamb, who made thee'?:
 - William Blake
 - blake
 Who wrote Great Expectations?:
@@ -925,19 +925,19 @@ Who wrote The Canterbury Tales?:
 Who wrote about tarzan?:
 - Edgar Rice Burroughs
 - Burroughs
-Who wrote the "Dragonriders Of Pern" series?:
+Who wrote the 'Dragonriders Of Pern' series?:
 - Anne McCaffrey
 - mccaffrey
-Who wrote the "Father Brown" crime stories?:
+Who wrote the 'Father Brown' crime stories?:
 - G.K. Chesterton
 - chesterton
 - gk chesterton
-Who wrote the "Myth" series?:
+Who wrote the 'Myth' series?:
 - Robert Asprin
-Who wrote the "Noddy Stories"?:
+Who wrote the 'Noddy Stories'?:
 - Enid Blyton
 - blyton
-Who wrote the "Noddy" books?:
+Who wrote the 'Noddy' books?:
 - Enid Blyton
 - blyton
 Who wrote the Barsetshire novels?:
@@ -949,44 +949,44 @@ Who wrote the Tin Tin stories?:
 Who wrote the book "The Origin of Species"?:
 - Charles Darwin
 - darwin
-Who wrote the books "The Firm" and "The Pelican Brief" - both of which were made into films?:
+Who wrote the books 'The Firm' and 'The Pelican Brief' - both of which were made into films?:
 - John Grisham
 - Grisham
 Who wrote the epic poems, the Iliad and the Odyssey?:
 - Homer
-Who wrote the famous book "A Brief History Of Time" in 1988Â ?:
-- Stephen HawkingÂ
-Who wrote the gothic novel "Dracula"?:
+Who wrote the famous book 'A Brief History Of Time' in 1988Â ?:
+- Stephen Hawking
+Who wrote the gothic novel 'Dracula'?:
 - Bram Stoker
 - Stoker
 Who wrote the long religious epic, "Paradise Lost"?:
 - John Milton
 - milton
-Who wrote the novel "Emma"?:
-- Jane Austen
-- austen
-Who wrote the novel "Silence Of The Lambs"?:
-- Thomas Harris
-- Harris
 Who wrote the novel "The Strange Case of Dr. Jekyll and Mr Hyde"?:
 - Robert Louis Stevenson
 - Stevenson
+Who wrote the novel 'Emma'?:
+- Jane Austen
+- austen
+Who wrote the novel 'Silence Of The Lambs'?:
+- Thomas Harris
+- Harris
 Who wrote the novel Jaws, which was later turned into a blockbuster movie by Steven Spielburg?:
 - Peter Benchley
 - benchley
-Who wrote the novels "About A Boy"", "How To Be Good"" and "High Fidelity""Â ?:
-- Nick HornbyÂ
-Who wrote the novels "Slaughterhouse Five" and "Breakfast Of Champions"?:
+Who wrote the novels 'About A Boy'', 'How To Be Good'' and 'High Fidelity''Â ?:
+- Nick Hornby
+Who wrote the novels 'Slaughterhouse Five' and 'Breakfast Of Champions'?:
 - Kurt Vonnegut
 - vonnegut
-Who wrote the novels "The Hunt For Red October" and "Clear And Present Danger"?:
-- Tom ClancyÂ
-Who wrote the opera "The Flying Dutchman"?:
-- WagnerÂ
-Who wrote the play "Hay Fever"?:
+Who wrote the novels 'The Hunt For Red October' and 'Clear And Present Danger'?:
+- Tom Clancy
+Who wrote the opera 'The Flying Dutchman'?:
+- Wagner
+Who wrote the play 'Hay Fever'?:
 - Noel Coward
 - coward
-Who wrote the play "The Mousetrap"?:
+Who wrote the play 'The Mousetrap'?:
 - Agatha Christie
 - Christie
 Who wrote the shortest ever letter?:
@@ -1000,28 +1000,28 @@ Who wrote the vampire series that featured Lestat as the main character?:
 Who wrote three books under the title "Das Kapital"?:
 - Karl Marx
 - marx
-Whose autobiography was entitled "Dear Me"?:
+Whose autobiography was entitled 'Dear Me'?:
 - Peter Ustinov
 - ustinov
-Whose first collection of short stories entitled "In Our Time" was published in 1925?:
+Whose first collection of short stories entitled 'In Our Time' was published in 1925?:
 - Ernest Hemmingway
 - hemmingway
-Whose ghost appears at the dinner table in "Macbeth"?:
+Whose ghost appears at the dinner table in 'Macbeth'?:
 - Banquo
-Whose last words were "Thus with a kiss I die"?:
+Whose last words were 'Thus with a kiss I die'?:
 - Romeo
-Whose life was the subject of James Boswell"s Biography, published in 1791?:
+Whose life was the subject of James Boswell's Biography, published in 1791?:
 - Samuel Johnson
 - johnson
 Whose smile remained after the rest of it had vanished?:
 - The Cheshire Cat
 - cheshire cat
-Whose works "The Ballad Of Reading Gaol" & "De Profundis", were written from his experiences in prison?:
+Whose works 'The Ballad Of Reading Gaol' & 'De Profundis', were written from his experiences in prison?:
 - Oscar Wilde
 - Wilde
 With what art movement was Salvador Dali associated?:
-- SurrealismÂ
-Women"s magazine launched by New York in the 70"s?:
+- Surrealism
+Women's magazine launched by New York in the 70's?:
 - Ms
 Works of a culturally homogenous people without formal training, generally according to regional traditions and involving crafts?:
 - Folk art

--- a/redbot/trivia/lists/boombeach.yaml
+++ b/redbot/trivia/lists/boombeach.yaml
@@ -8,7 +8,7 @@ Every player in Boom Beach starts with this IGN?:
 How fast does Robot Overlord spawn critters when maxed?:
 - 4.3 seconds
 - 4.3s
-- '4.3'
+- "4.3"
 How intel much would 3 sabotages cost?:
 - 15
 - fifteen
@@ -67,7 +67,7 @@ How many statues can a level 4 statue storage hold?:
 How many statues can a level 6 sculptor have?:
 - 8
 - eight
-How many tiles is a scorcher"s death radius?:
+How many tiles is a scorcher's death radius?:
 - 3 tiles
 - 3
 - three
@@ -139,11 +139,11 @@ If you have level 5 critters how many critters will be in each crate?:
 In game you can be invaded by Blackguard and what?:
 - mercenary
 - mercenaries
-'Name this prototype module: https://goo.gl/DXrKtM':
+"Name this prototype module: https://goo.gl/DXrKtM":
 - Complex Gear
 Sgt Brick has three abilities. Iron Will, Battle Orders, and___?:
 - Cluster Grenade
-There"s a gunboat on your map and it"s Monday, what event is it?:
+There's a gunboat on your map and it's Monday, what event is it?:
 - Hammerman Strikes Back
 This mortar has no blindspot, what is it called? https://goo.gl/5Ekjop:
 - Super Mortar 3000
@@ -151,7 +151,7 @@ This mortar has no blindspot, what is it called? https://goo.gl/5Ekjop:
 War Factory comes on which day of the week?:
 - Thursday
 - thurs
-"War Timeâ\x80¦ what?  https://goo.gl/JIwbAK":
+War TimeÃ¢â‚¬Â¦ what?  https://goo.gl/JIwbAK:
 - epaulets
 - Epaulettes
 What HQ is required to unlock Mega Crab:
@@ -175,7 +175,7 @@ What can you buy with Trader Tickets?:
 - crates
 What colour are Ice Stones?:
 - Blue
-What is a Cryoneer"s weapon called?:
+What is a Cryoneer's weapon called?:
 - Freeze Beam
 What is smaller than a Shard?:
 - fragment
@@ -233,7 +233,7 @@ What is the name of this building? https://goo.gl/arvmiT:
 - Dream Pipes
 What is the name of this prototype? https://goo.gl/MWmygA:
 - Field Capacitor
-What is the name of zmoT"s Task Force?:
+What is the name of zmoT's Task Force?:
 - Triangle Nine
 - T9
 - Triangle 9
@@ -245,7 +245,7 @@ What is the official name for Purple Stones?:
 What is the official name for Red Stones?:
 - Magma Stones
 - Magma
-What is the only building whose last upgrade doesn"t cost Wood?:
+What is the only building whose last upgrade doesn't cost Wood?:
 - Sawmill
 What is the only unit that can move and attack at the same time?:
 - Heavy
@@ -281,13 +281,13 @@ What rank is obtained at 450 VP?:
 What rate does a building frozen by a Cryoneer shoot?:
 - 50%
 - half
-- '0.5'
+- "0.5"
 What sign is on the front of the Operation Reward boat?:
-- 'No smoking: http://i.imgur.com/Tk49o1E.jpg'
+- "No smoking: http://i.imgur.com/Tk49o1E.jpg"
 - No smoking
 What time does the Trader arrive?:
 - 7pm
-- '19:00'
+- "19:00"
 - 7:00pm
 - 1900
 - 7 pm
@@ -298,12 +298,12 @@ What variety of tree grows on ice bases?:
 What was the name of the update that contained the first Mega Crab?:
 - The Last Crustacean
 - Last Crustacean
-What word does the troop name "Zooka" come from?:
+What word does the troop name 'Zooka' come from?:
 - Bazooka
-What"s the lowest possible level of a resource base?:
+What's the lowest possible level of a resource base?:
 - 3
 - three
-What"s the most GBE that can be returned (from destroyed buildings) using a single artillery shot?:
+What's the most GBE that can be returned (from destroyed buildings) using a single artillery shot?:
 - 12
 - twelve
 When you beat an NPC what percent chance do you have of getting a prototype part?:
@@ -337,7 +337,7 @@ Which defense reduces attack and movement speed by 75%?:
 Which is the only defense that is manned by a troop?:
 - Sniper Tower
 - sniper
-Which of Dr.T"s islands appears first in the event cycle?:
+Which of Dr.T's islands appears first in the event cycle?:
 - Tropical
 Which one default (non prototype) defense can not be found on resource bases?:
 - Shock Launcher

--- a/redbot/trivia/lists/clashroyale.yaml
+++ b/redbot/trivia/lists/clashroyale.yaml
@@ -1,4 +1,4 @@
-'"Roses are red, ....... are blue, they can fly, and will crush you!" Who is this about?':
+"\"Roses are red, ....... are blue, they can fly, and will crush you!\" Who is this about?":
 - Minions
 - minion
 - 3 minions
@@ -30,11 +30,11 @@ At which Arena can you unlock Furnace?:
 At which Arena can you unlock Golem?:
 - Arena 6
 - 6
-- Builder"s Workshop
+- Builder's Workshop
 At which Arena can you unlock Hog Rider?:
 - Arena 4
 - 4
-- P.E.K.K.A"s Playhouse
+- P.E.K.K.A's Playhouse
 At which Arena can you unlock Ice Spirit?:
 - Arena 8
 - 8
@@ -80,8 +80,8 @@ How many Gems does a Bucket of Gold cost?:
 How many Gems does a Wagon contain?:
 - 6500
 - 6,500
-- 6"500
-- '6.500'
+- 6'500
+- "6.500"
 - 6.5k
 - six thousand five hundred
 - sixtyfive hundred
@@ -89,10 +89,10 @@ How many Gems does a Wagon of Gold cost?:
 - 4500
 - 4 500
 - 4,500
-- '4.500'
+- "4.500"
 - 4.5k
 - 4,5k
-- 4"500
+- 4'500
 - Four Thousand Five Hundred
 How many cards are you rewarded for winning a 200 player tournament?:
 - 120
@@ -101,8 +101,8 @@ How many cards are you rewarded for winning a 500 player tournament?:
 - 1200
 - 1 200
 - 1,200
-- 1"200
-- '1.200'
+- 1'200
+- "1.200"
 - 1.2k
 - one thousand two hundred
 - twelve hundred
@@ -119,9 +119,9 @@ How many gems does a Pouch of Gold cost?:
 - sixty
 How many gems does it cost to create the largest tournament?:
 - 250000
-- 250"000
+- 250'000
 - 250 000
-- '250.000'
+- "250.000"
 - 250,000
 - two hundred and fifty thousand
 How many make a crowd?:
@@ -136,18 +136,18 @@ How many trophies do you need to get into Barbarian Bowl?:
 How many trophies do you need to get into Bone Pit?:
 - 400
 - four hundred
-How many trophies do you need to get into Builder"s Workshop?:
+How many trophies do you need to get into Builder's Workshop?:
 - 1700
 - 1,700
-- 1"700
-- '1.700'
+- 1'700
+- "1.700"
 - seventeen hundred
 - one thousand seven hundred
 How many trophies do you need to get into Frozen Peak?:
 - 2300
 - 2,300
-- '2.300'
-- 2"300
+- "2.300"
+- 2'300
 - two thousand three hundred
 - twenty three hundred
 How many trophies do you need to get into Goblin Stadium?:
@@ -156,29 +156,29 @@ How many trophies do you need to get into Goblin Stadium?:
 How many trophies do you need to get into Legendary Arena?:
 - 3000
 - 3,000
-- '3.000'
-- 3"000
+- "3.000"
+- 3'000
 - 3k
 - three thousand
-How many trophies do you need to get into P.E.K.K.A"s Playhouse?:
+How many trophies do you need to get into P.E.K.K.A's Playhouse?:
 - 1100
-- 1"100
+- 1'100
 - 1,000
-- '1.100'
+- "1.100"
 - one thousand one hundred
 - eleven hundred
 How many trophies do you need to get into Royal Arena?:
 - 2000
 - 2,000
-- 2"000
-- '2.000'
+- 2'000
+- "2.000"
 - 2k
 - two thousand
 How many trophies do you need to get into Spell Valley?:
 - 1400
-- 1"400
+- 1'400
 - 1,400
-- '1.400'
+- "1.400"
 - fourteen hundred
 - one thousand four hundred
 How many trophies do you need to get into Training Camp?:
@@ -189,18 +189,18 @@ How much Gold does a Bucket of Gold contain?:
 - 10000
 - 10 000
 - 10k
-- '10.000'
+- "10.000"
 - 10,000
-- 10"000
+- 10'000
 - ten thousand
 - 10 thousand
 How much Gold does a Wagon of Gold contain?:
 - 100 000
 - 100000
 - 100k
-- 100"000
+- 100'000
 - 100,000
-- '100.000'
+- "100.000"
 - one hundred thousand
 - 100 thousand
 How much damage does a tournament level Freeze deal?:
@@ -210,26 +210,26 @@ How much gold does a Pouch of Gold contain?:
 - 1000
 - 1k
 - 1,000
-- '1.000'
+- "1.000"
 - 1 000
-- 1"000
+- 1'000
 - one thousand
 - a thousand
 How much gold does the 2nd Legendary cost in the shop?:
 - 80000
 - 80k
 - 80,000
-- 80"000
-- '80.000'
+- 80'000
+- "80.000"
 - 80 000
 - eighty thousand
 Larry, Harry, Terry, Mary, Leedoot and friends together make a...?:
 - Skeleton Army
 - skarmy
-Miner doesn"t use magic,but a...?:
+Miner doesn't use magic,but a...?:
 - Shovel
 - shovel
-Name one Legendary card that is unlocked at Builder"s Workshop.:
+Name one Legendary card that is unlocked at Builder's Workshop.:
 - Sparky Miner or The Log
 - Sparky
 - Miner
@@ -259,17 +259,17 @@ What does the hog say?:
 What is The Log seeking for?:
 - Revenge
 - revenge
-What is The Log"s favourite song?:
-- They see me rollin"
+What is The Log's favourite song?:
+- They see me rollin'
 - they see me rollin
 What is adorable, but on fire?:
 - Fire Spirits
 - firespirits
 - fs
-What is the Furnace"s specialty?:
+What is the Furnace's specialty?:
 - Pancakes
 - pancake
-What is the Royal Giant"s passion?:
+What is the Royal Giant's passion?:
 - his beard
 - beard
 What is the best distraction for the Mini P.E.K.K.A?:
@@ -312,11 +312,11 @@ What makes everyone say "Chaaaarge!":
 - Rage
 What uses the power of Electrickery?:
 - Tesla
-What"s the only thing in the game that isn"t affected by Poison?:
+What's the only thing in the game that isn't affected by Poison?:
 - The grass
 - grass
-What"s too hot for TV?:
-- Ice wizard"s mustache
+What's too hot for TV?:
+- Ice wizard's mustache
 - iwmustache
 - ice wiz mustache
 - handlebar mustache
@@ -331,13 +331,13 @@ Where is the 4th Skeleton?:
 - In the army now
 - skeleton army
 - skarmy
-Where you shouldn"t look inside?:
+Where you shouldn't look inside?:
 - Goblin Hut
 - gob hut
 Which Legendary card is unlocked at Frozen Peak?:
 - Lumberjack
 - lj
-Which Legendary card is unlocked at P.E.K.K.A"s Playhouse?:
+Which Legendary card is unlocked at P.E.K.K.A's Playhouse?:
 - Lava Hound
 - lavahound
 - lh
@@ -352,7 +352,7 @@ Who are the Guards without their shields?:
 Who carries around a drink on the Arena?:
 - Lumberjack
 - lj
-Who doesn"t know what "Overkill" means?:
+Who doesn't know what "Overkill" means?:
 - Sparky
 Who has a coil of iron and wheels of wood?:
 - Sparky
@@ -362,7 +362,7 @@ Who has delicately coiffed hair?:
 - musky
 - musket
 - musk
-Who has eyes that unfortunately don"t shoot lasers?:
+Who has eyes that unfortunately don't shoot lasers?:
 - Witch
 Who is the Knight for the barbarian?:
 - Cousin
@@ -373,21 +373,21 @@ Who sounds like he has a bucket on his head?:
 - dp
 - darkp
 - dark p
-Who won"t help you colour your hair thus often doing it?:
+Who won't help you colour your hair thus often doing it?:
 - Archers
-Who"s a majestic flying beast?:
+Who's a majestic flying beast?:
 - Lava Hound
 - lavahound
 - lh
-Who"s a one-man wrecking crew?:
+Who's a one-man wrecking crew?:
 - Giant
-Who"s born ready for a barbeque?:
+Who's born ready for a barbeque?:
 - Baby Dragon
 - baby drag
-Who"s stunning?:
+Who's stunning?:
 - Princess
 Why is it bad for you if you feel warm feelings towards the Princess?:
-- Because you"re probably on fire!
+- Because you're probably on fire!
 - cuz ur on fire
 - because your probably on fire
 - You are on fire

--- a/redbot/trivia/lists/computers.yaml
+++ b/redbot/trivia/lists/computers.yaml
@@ -3,17 +3,17 @@ A compact disc containing permanently stored data that cannot be altered?:
 - CD-ROM
 - CD ROM
 - Compact Disc-Read-Only Memory
-- ''
+- ""
 - Compact Disk Read-Only Memory
-- ''
+- ""
 - Compact Disc Read Only Memory
-- ''
+- ""
 - Compact Disk Read Only Memory
 A computer that is on the network is a...?:
 - Node
 A computer which links several PCs together in a network is called a...?:
 - Server
-A computer"s cache will hold data that is used most often to make it faster to access. There are various levels of cache, the first of which is a small amount of memory found inside the what?:
+A computer's cache will hold data that is used most often to make it faster to access. There are various levels of cache, the first of which is a small amount of memory found inside the what?:
 - CPU
 - Central processing unit
 A network technician is configuring port security on switches. The interfaces on the switches are configured in such a way that when a violation occurs, packets with unknown source address are dropped and no notification is sent. Which violation mode is configured on the interfaces?:
@@ -38,7 +38,7 @@ Business-oriented social networking service, co-founded by Reid Hoffman in 2003?
 - LinkedIn
 Crowdfunding platform founded in 2009 by Perry Chen, Yancey Strickler and Charles Adler?:
 - Kickstarter
-Data can come from information stored in the computer"s permanent storage, or it can come from peripheral devices, such as keyboards. Regardless of whether it is input through a peripheral device or taken from storage, which type of memory does most data go through first?:
+Data can come from information stored in the computer's permanent storage, or it can come from peripheral devices, such as keyboards. Regardless of whether it is input through a peripheral device or taken from storage, which type of memory does most data go through first?:
 - RAM
 E-commerce business founded in 1998 and focuses on money transfers to be made through the Internet?:
 - PayPal
@@ -74,7 +74,7 @@ In which year was ASCII formed?:
 - 1963
 In which year was MIDI introduced?:
 - 1983
-In which year was the Personal Computer featured as the Times "Man of the Year"?:
+In which year was the Personal Computer featured as the Times 'Man of the Year'?:
 - 1982
 Inside the hard disk drive, where is the data actually stored?:
 - platter
@@ -103,13 +103,13 @@ Rewritable optical disk where you can save and erase data several times?:
 - CD-RW
 - CD RW
 - Compact Disc Rewritable
-- ''
+- ""
 - Compact Disk Rewritable
 - Compact Disk-Rewritable
-Secondary storage, like the hard drive, isn"t directly accessible to the CPU like primary storage. What is another name for secondary storage?:
+Secondary storage, like the hard drive, isn't directly accessible to the CPU like primary storage. What is another name for secondary storage?:
 - auxiliary storage
 - auxiliary
-"Small portable disk inside a plastic cover. It‚\x80\x99s thicker than the floppy and needs a special drive connected to the computer?":
+Small portable disk inside a plastic cover. It‚Äôs thicker than the floppy and needs a special drive connected to the computer?:
 - Zip Disk
 - zip drive
 - zip disc
@@ -127,7 +127,7 @@ The OSPF Type 1 packet is the _________ packet.:
 - Hello
 The buffers for packet processing and the running configuration file are temporarily stored in which type of router memory?:
 - RAM
-"The cabinet containing the computer‚\x80\x99s working parts is known as the...?":
+The cabinet containing the computer‚Äôs working parts is known as the...?:
 - Workstation
 - Case
 The default administrative distance for a static route is...?:
@@ -202,11 +202,11 @@ What is the largest piece of the computer; it is also the one that has the fewes
 - Case
 What is the maximum number of peripheral devices which can be connected through a single USB port?:
 - 127
-What is the name of Linux"s Mascot?:
+What is the name of Linux's Mascot?:
 - Tux
 What is the name of the software that allows us to browse through web pages called?:
 - Browser
-What is the phrase for how often your screen"s image is redrawn?:
+What is the phrase for how often your screen's image is redrawn?:
 - Refresh Rate
 What numeric base system was used by the Honeywell-800?:
 - octal
@@ -222,7 +222,7 @@ When a key is pressed on the keyboard, which standard is used for converting the
 - ANSI
 When an application fires up, the application is loaded into...?:
 - RAM
-When looking at your computer"s memory, you will come across the storage hierarchy, which separates storage into primary, secondary, and tertiary. Primary storage refers to memory that is directly accessible to the CPU. What is another name for primary storage?:
+When looking at your computer's memory, you will come across the storage hierarchy, which separates storage into primary, secondary, and tertiary. Primary storage refers to memory that is directly accessible to the CPU. What is another name for primary storage?:
 - Main Memory
 - Main
 When you look at a processor, you normally see a plastic or ceramic case with metal pins and possibly other metal parts. However, the active component inside is made of a different material - which one?:
@@ -239,151 +239,151 @@ Which subnet mask would be used as the classful mask for the IP address 128.107.
 - 255.255.0.0
 Which subnet mask would be used as the classful mask for the IP address 192.135.250.27?:
 - 255.255.255.0
-"Which value represents the ‚\x80\x9Ctrustworthiness‚\x80\x9D of a route and is used to determine which route to install into the routing table when there are multiple routes toward the same destination?":
+Which value represents the ‚Äútrustworthiness‚Äù of a route and is used to determine which route to install into the routing table when there are multiple routes toward the same destination?:
 - Administrative distance
 Who invented the computer mouse?:
 - Douglas Engelbart
-'[Acronyms]What does CD-R stand for?':
+"[Acronyms]What does CD-R stand for?":
 - Compact Disc-Recordable
 - Compact Disc Recordable
 - Compact Disk-Recordable
 - Compact Disk Recordable
-'[Acronyms]What does CD-ROM stand for?':
+"[Acronyms]What does CD-ROM stand for?":
 - Compact Disc-Read Only Memory
 - Compact Disc Read Only Memory
 - Compact Disk-Read Only Memory
 - Compact Disk Read Only Memory
-'[Acronyms]What does CD-RW stand for?':
+"[Acronyms]What does CD-RW stand for?":
 - Compact Disc-Rewritable
 - Compact Disc Rewritable
 - Compact Disk-Rewritable
 - Compact Disk Rewritable
-'[Acronyms]What does CPU stand for?':
+"[Acronyms]What does CPU stand for?":
 - Central Processing Unit
-'[Acronyms]What does CRT stand for?':
+"[Acronyms]What does CRT stand for?":
 - Cathode Ray Tube
-'[Acronyms]What does DVI stand for?':
+"[Acronyms]What does DVI stand for?":
 - Digital Visual Interface
-'[Acronyms]What does EOF stand for?':
+"[Acronyms]What does EOF stand for?":
 - End of File
-'[Acronyms]What does IP stand for?':
+"[Acronyms]What does IP stand for?":
 - Internet Protocol
-'[Acronyms]What does ISO stand for?':
+"[Acronyms]What does ISO stand for?":
 - International Standard Organization
-'[Acronyms]What does ISP stand for?':
+"[Acronyms]What does ISP stand for?":
 - Internet Service Provider
-'[Acronyms]What does LCD stand for?':
+"[Acronyms]What does LCD stand for?":
 - Liquid Crystal Display
-'[Acronyms]What does LPT stand for?':
+"[Acronyms]What does LPT stand for?":
 - Line Printer
-'[Acronyms]What does MTBF stand for?':
+"[Acronyms]What does MTBF stand for?":
 - Mean Time Between Failures
-'[Acronyms]What does NIC stand for?':
+"[Acronyms]What does NIC stand for?":
 - Network Interface Card
-'[Acronyms]What does PAN stand for?':
+"[Acronyms]What does PAN stand for?":
 - Personal Area Network
-'[Acronyms]What does RAM stand for?':
+"[Acronyms]What does RAM stand for?":
 - Random Access Memory
-'[Acronyms]What does ROM stand for?':
+"[Acronyms]What does ROM stand for?":
 - Read Only Memory
-'[Acronyms]What does SCSI port (pronounced skuzzy) stand for?':
+"[Acronyms]What does SCSI port (pronounced skuzzy) stand for?":
 - Small Computer System Interface
-'[Acronyms]What does SCSI stand for?':
+"[Acronyms]What does SCSI stand for?":
 - Small Computer System Interface
-'[Acronyms]What does SDLC stand for in Networking protocol?':
+"[Acronyms]What does SDLC stand for in Networking protocol?":
 - Synchronous Data Link Control
-'[Acronyms]What does SDRAM stand for?':
+"[Acronyms]What does SDRAM stand for?":
 - Synchronous Dynamic Random Access Memory
-'[Acronyms]What does Spool stand for?':
+"[Acronyms]What does Spool stand for?":
 - Simultaneous Peripheral Output On-Line
 - Simultaneous Peripheral Output On Line
-'[Acronyms]What does TCP stand for?':
+"[Acronyms]What does TCP stand for?":
 - Transmission Control Protocol
-'[Acronyms]What does USB stand for?':
+"[Acronyms]What does USB stand for?":
 - Universal Serial Bus
-'[Acronyms]What does VDU stand for?':
+"[Acronyms]What does VDU stand for?":
 - Visual Display Unit
-'[Acronyms]What does modem stand for?':
+"[Acronyms]What does modem stand for?":
 - Modulator Demodulater
-'[Acronyms]What does www stand for?':
+"[Acronyms]What does www stand for?":
 - World Wide Web
-'[Input/Output]Digital Camera?':
+"[Input/Output]Digital Camera?":
 - Input
-'[Input/Output]Graphics Tablet?':
+"[Input/Output]Graphics Tablet?":
 - Input
-'[Input/Output]Inkjet Printer?':
+"[Input/Output]Inkjet Printer?":
 - Output
-'[Input/Output]Keyboard?':
+"[Input/Output]Keyboard?":
 - Input
-'[Input/Output]Laser Printer?':
+"[Input/Output]Laser Printer?":
 - Output
-'[Input/Output]Monitor?':
+"[Input/Output]Monitor?":
 - Output
-'[Input/Output]Mouse?':
+"[Input/Output]Mouse?":
 - Input
-'[Input/Output]Scanner?':
+"[Input/Output]Scanner?":
 - Input
-'[Input/Output]Speakers?':
+"[Input/Output]Speakers?":
 - Output
-'[Input/Output]Touchpad?':
+"[Input/Output]Touchpad?":
 - Input
-'[Input/Output]Trackball?':
+"[Input/Output]Trackball?":
 - Input
-'[Programming Languages]A popular scripting language for computers, often run in web browsers to create or alter dynamic content. It was developed by Brendan Eich for Netscape in 1995.':
+"[Programming Languages]A popular scripting language for computers, often run in web browsers to create or alter dynamic content. It was developed by Brendan Eich for Netscape in 1995.":
 - Javascript
-'[Programming Languages]Compiled computer programming language created in 1959 and primarily used in business, finance, and administrative systems.':
+"[Programming Languages]Compiled computer programming language created in 1959 and primarily used in business, finance, and administrative systems.":
 - COBOL
-'[Programming Languages]Computer language since 1982 for creating vector graphics, best known for its use as a page description language in the electronic and desktop publishing areas.':
+"[Programming Languages]Computer language since 1982 for creating vector graphics, best known for its use as a page description language in the electronic and desktop publishing areas.":
 - Postscript
-'[Programming Languages]Computer scripting language originally developed by Macromedia Inc., now primarily used in Adobe Flash Player':
+"[Programming Languages]Computer scripting language originally developed by Macromedia Inc., now primarily used in Adobe Flash Player":
 - ActionScript
-'[Programming Languages]Dynamic, object-oriented, general-purpose programming language with a focus on shortness and ease of use. It was influenced by Perl, Ada and Lisp and designed by Yukihiro Matsumoto in 1995.':
+"[Programming Languages]Dynamic, object-oriented, general-purpose programming language with a focus on shortness and ease of use. It was influenced by Perl, Ada and Lisp and designed by Yukihiro Matsumoto in 1995.":
 - Ruby
-'[Programming Languages]Educational programming language, designed in 1967 and modeled on the LISP programming language.':
+"[Programming Languages]Educational programming language, designed in 1967 and modeled on the LISP programming language.":
 - Logo
-'[Programming Languages]General-purpose, object-oriented programming language designed by Brad Cox and Tom Love. It is the main programming language used by Apple for the OS X and iOS operating systems,and their application programming interfaces.':
+"[Programming Languages]General-purpose, object-oriented programming language designed by Brad Cox and Tom Love. It is the main programming language used by Apple for the OS X and iOS operating systems,and their application programming interfaces.":
 - Objective-C
 - objective c
 - objectivec
-'[Programming Languages]Influential programming language, published in 1970 by Niklaus Wirth as a small and efficient language intended to encourage good programming practices using structured programming and data structuring.':
+"[Programming Languages]Influential programming language, published in 1970 by Niklaus Wirth as a small and efficient language intended to encourage good programming practices using structured programming and data structuring.":
 - Pascal
-'[Programming Languages]Interpreted programming language for text processing and data extraction and was very popular in the late 1970s and 1980s. It is a standard feature of most Unix-like operating systems.':
+"[Programming Languages]Interpreted programming language for text processing and data extraction and was very popular in the late 1970s and 1980s. It is a standard feature of most Unix-like operating systems.":
 - AWK
-'[Programming Languages]Language originally developed by Borland as a rapid application development tool for Windows as a successor to Borland Pascal.':
+"[Programming Languages]Language originally developed by Borland as a rapid application development tool for Windows as a successor to Borland Pascal.":
 - Delphi
-'[Programming Languages]Language that appeared in 1985, originally to create database and business programs operated primarily under DOS.':
+"[Programming Languages]Language that appeared in 1985, originally to create database and business programs operated primarily under DOS.":
 - Clipper
-'[Programming Languages]Multi-paradigm numerical computing environment and fourth-generation programming language since the late 70s, primarily intended for numerical computing.':
+"[Programming Languages]Multi-paradigm numerical computing environment and fourth-generation programming language since the late 70s, primarily intended for numerical computing.":
 - MATLAB
-'[Programming Languages]Multi-paradigm, high level programming language launched by Microsoft in 2002 to make programs for Windows in a an "drag-and-drop" interface.':
+"[Programming Languages]Multi-paradigm, high level programming language launched by Microsoft in 2002 to make programs for Windows in a an 'drag-and-drop' interface.":
 - Visual Basic .NET
-'[Programming Languages]Not a programming language, but a popular group of interrelated client-side web development techniques to exchange data without full webpage reloads.':
+"[Programming Languages]Not a programming language, but a popular group of interrelated client-side web development techniques to exchange data without full webpage reloads.":
 - Ajax
-'[Programming Languages]One of the first programming languages, designed by Kemeny and Kurtz in 1964. Its design philosophy emphasizes ease of use and became widespread on microcomputers in the mid-1970s and 1980s.':
+"[Programming Languages]One of the first programming languages, designed by Kemeny and Kurtz in 1964. Its design philosophy emphasizes ease of use and became widespread on microcomputers in the mid-1970s and 1980s.":
 - BASIC
-'[Programming Languages]One of the most popular programming languages, created by James Gosling at Sun Microsystems in 1995. It is platform independent and based upon C and C++.':
+"[Programming Languages]One of the most popular programming languages, created by James Gosling at Sun Microsystems in 1995. It is platform independent and based upon C and C++.":
 - Java
-'[Programming Languages]One of the most widely used and influentual programming languages of all time. It is an imperative and compiled language, initially developed by Dennis Ritchie and Ken Thompson between 1969 and 1973 at AT&T Bell Labs.':
+"[Programming Languages]One of the most widely used and influentual programming languages of all time. It is an imperative and compiled language, initially developed by Dennis Ritchie and Ken Thompson between 1969 and 1973 at AT&T Bell Labs.":
 - C
-'[Programming Languages]One of the oldest high-level programming languages in widespread use today. It was designed by John McCarthy in 1958 and quickly became a favored programming language for artificial intelligence':
+"[Programming Languages]One of the oldest high-level programming languages in widespread use today. It was designed by John McCarthy in 1958 and quickly became a favored programming language for artificial intelligence":
 - LISP
-'[Programming Languages]Popular high-level, general-purpose, interpreted, dynamic programming language created by Larry Wall in 1987. It is often used in CGI and text processing (e.g. parsing).':
+"[Programming Languages]Popular high-level, general-purpose, interpreted, dynamic programming language created by Larry Wall in 1987. It is often used in CGI and text processing (e.g. parsing).":
 - Perl
-'[Programming Languages]Programming language and software environment for statistical computing and graphics. It was introduced in 1993 and has become popular among statisticians and data miners.':
+"[Programming Languages]Programming language and software environment for statistical computing and graphics. It was introduced in 1993 and has become popular among statisticians and data miners.":
 - R
-'[Programming Languages]Programming language and web application development platform invented in 1995 and purchased by Adobe in 2006. It was originally designed to connect simple HTML pages to a database.':
+"[Programming Languages]Programming language and web application development platform invented in 1995 and purchased by Adobe in 2006. It was originally designed to connect simple HTML pages to a database.":
 - ColdFusion
-'[Programming Languages]Purely functional programming language since 1990. It was named after US mathematician and logican H. Curry and uses the Greek letter lambda as its logo.':
+"[Programming Languages]Purely functional programming language since 1990. It was named after US mathematician and logican H. Curry and uses the Greek letter lambda as its logo.":
 - Haskell
-'[Programming Languages]Scripting and object-oriented programming language developed by John H. Thompson for use in Adobe Director':
+"[Programming Languages]Scripting and object-oriented programming language developed by John H. Thompson for use in Adobe Director":
 - Lingo
-'[Programming Languages]Server-side script engine that uses the VBScript or JScript languages for dynamically generated web pages. It was created by Microsoft in the mid 1990s and succeeded by a .NET version in 2002.':
+"[Programming Languages]Server-side script engine that uses the VBScript or JScript languages for dynamically generated web pages. It was created by Microsoft in the mid 1990s and succeeded by a .NET version in 2002.":
 - ASP
-'[Programming Languages]The most widespread logic programming language, desgined by Alain Colmerauer in 1972. Unlike many programming languages, it"s declarative.':
+"[Programming Languages]The most widespread logic programming language, desgined by Alain Colmerauer in 1972. Unlike many programming languages, it's declarative.":
 - Prolog
-'[Programming Languages]Very popular general-purpose, imperative programming language in high-performance computing (e.g. scientific use and supercomputers). It was initiated by John Backus and IBM in 1957.':
+"[Programming Languages]Very popular general-purpose, imperative programming language in high-performance computing (e.g. scientific use and supercomputers). It was initiated by John Backus and IBM in 1957.":
 - Fortran
-'[Programming Languages]Widely used general-purpose, high-level programming language created by Guido van Rossum in 1991. Its design philosophy emphasizes code readability and its syntax allows to express concepts in relatively few lines of code.':
+"[Programming Languages]Widely used general-purpose, high-level programming language created by Guido van Rossum in 1991. Its design philosophy emphasizes code readability and its syntax allows to express concepts in relatively few lines of code.":
 - Python
-'[Programming Languages]Widely used programming language designed for managing data held in a relational database management system. It was initially developed Chamberlin and Boyce at IBM in the early 1970s.':
+"[Programming Languages]Widely used programming language designed for managing data held in a relational database management system. It was initially developed Chamberlin and Boyce at IBM in the early 1970s.":
 - SQL

--- a/redbot/trivia/lists/disney.yaml
+++ b/redbot/trivia/lists/disney.yaml
@@ -1,14 +1,14 @@
-'"El Libro de la Selva" in English is translated into what Disney film?':
+"\"El Libro de la Selva\" in English is translated into what Disney film?":
 - The Jungle Book
-'"Higitus Figitus" is the spellbinding song from what film?':
+"\"Higitus Figitus\" is the spellbinding song from what film?":
 - The Sword in the Stone
-'"The flower that blooms in adversity is the most rare and beautiful of all", is a reference to which Disney animated character?':
+"\"The flower that blooms in adversity is the most rare and beautiful of all\", is a reference to which Disney animated character?":
 - Mulan
-'"Two Worlds" is a song from which Disney film?':
+"\"Two Worlds\" is a song from which Disney film?":
 - Tarzan
 10,000 ingots would be your reward for capturing which Disney animated character?:
 - Robin Hood
-'101 Dalmatians: What type of animals feed the Dalmatian puppies when they escape from Jasper and Horace?':
+"101 Dalmatians: What type of animals feed the Dalmatian puppies when they escape from Jasper and Horace?":
 - Cows
 25 songs were written for Snow White and the Seven Dwarfs but how many were actually used?:
 - 8
@@ -17,7 +17,7 @@ A Story of Dogs was a behind-the-scenes television show about the making of what
 - Lady and the Tramp
 According to Captain Barbossa in the live-action film The Pirates of the Caribbean, what did they name the monkey?:
 - Jack
-According to Disney"s version of "Robin Hood", "every town has its ups and downs. Sometimes ups outnumber downs, but not in..." where?:
+According to Disney's version of 'Robin Hood', "every town has its ups and downs. Sometimes ups outnumber downs, but not in..." where?:
 - Nottingham
 According to Frollo in The Hunchback of Notre Dame, what does "A" for?:
 - Abomination
@@ -39,9 +39,9 @@ According to Winnie the pooh what do Heffalumps and Woozles steal?:
 According to a song in Alice in Wonderland, how many un-birthdays does one have each year?:
 - 364
 - three hundred and sixty four
-According to a tax return filled out in an early cartoon, what is Donald Duck"s self proclaimed occupation?:
+According to a tax return filled out in an early cartoon, what is Donald Duck's self proclaimed occupation?:
 - Actor
-According to the audio commentary on the DVD of Hunchback of Notre Dame, what is the name of Frollo"s horse?:
+According to the audio commentary on the DVD of Hunchback of Notre Dame, what is the name of Frollo's horse?:
 - Snowball
 According to the bell tower in Cinderella, what time does the royal ball start?:
 - 8 PM
@@ -60,7 +60,7 @@ After arriving at the training camp Mulan gets into a fight and spills what kind
 After being on earth, where did Hercules first meet his father Zeus?:
 - In the Temple of Zeus
 - Temple of Zeus
-After refusing to join Captain Hook"s band of pirates, who is forced to walk the plank first?:
+After refusing to join Captain Hook's band of pirates, who is forced to walk the plank first?:
 - Wendy
 After saving his daughter what title does the Indian Chief bestow upon Peter Pan?:
 - Little Flying Eagle
@@ -68,14 +68,14 @@ As part of her test, what must Mulan serve to the match maker?:
 - Tea
 At the end of Mary Poppins, who is the only one to see Mary fly away?:
 - Bert
-At the end of the song I just Can"t Wait to be King in The Lion King, what kind of animal sits on Zazu?:
+At the end of the song I just Can't Wait to be King in The Lion King, what kind of animal sits on Zazu?:
 - Rhinoceros
 At the start of Frozen, how old is Elsa?:
 - 8
 - eight
 Before Lilo named him Stitch, what was his designation?:
 - Experiment 626
-Before Mickey Mouse, what Disney character was suggested to be the Sorcerer"s Apprentice in Fantasia?:
+Before Mickey Mouse, what Disney character was suggested to be the Sorcerer's Apprentice in Fantasia?:
 - Dopey
 By what name did the kids refer to Hercules when he was young to make fun of him?:
 - Jerkules
@@ -89,27 +89,27 @@ By what name is Mickey Mouse known as in Italy?:
 By what nickname does Sally call Lightning McQueen in CARS?:
 - Stickers
 Cars was the second Disney Pixar film to have an entirely non human cast. What movie was the first?:
-- A Bug"s Life
+- A Bug's Life
 - a bugs life
-- bug"s life
+- bug's life
 - bugs life
 Dumbo was the first Full Length Feature Animation to be set in its present day, what was the next feature to do that?:
 - Bambi
-During the ballroom scene of Beauty & the Beast, what color is Belle"s Gown?:
+During the ballroom scene of Beauty & the Beast, what color is Belle's Gown?:
 - Gold
 - Yellow
 During the battle with Aladdin, what type of animal does Jafar transform himself into?:
 - A Cobra
 - cobra
-During the wizard"s duel in The Sword in the Stone, who turns into a mouse?:
+During the wizard's duel in The Sword in the Stone, who turns into a mouse?:
 - Merlin
 During what song in Cinderella do the mice and birds make a dress?:
 - The Work Song
-Fill in the blank from this Disney Song?..."I can show you the world, _______, shimmering, splendid. Tell me princess now when did you last let your heart decide?":
+Fill in the blank from this Disney Song?...'I can show you the world, _______, shimmering, splendid. Tell me princess now when did you last let your heart decide?':
 - shining
 For what animated feature did Disney animators take a four-thousand-mile, two-and-a-half-week Australian expedition to research, take photos, and make sketches?:
 - The Rescuers Down Under
-How many Golden Globe awards did "The Lion King" win?:
+How many Golden Globe awards did 'The Lion King' win?:
 - 3
 - three
 How many Muses are there in the animated feature Hercules?:
@@ -130,10 +130,10 @@ How many kittens does Duchess have in The Aristocats?:
 How many lost boys are there in Peter Pan?:
 - 6
 - six
-How many mice are turned into horses to drive Cinderella"s carriage?:
+How many mice are turned into horses to drive Cinderella's carriage?:
 - 4
 - four
-How many mice were turned into horses in order to pull Cinderella"s carriage?:
+How many mice were turned into horses in order to pull Cinderella's carriage?:
 - 4
 - four
 How many puppies do Lady and the Tramp have?:
@@ -161,36 +161,36 @@ How old is Mogli when he taken back to the man village in The Jungle Book?:
 - ten
 How old was Lady when she received her dog license in Lady and the Tramp?:
 - 6 months
-In "A Bug"s Life", what gift do the circus bugs present to Princess Atta before they leave?:
-- rock
-In "Alice in Wonderland" what substance won"t the Mad Hatter put in the White Rabbit"s watch, saying, "Don"t let"s be silly!"?:
-- Mustard
-In "Bug"s Life" what is the name of the group of girls that Dot belongs to?:
+In "Bug's Life" what is the name of the group of girls that Dot belongs to?:
 - The Blueberries
 - blueberries
-In "Cinderella" when the Fairy Godmother"s magic spell ends, what is the only thing that doesn"t transform back to it"s original form?:
-- Glass Slippers
-In "Fantasia", who does Mickey Mouse as the Sorcerer"s Apprentice, teach to do his work?:
-- Brooms
-In "Robin Hood", what animals play Robin Hood and Maid Marian?:
-- Foxes
 In "Robin Hood", what does Robin disguise himself as at the archery tournament?:
 - Stork
-In "Snow White and the Seven Dwarfs", which one of the dwarfs has white eyebrows?:
-- Happy
 In "The Tigger Movie," what does Tigger go looking for?:
 - His family
 - family
-In 101 Dalmatians what color is Cruella DeVille"s smoke from her cigarette?:
+In 'A Bug's Life', what gift do the circus bugs present to Princess Atta before they leave?:
+- rock
+In 'Alice in Wonderland' what substance won't the Mad Hatter put in the White Rabbit's watch, saying, 'Don't let's be silly!'?:
+- Mustard
+In 'Cinderella' when the Fairy Godmother's magic spell ends, what is the only thing that doesn't transform back to it's original form?:
+- Glass Slippers
+In 'Fantasia', who does Mickey Mouse as the Sorcerer's Apprentice, teach to do his work?:
+- Brooms
+In 'Robin Hood', what animals play Robin Hood and Maid Marian?:
+- Foxes
+In 'Snow White and the Seven Dwarfs', which one of the dwarfs has white eyebrows?:
+- Happy
+In 101 Dalmatians what color is Cruella DeVille's smoke from her cigarette?:
 - Green
 In 101 Dalmatians which one of the puppies does Roger save after rubbing him with a towel?:
 - Lucky
-In 101 Dalmatians which one of the puppies was thought to be dead at birth but really wasn"t?:
+In 101 Dalmatians which one of the puppies was thought to be dead at birth but really wasn't?:
 - Lucky
 In 101 Dalmatians, How many puppies did Pongo and Perdita have before adopting the rest?:
 - 15
 - fifteen
-In 101 Dalmatians, what color are Cruella De Vil"s gloves?:
+In 101 Dalmatians, what color are Cruella De Vil's gloves?:
 - Red
 In 101 Dalmatians, what do the dogs disguise themselves as in order to escape?:
 - Labradors
@@ -202,12 +202,12 @@ In 102 Dalmatians when Chloe and Kevin leave for their date, what movie are the 
 - Lady and the Tramp
 In 1998 which Disney Full Length Animated Feature was depicted on a US Postage Stamp?:
 - The Jungle Book
-In A Bug"s Life when the bird takes Hopper to her nest to feed him to her babies, how many baby chicks are in the nest?:
+In A Bug's Life when the bird takes Hopper to her nest to feed him to her babies, how many baby chicks are in the nest?:
 - 3
 - three
-In A Bug"s Life, what is the name of Hopper"s brother who joins the flea circus at the end of the film?:
+In A Bug's Life, what is the name of Hopper's brother who joins the flea circus at the end of the film?:
 - Molt
-In A Bug"s Life, who suggests that they leave the ants alone this season since they have plenty of food?:
+In A Bug's Life, who suggests that they leave the ants alone this season since they have plenty of food?:
 - Molt
 In A Goofy Movie, what profession does Goofy have?:
 - Photographer
@@ -217,7 +217,7 @@ In Aladdin, what does Jasmine steal from the Marketplace?:
 - Apple
 In Aladdin, what does the Genie say he would wish for if anyone gave him the chance?:
 - Freedom
-In Aladdin, what is the name of Jasmine"s pet tiger?:
+In Aladdin, what is the name of Jasmine's pet tiger?:
 - Rajah
 In Aladdin,who gets turned into a elephant?:
 - Abu
@@ -225,14 +225,14 @@ In Alice in Wonderland, what did the Queen of Hearts use as a croquet mallet?:
 - Flamingo
 In Alice in Wonderland, what is the White Rabbit carrying aside from his pocket watch when he meets Alice?:
 - umbrella
-In Alice in Wonderland, what is the name of Alice"s kitten?:
+In Alice in Wonderland, what is the name of Alice's kitten?:
 - Dinah
-In Alice in Wonderland, what is the name of the "lizard with a ladder"?:
+In Alice in Wonderland, what is the name of the 'lizard with a ladder'?:
 - Bill
 In Alice in Wonderland, what is the name of the forest that Alice gets lost in?:
 - The Tulgey Wood
 In Alice in Wonderland, what time is on the rabbits watch?:
-- '12:25'
+- "12:25"
 - twelve twentyfive
 - twelve twenty-five
 In Alice in Wonderland, what type of vegetable will give Alice the power to shrink or grow?:
@@ -269,7 +269,7 @@ In Beauty and the Beast, what does Gaston use in all of his decorating?:
 - Antlers
 In Beauty and the Beast, what does LeFou disguise himself as when spying on Belle to come home?:
 - snowman
-In Beauty and the Beast, while Belle"s father is traveling through the forest with his invention he comes across a directional sign pointing to 2 cities. Name one of the two cities?:
+In Beauty and the Beast, while Belle's father is traveling through the forest with his invention he comes across a directional sign pointing to 2 cities. Name one of the two cities?:
 - Anaheim or Valencia
 - Anaheim
 - Valencia
@@ -283,36 +283,36 @@ In Cars what color rookie stripe did Lightning McQueen have on his rear bumper?:
 - Yellow
 In Cars what color was Mater before he rusted?:
 - Blue
-In Cars, what is Lightning McQueen"s racing number?:
+In Cars, what is Lightning McQueen's racing number?:
 - 95
-In Cars, what is the name of Sally"s motel?:
+In Cars, what is the name of Sally's motel?:
 - The Cozy Cone
 In Cinderella what musical instrument does Lady Tremaine play?:
 - Piano
 In Cinderella, who hides under Anastasias tea cup?:
 - Gus
-In Disney"s "Alice in Wonderland," where does Alice encounter the umbrella birds?:
+In Disney's "Alice in Wonderland," where does Alice encounter the umbrella birds?:
 - Tugley Wood
-In Disney"s "Lady and the Tramp", what is Lady chasing when the dog catcher captures her and puts her in the dog pound?:
+In Disney's "Lady and the Tramp", what is Lady chasing when the dog catcher captures her and puts her in the dog pound?:
 - Chickens
-In Disney"s Aladdin what kind of pet does the Princess Jasmine have?:
+In Disney's Aladdin what kind of pet does the Princess Jasmine have?:
 - Tiger
-In Disney"s Bambi, what is the skunks name?:
+In Disney's Bambi, what is the skunks name?:
 - Flower
-In Disney"s Flubber what is the name of the professor"s robot sidekick?:
+In Disney's Flubber what is the name of the professor's robot sidekick?:
 - Weebo
-In Disney"s Flubber, what automobile manufacturer does Professor Brainard offer his new invention to?:
+In Disney's Flubber, what automobile manufacturer does Professor Brainard offer his new invention to?:
 - Ford
-In Disney"s Hercules, how many eyeballs do the the three fates share?:
+In Disney's Hercules, how many eyeballs do the the three fates share?:
 - One
 - 1
-In Disney"s Movie The Haunted Mansion, what US city does the movie take place in?:
+In Disney's Movie The Haunted Mansion, what US city does the movie take place in?:
 - New Orleans
-In Disney"s The Fox and the Hound what was the hound"s name?:
+In Disney's The Fox and the Hound what was the hound's name?:
 - Copper
-In Disney"s the Jungle Book what kind of animal is Baloo?:
+In Disney's the Jungle Book what kind of animal is Baloo?:
 - Bear
-"In Disney‚\x80\x99s ‚\x80\x9CPinocchio,‚\x80\x9D who sings the famous ‚\x80\x9CWhen You Wish Upon a Star‚\x80\x9D?":
+In Disney‚Äôs ‚ÄúPinocchio,‚Äù who sings the famous ‚ÄúWhen You Wish Upon a Star‚Äù?:
 - Jiminy Cricket
 In Dumbo, where is Mrs. Jumbo when the stork delivers her baby?:
 - In the circus Train
@@ -322,7 +322,7 @@ In Fantasia, what tool does Mickey Mouse use to attempt to stop the broom?:
 - Axe
 In Finding Dory when Dory first visits the quarantine facility, what characters photo from Finding Nemo can be seen in the background?:
 - Darla
-In Finding Nemo on the dental surgery wall near the window, which animal was shown on a poster, advising patients to "Floss"?:
+In Finding Nemo on the dental surgery wall near the window, which animal was shown on a poster, advising patients to 'Floss'?:
 - Alligator
 In Finding Nemo what nickname does Dory give to her pet jellyfish?:
 - Squishy
@@ -330,11 +330,11 @@ In Finding Nemo what other Pixar character can be seen on the floor of the Denti
 - Buzz Lightyear
 In Finding Nemo what was the name of the advanced filter system the dentist bought for the fish tank?:
 - Aquascum 2003
-In Finding Nemo when the dentist went to the bathroom with a "Readers Digest", how long did Peach say that the fish had to execute their escape plan, before he returned?:
+In Finding Nemo when the dentist went to the bathroom with a 'Readers Digest', how long did Peach say that the fish had to execute their escape plan, before he returned?:
 - 4.2 Minutes
 In Finding Nemo, although it is never mentioned in the film, it is revealed by the directors in the commentary that Crush and his crew turtles are headed for where?:
 - Hawaii
-In Finding Nemo, in the tank gang in the dentist"s office, the germophobic purple and yellow fish is the only one never mentioned by name. What name was he later given after the movie?:
+In Finding Nemo, in the tank gang in the dentist's office, the germophobic purple and yellow fish is the only one never mentioned by name. What name was he later given after the movie?:
 - Gurgle
 In Finding Nemo, what does Dory name her pet Jelly Fish?:
 - Squishy
@@ -342,15 +342,15 @@ In Finding Nemo, what fish in the dentist office tank went crazy with the bubble
 - Bubbles
 In Finding Nemo, what is the full name of the Dentist?:
 - Phillip Sherman
-In Finding Nemo, what is the name of Crush"s Son?:
+In Finding Nemo, what is the name of Crush's Son?:
 - Squirt
 In Finding Nemo, what is the name of the Pelican?:
 - Nigel
-In Finding Nemo, what is the name of the fish that yells "Oh, my gosh! Nemo"s swimming out to sea!"?:
+In Finding Nemo, what is the name of the fish that yells "Oh, my gosh! Nemo's swimming out to sea!"?:
 - Kathy
-In Finding Nemo, what is the name of the school on the diploma on the dentist"s wall?:
+In Finding Nemo, what is the name of the school on the diploma on the dentist's wall?:
 - Pixar University School of Dentistry
-In Finding Nemo, what is the name that appears on the diver"s mask to help Marlin and Dory find Nemo?:
+In Finding Nemo, what is the name that appears on the diver's mask to help Marlin and Dory find Nemo?:
 - P. Sherman
 In Finding Nemo, what kind of fish is Bubbles?:
 - Yellow Tang
@@ -362,9 +362,9 @@ In Finding Nemo, what medical problem does the young seahorse claim to have?:
 - H2O Intolerance
 In Finding Nemo, what species is the school teacher?:
 - Stingray
-In Finding Nemo, what was the name of Nemo"s mom?:
+In Finding Nemo, what was the name of Nemo's mom?:
 - Coral
-In Finding Nemo, which one of Nemo"s fins is the smaller one?:
+In Finding Nemo, which one of Nemo's fins is the smaller one?:
 - Right
 In Frozen what is Anna and Elsas favorite food?:
 - Chocolate
@@ -374,12 +374,12 @@ In Frozen what is the name of the place where Elsa builds her castle?:
 - The North Mountain
 In Frozen who is the adoptive mother of Kristoff and Sven?:
 - Bulda
-In Frozen, at Elsa"s coronation, what other Disney Princess makes a cameo appearance?:
+In Frozen, at Elsa's coronation, what other Disney Princess makes a cameo appearance?:
 - Rapunzel
 In Frozen, how many brothers does Prince Hans have?:
 - 12
 - twelve
-In Frozen, what is Sven"s favorite food?:
+In Frozen, what is Sven's favorite food?:
 - Carrots
 In Frozen, what kind of hugs does Olaf like?:
 - Warm ones
@@ -404,23 +404,23 @@ In Hercules, by what nickname does Phil refer to the city of Thebes as?:
 - The Big Olive
 In Hercules, what character makes a cameo appearance from The Lion King?:
 - Scar
-In Hercules, what gift does Hades bring to baby Hercules" party?:
+In Hercules, what gift does Hades bring to baby Hercules' party?:
 - Pacifier
-In Hercules, what is the name of Hercules" trainer?:
+In Hercules, what is the name of Hercules' trainer?:
 - Philoctetes
 - Phil
 In Hercules, what name is given to the group of villains imprisioned by Zeus?:
 - The Titans
 - titans
-In Hercules, who blows Hades" hair out?:
+In Hercules, who blows Hades' hair out?:
 - Pegasus
-'In Hercules, who said this line: "I"ve not seen so much love in a room since Narcissus discovered himself!"?':
+"In Hercules, who said this line: \"I've not seen so much love in a room since Narcissus discovered himself!\"?":
 - Hermes
-In Hunchback of Notre Dame, what is Judge Frollo"s first name?:
+In Hunchback of Notre Dame, what is Judge Frollo's first name?:
 - Claude
 In Hunchback of Notre Dame, what is the date of Topsy-Turvy Day?:
 - January 6
-In Jungle Book, what type of birds sing "That"s What Friends Are For"?:
+In Jungle Book, what type of birds sing "That's What Friends Are For"?:
 - Vultures
 In Lady & the Tramp, by what name did Tony call Tramp?:
 - Butch
@@ -441,18 +441,18 @@ In Lilo and Stitch, what does Ohana mean?:
 - Family
 In Lilo and Stitch, what is Earth named?:
 - Section 17 Area 51
-In Lilo and Stitch, what is Stitch"s number?:
+In Lilo and Stitch, what is Stitch's number?:
 - 626
 In Lilo and Stitch, what is considered to be Stitchs greatest weakness?:
 - Water
-'In Lion King II: Simba"s Pride, what is the name of Scar"s successor?':
+"In Lion King II: Simba's Pride, what is the name of Scar's successor?":
 - Kovu
 In Lion King, what name does Simba refer to Zazu as?:
 - Banana Beak
-In Mary Poppins, what animal was on the end of Mary Poppins" umbrella that spoke?:
+In Mary Poppins, what animal was on the end of Mary Poppins' umbrella that spoke?:
 - A Parrot
 - parrot
-In Mary Poppins, what is the name of Jane and Michael"s mother?:
+In Mary Poppins, what is the name of Jane and Michael's mother?:
 - Winifred
 In Mary Poppins, who is the last person to talk to Mary before she leaves?:
 - Bert
@@ -462,7 +462,7 @@ In Meet the Robinsons, what is Mr. Robinsons motto?:
 - Keep Moving Forward
 In Mickey and the Beanstalk what does mickey trade for the magic beans?:
 - Cow
-"In Mickey‚\x80\x99s Christmas Carol who plays the part of the Ghost of Christmas Past?":
+In Mickey‚Äôs Christmas Carol who plays the part of the Ghost of Christmas Past?:
 - Jiminy Crickett
 In Monsters Inc what is the name of the restaurant that Mike takes Celia for their date?:
 - Harryhausen
@@ -473,13 +473,13 @@ In Monsters Inc, how many snakes make up Celias hair?:
 - five
 In Monsters Inc, what does the abominable snowman offer to Mike and Sully?:
 - Snowcones
-In Monsters Inc, what is Sully"s first name?:
+In Monsters Inc, what is Sully's first name?:
 - James
 In Monsters Inc, what kind of milk does the Abominal Snowman like?:
 - Yaks Milk
 - yaks
-- yak"s
-- yak"s milk
+- yak's
+- yak's milk
 In Monsters Inc, what scent of deodorant does Mike use?:
 - Wet Dog
 In Monsters Inc, when Boo is disguised what does she have on her head for hair?:
@@ -491,15 +491,15 @@ In Monsters Inc, who is Boos Monster?:
 In Monsters Inc. what acts as the portal between the monsters world, and the humans world?:
 - Closet Doors
 - Doors
-In Monsters Inc. what is Sulley"s full name (including his middle initial)?:
+In Monsters Inc. what is Sulley's full name (including his middle initial)?:
 - James P. Sullivan
 - james p sullivan
 In Monsters Inc., how many eyes does Mr. Waternoose have?:
 - 5
 - five
-In Monsters Inc., what is Randall"s last name?:
+In Monsters Inc., what is Randall's last name?:
 - Boggs
-In Monsters Inc., what is the name of James P Sullivan"s home town?:
+In Monsters Inc., what is the name of James P Sullivan's home town?:
 - Monstropolis
 In Monsters University during her cameo at the end, what famous line does Roz say?:
 - Always watching
@@ -508,7 +508,7 @@ In Mulan before Mushu comes to life, what type of object is he?:
 In Mulan when retrieving the arrow from the high post, what did the two heavy medallions represent?:
 - Discipline and strength
 - strength and discipline
-In Mulan when trying to trick the Huns by dressing as women, what fruit fell from Ling"s dress?:
+In Mulan when trying to trick the Huns by dressing as women, what fruit fell from Ling's dress?:
 - Apple
 In Mulan, by what nickname does Mushu call the Great Stone Dragon after the statue breaks apart?:
 - Stoney
@@ -530,28 +530,28 @@ In Peter Pan, Captain Hook had a hook on which one of his hands?:
 - Left
 In Peter Pan, what city does the story begin in?:
 - London
-In Peter Pan, what does the Tattoo on Mr. Smee"s chest read?:
+In Peter Pan, what does the Tattoo on Mr. Smee's chest read?:
 - Mother
 In Peter Pan, what does the boy Michael always carry with him?:
 - Teddy Bear
 - bear
 - teddybear
-In Peter Pan, what is Wendy"s full name?:
+In Peter Pan, what is Wendy's full name?:
 - Wendy Moira Angela Darling
-In Peter Pan, what part of London are the Darling"s from?:
+In Peter Pan, what part of London are the Darling's from?:
 - Bloomsbury
-In Pinocchio, what are most of the items found on Gepetto"s shelves in his work shop?:
+In Pinocchio, what are most of the items found on Gepetto's shelves in his work shop?:
 - Clocks
 In Pinocchio, what do the little boys become when they visit Pleasure Island?:
 - Donkeys
 - donkey
-In Pinocchio, what does Jiminy Cricket use for his bed in Gepetto"s Workshop?:
+In Pinocchio, what does Jiminy Cricket use for his bed in Gepetto's Workshop?:
 - matchbox
 In Pinocchio, who does Geppetto call over to see the "wishing star"?:
 - Figaro
 In Pirates of the Caribbean at Worlds end, who owns the parrot?:
 - Cotton
-In Pluto"s cartoon "Judgement Day", Pluto is put on trial, what type of animals make up the jury?:
+In Pluto's cartoon "Judgement Day", Pluto is put on trial, what type of animals make up the jury?:
 - Cats
 In Pocahontas, what does John Smith feed Meeko?:
 - Biscuit
@@ -563,7 +563,7 @@ In Pocahontas, what type of dog is Percy?:
 - Pug
 In Pocahontas, what was Ratcliffe looking for that he was sure the Indians were hiding?:
 - Gold
-In Pooh, who is considered to be Roo"s best Friend?:
+In Pooh, who is considered to be Roo's best Friend?:
 - Tigger
 In Princess and the Frog, what fictional country is Prince Naveen from?:
 - Maldonia
@@ -577,7 +577,7 @@ In Robin Hood, who pretends to be the Duke of Chutney?:
 - Little John
 In Robin Hood, who receives "a whole farthing" for his birthday?:
 - Skippy
-In Sleeping Beauty Princess Aurora"s mother does not have a name in the movie, but in promotional materials she was given one. What was is?:
+In Sleeping Beauty Princess Aurora's mother does not have a name in the movie, but in promotional materials she was given one. What was is?:
 - Queen Leah
 In Sleeping Beauty how old is Aurora when the spell is broken?:
 - 16
@@ -589,7 +589,7 @@ In Sleeping Beauty what gift does Flora give to Aurora?:
 In Sleeping Beauty who was Prince Phillip named after?:
 - The Duke of Edinburgh
 - Duke of Edinburgh
-In Sleeping Beauty, how old would Princess Aurora be when she would "prick her finger on the spindle of a spinning wheel" according to Maleficient"s spell?:
+In Sleeping Beauty, how old would Princess Aurora be when she would "prick her finger on the spindle of a spinning wheel" according to Maleficient's spell?:
 - 16
 - sixteen
 In Sleeping Beauty, what is it that Prince Phillip tells his horse Samson he will not be receiving, after being dumped into the stream?:
@@ -617,7 +617,7 @@ In Tangled, how old is Rapunzel?:
 - eighteen
 In Tangled, what color does Rapunzels hair turn in to when it is cut?:
 - Brown
-In Tangled, what is the name of the Captain"s horse?:
+In Tangled, what is the name of the Captain's horse?:
 - Maximus
 In Tangled, what kind is the name of the chameleon?:
 - Pascal
@@ -625,17 +625,17 @@ In Tarzan where are Jane and her father from?:
 - London
 In Tarzan, during the campground scene, characters from which other Disney Full Length Animated Feature can be seen on the table?:
 - Beauty and the Beast
-In Tarzan, what disney character falls out of the professor"s pocket when he is turned upside down by the gorillas?:
+In Tarzan, what disney character falls out of the professor's pocket when he is turned upside down by the gorillas?:
 - Little Brother (dog from Mulan)
 - Little Brother
 In The Aristocats, how many kittens does Duchess have?:
 - 3
 - three
-In The Aristocats, what does Thomas O" Malley say Dutchess" eyes look like?:
+In The Aristocats, what does Thomas O' Malley say Dutchess' eyes look like?:
 - Sapphires
-In The Emperor"s New Groove, what is Kronks favorite game?:
+In The Emperor's New Groove, what is Kronks favorite game?:
 - Exotic Bird Bingo
-In The Emperor"s New Groove, what language does Kronk speak?:
+In The Emperor's New Groove, what language does Kronk speak?:
 - Squirrel
 In The Incredibles, what accessory does Edna refuse to put on Mr. Incredibles costume?:
 - Cape
@@ -644,15 +644,15 @@ In The Incredibles, what is the name of the monster that Mirage initially hires 
 In The Incredibles, where is Mr. Incredible on his way to at the beginning of the film when he is continually distracted by crimes in progress?:
 - His Wedding
 - wedding
-In The Jungle Book, the vultures were created to parody which popular 60"s rock "n" roll band?:
+In The Jungle Book, the vultures were created to parody which popular 60's rock 'n' roll band?:
 - The Beatles
 In The Lion King, as a young cub, what kind of animal does Simba practice his roar on?:
 - Chameleon
 In The Lion King, what color bug is the first one that Simba eats?:
 - Red
-In The Lion King, what does Nala"s name mean in Swahili?:
+In The Lion King, what does Nala's name mean in Swahili?:
 - gift
-In The Lion King, who claims to be a Monkey"s Uncle?:
+In The Lion King, who claims to be a Monkey's Uncle?:
 - Scar
 In The Little Mermaid Who trades places with Ariel in order to save her?:
 - King Triton
@@ -674,14 +674,14 @@ In The Little Mermaid, where does Scuttle listen to to see if Eric has a heartbe
 - foot
 In The Many Adventures of Winnie the Pooh, whose house was destroyed by on the blustery day?:
 - Owl
-In The Nightmare before Christmas, what is the ingredient Sally puts in the Evil Scientist"s soup that makes him go to sleep?:
+In The Nightmare before Christmas, what is the ingredient Sally puts in the Evil Scientist's soup that makes him go to sleep?:
 - Deadly Nightshade
 In The Princess and the Frog what is Charlottes nickname for Tiana?:
 - Tia
 In The Princess and the Frog, who was the alligator Louis named after?:
 - Louis Armstrong
 In The Rescuers, what was Penny sent into the pirates cave to retrieve?:
-- Devil"s Eye
+- Devil's Eye
 In The Santa Clause Movie, who delivered the lists of good and bad children?:
 - Fed Ex
 - fedex
@@ -690,11 +690,11 @@ In The Swiss Family Robinson, what does Mrs. Robinson rename the island?:
 In The Sword in the Stone, what does Merlin call The Greatest Force on Earth?:
 - Love
 In Toy Story 2 what does Woody find out what the name of his television show is:
-- Woody"s Roundup
+- Woody's Roundup
 In Toy Story 2 what was the name of the girl that use to own Jessie?:
 - Emily
 In Toy Story 2 when Mr. Potato Head is watch the Barbie Dolls Party, what does he keep chanting to himself?:
-- I"m a Married Spud
+- I'm a Married Spud
 In Toy Story 2 who steals Woody?:
 - Al McWiggin
 - al
@@ -703,7 +703,7 @@ In Toy Story 2, what is the name of the camp that Andy attends?:
 In Toy Story 2, what kind of ball does Emperor Zurg and his son play catch with?:
 - Nerf ball
 - nerf
-In Toy Story 2, who is revealed as being Buzz Lightyear"s father?:
+In Toy Story 2, who is revealed as being Buzz Lightyear's father?:
 - Emperor Zurg
 In Toy Story 3 how many different outfits does Ken wear?:
 - 21
@@ -718,13 +718,13 @@ In Toy Story what was in the first present that Andy opened?:
 In Toy Story, what does Mr. Potato head wish Andy gets for his birthday?:
 - Mrs Potato head
 - mrs. potato head
-In Toy Story, what food does Sid"s mom make him which makes him stop his torture of the toys?:
+In Toy Story, what food does Sid's mom make him which makes him stop his torture of the toys?:
 - Pop Tarts
 In Toy Story, what game does the slinky play?:
 - Checkers
 In Toy Story, what gift does Andy receive at Christmas that fills Buzz and Woody with dread?:
 - Puppy
-In Toy Story, what is the name of Sid"s Dog?:
+In Toy Story, what is the name of Sid's Dog?:
 - Skud
 In Toy Story, what is the name of the gas station where Woody and Buzz get left behind?:
 - Dinoco
@@ -740,42 +740,42 @@ In Treasure Planet, what does B.E.N. stand for?:
 - Bio Electronic Navigator
 In UP, what did Carl sell before retiring?:
 - Balloons
-In Up the plates and silverware found in Charles Muntz"s blimp came from what other Disney Pixar Film?:
+In Up the plates and silverware found in Charles Muntz's blimp came from what other Disney Pixar Film?:
 - Ratatouille
-In Up, what is Carl"s dream destination?:
+In Up, what is Carl's dream destination?:
 - Paradise Falls
 In Up, what is the name of the ice cream parlor that Carl and Russel get ice cream from?:
 - Fentons
-- fenton"s
+- fenton's
 In Up, what items can be found at the bottom of Carls cane?:
 - Tennis Balls
 In Wall-E what is the name of the spaceship the humans live on?:
 - Axiom
-In What Country was Walt Disney"s father Elias born?:
+In What Country was Walt Disney's father Elias born?:
 - Canada
 In Winnie the Pooh and the blustery day, what day does Gopher tell pooh it is?:
 - Windsday
-In a Bug"s Life, what location is the Grasshopper Gang at before coming to collect the food from the Ants?:
+In a Bug's Life, what location is the Grasshopper Gang at before coming to collect the food from the Ants?:
 - Mexico
-In cartoons Pluto had an arch-nemesis who is a bulldog. What was this bulldog"s name?:
+In cartoons Pluto had an arch-nemesis who is a bulldog. What was this bulldog's name?:
 - Butch
-"In comic books only, Goofy has a nephew. What is the nephew‚\x80\x99s name?":
+In comic books only, Goofy has a nephew. What is the nephew‚Äôs name?:
 - Gilbert
 In his final battle with Captain Hook what did Peter Pan give his word not to do?:
 - Fly
 In one scene during Cinderella the King is asleep and dreaming. What is he dreaming about?:
 - Grandchildren
-'In one sequence that was cut from Snow White and the Seven Dwarfs, the Dwarfs were building something for Snow White: what was it?':
+"In one sequence that was cut from Snow White and the Seven Dwarfs, the Dwarfs were building something for Snow White: what was it?":
 - Bed
-In the 1960 Disney Film The Parent Trap, what is the name of Susan"s dance partner in the dance scene?:
+In the 1960 Disney Film The Parent Trap, what is the name of Susan's dance partner in the dance scene?:
 - Wilfred
-In the Animated Feature Tarzan, what is Jane"s Last Name?:
+In the Animated Feature Tarzan, what is Jane's Last Name?:
 - Porter
 In the Animated Feature The Aristocats, who was the leader of the Jazz Band?:
 - Scat Cat
 In the Aristocats, what is the name of the concoction that Edgar makes to drug the Cats?:
 - Creme de la Creme a la Edgar
-In the Aristocats, what kind of truck does O"Malley give Dutchess and the kittens a ride back to Paris in?:
+In the Aristocats, what kind of truck does O'Malley give Dutchess and the kittens a ride back to Paris in?:
 - A Milk Truck
 - milk truck
 In the Aristocats, who picks the lock of the trunk to free Dutchess and the kittens?:
@@ -802,19 +802,19 @@ In the Incredibles, by what name did Syndrome go by as a young boy?:
 - incrediboy
 In the Incredibles, what day of the week did Bob and Lucius always go bowling?:
 - Wednesday
-In the Incredibles, what does Dash put on his teacher"s chair?:
+In the Incredibles, what does Dash put on his teacher's chair?:
 - Tack
-In the Incredibles, what is Dash"s middle name?:
+In the Incredibles, what is Dash's middle name?:
 - Robert
 In the Jungle Book, what did Shere Khan fear the most?:
 - Fire
 In the Jungle Book, what does Kaa use in an attempt to catch his prey?:
 - hypnosis
-In the Lion King, what character"s name means Comrade or Friend in Swahili?:
+In the Lion King, what character's name means Comrade or Friend in Swahili?:
 - Rafiki
 In the Lion King, what is Scar about to eat when Zazu interrupts him?:
 - Mouse
-In the Lion King, what is the name of Nala"s Mother?:
+In the Lion King, what is the name of Nala's Mother?:
 - Sarafina
 In the Lion King, what kind of tree does Rafiki live in?:
 - A Baobab Tree
@@ -827,7 +827,7 @@ In the Lion King, which hyena fell into the thorns when chasing Simba?:
 - Banzai
 In the Little Mermaid, the housekeeper in the palace is wearing a dress from another Disney Full Length Feature Animation, which one?:
 - Cinderella
-In the Little Mermaid, what color is Ariel"s hair bow when she is sitting in the boat during the song "Kiss the Girl"?:
+In the Little Mermaid, what color is Ariel's hair bow when she is sitting in the boat during the song "Kiss the Girl"?:
 - Light Blue
 - Blue
 In the Little Mermaid, what does Ariel clothe herself with after she becomes human?:
@@ -844,20 +844,20 @@ In the Rescuers, where is the Rescue Aid Society headquarters located?:
 - UN Building
 In the Silly Symphony The Robber Kitten, by what nickname did the cat Ambrose prefer to be called?:
 - Butch
-In the animated feature 101 Dalmatians, what is the name of the puppies" canine television superhero?:
+In the animated feature 101 Dalmatians, what is the name of the puppies' canine television superhero?:
 - Thunderbolt
 In the animated feature Alice in Wonderland, how tall is the caterpillar Alice meets along her journey?:
 - 3 Inches
 - 3 in.
-In the animated feature Alice in Wonderland, when Alice first arrives at the White Rabbit"s house, he refers to her by another girl"s name. What is that name?:
+In the animated feature Alice in Wonderland, when Alice first arrives at the White Rabbit's house, he refers to her by another girl's name. What is that name?:
 - Maryanne
-In the animated feature Cinderella, what is the name of Cinderella"s stepmother?:
+In the animated feature Cinderella, what is the name of Cinderella's stepmother?:
 - Lady Tremaine
 In the animated feature Pocahontas, Meeko is a raccoon. What type of animal was he originally supposed to be?:
 - Turkey
 In the animated feature Pocahontas, what is the name of the Indian that wanted to marry Pocahontas?:
 - Kocoum
-In the animated feature Robin Hood, what is the name of Prince John"s brother?:
+In the animated feature Robin Hood, what is the name of Prince John's brother?:
 - King Richard
 In the beginning of Peter Pan when Nana is re-arranging the toy blocks what sequence of letters is she trying to form?:
 - ABC
@@ -872,11 +872,11 @@ In the feature film 102 Dalmatians, which dalmatian has no spots?:
 - Oddball
 In the feature film, The Shaggy Dog, what transforms Wilby Daniels into the Shaggy Dog?:
 - Ring
-'In the film Pirates of the Caribbean: Dead Man"s Chest, to whom does Captain Jack Sparrow owe his soul?':
+"In the film Pirates of the Caribbean: Dead Man's Chest, to whom does Captain Jack Sparrow owe his soul?":
 - Davy Jones
-'In the film Pirates of the Caribbean: Dead Man?s Chest, what is the name of the ship captained by Davy Jones?':
+"In the film Pirates of the Caribbean: Dead Man?s Chest, what is the name of the ship captained by Davy Jones?":
 - The Flying Dutchman
-'In the film Pirates of the Caribbean: The Curse of the Black Pearl, what kind of gold are the cursed medallions made of?':
+"In the film Pirates of the Caribbean: The Curse of the Black Pearl, what kind of gold are the cursed medallions made of?":
 - Aztec Gold
 - aztec
 In the full-length animated feature Aladdin, what type of magical device points the way to the Cave of Wonders?:
@@ -887,7 +887,7 @@ In the full-length animated feature Sleeping Beauty, what type of animals steal 
 - Rabbits
 In the full-length animated feature The Little Mermaid, which character sings the lyrics, "Beluga, Sevruga, come winds of the Caspian Sea"?:
 - Ursula
-'In the live-action feature film The Chronicles of Narnia: The Lion, The Witch and The Wardrobe, who is the first of the Pevensie children to pass through the wardrobe?':
+"In the live-action feature film The Chronicles of Narnia: The Lion, The Witch and The Wardrobe, who is the first of the Pevensie children to pass through the wardrobe?":
 - Lucy
 In the movie "Alice in Wonderland", what is last part of the Cheshire Cat to disappear?:
 - Smile
@@ -898,14 +898,14 @@ In the movie Snow White & the Seven Dwarfs, how old is Snow White?:
 - sixteen
 In the movie, the Haunted Mansion, what is the name of the mansion?:
 - Gracie Mansion
-In the original movie "The Parent Trap", where does the girls" mother live?:
+In the original movie 'The Parent Trap', where does the girls' mother live?:
 - Boston
 In the scene of Hercules where Hades is eating worms, what did he eat while taping that scene to make the slurping sound more realistic?:
 - Watermelon
 In their snowball fight how many snowballs does Belle hit the Beast with?:
 - 3
 - three
-'In what Disney Animated Feature can you hear the line: "Beef, Pork, Chicken mmmmmmmm"?':
+"In what Disney Animated Feature can you hear the line: \"Beef, Pork, Chicken mmmmmmmm\"?":
 - Mulan
 In what Disney Full Length Animated Feature can a ship be found named the "Jolly Roger"?:
 - Peter Pan
@@ -917,9 +917,9 @@ In what Disney Full Length Feature animation can you hear the following line" "Y
 - The LIttle Mermaid
 In what Disney Full Length animated feature can you find a character named "The Matchmaker"?:
 - Mulan
-'In what Disney Movie was the song: "Practically Perfect In Every Way" removed from and not included in its original release?':
+"In what Disney Movie was the song: \"Practically Perfect In Every Way\" removed from and not included in its original release?":
 - Mary Poppins
-'In what Disney Movie would you hear the Song: "Your Heart will lead you Home"?':
+"In what Disney Movie would you hear the Song: 'Your Heart will lead you Home'?":
 - The Tigger Movie
 In what Disney film can you find a hamster named Rhino?:
 - Bolt
@@ -927,7 +927,7 @@ In what Disney film is earth referred to as "Section 17, Area 51"?:
 - Lilo and Stitch
 In what Disney movie can you hear the line "I think I can, I think I can"?:
 - Dumbo
-'In what Full Length Animated Feature can the following line be heard: "Great Father who loves us and named us so well"?':
+"In what Full Length Animated Feature can the following line be heard: \"Great Father who loves us and named us so well\"?":
 - The Little Mermaid
 In what Movie would you find the Song The Phoney King of England?:
 - Robin Hood
@@ -947,7 +947,7 @@ In what city does The Hunchback of Notre Dame take place?:
 - Paris
 In what city does the Aristocats take place?:
 - Paris
-In what country did Alice in Wonderland have it"s premiere?:
+In what country did Alice in Wonderland have it's premiere?:
 - England
 In what country did Alice in Wonderland have its premiere?:
 - England
@@ -963,7 +963,7 @@ In what full length animated feature would you find a villain named Sykes?:
 - Oliver and Company
 In what full length feature animation were there an estimated 1,000,000 hand drawn bubbles?:
 - The Little Mermaid
-In what language is Mickey Mouse"s name translated to Musse Pigg?:
+In what language is Mickey Mouse's name translated to Musse Pigg?:
 - Swedish
 In what other Disney Pixar film did Lotso the bear from Toy Story 3 make a cameo appearance?:
 - Up
@@ -993,7 +993,7 @@ In which Disney film will you hear the song Reflection?:
 - Mulan
 In which Disney film would you find the character Mack?:
 - Cars
-In which Disney movie does Mickey Rooney"s voice "Tod" and Kurt Russell"s voice "Copper" appear?:
+In which Disney movie does Mickey Rooney's voice 'Tod' and Kurt Russell's voice 'Copper' appear?:
 - The Fox and the Hound
 In which Full Length Feature Animation can you find the boat the Susan Constant?:
 - Pocahontas
@@ -1009,7 +1009,7 @@ Many Disney movies are given a code word to use for identification purposes duri
 - Up
 Mary Gibbs provided the voice for what character from Monsters Inc.?:
 - Boo
-Minnie Mouse had a bird that appeared in 1 cartoon along with Figaro from Pinocchio. What was the bird"s name?:
+Minnie Mouse had a bird that appeared in 1 cartoon along with Figaro from Pinocchio. What was the bird's name?:
 - Frankie
 Mrs. Darling believes that Peter Pan is The Spirit of what?:
 - Youth
@@ -1021,10 +1021,10 @@ On what mountain was Hercules born?:
 - Mount Olympus
 - mt. olympus
 - olympus
-On what special Day did Disney"s Animal Kingdom open?:
+On what special Day did Disney's Animal Kingdom open?:
 - Earth Day
 - April 22, 1998
-On which Dwarf"s shoulders does Dopey stand in order to become a suitable dance partner for Snow White?:
+On which Dwarf's shoulders does Dopey stand in order to become a suitable dance partner for Snow White?:
 - Sneezy
 One Jump is a song from which Disney film?:
 - Aladdin
@@ -1038,11 +1038,11 @@ Some scenes of woodland creatures and the forest fire in Bambi are actually unus
 - Pinocchio
 Some scenes of woodland creatures and the forest from Bambi are rumored to have been "re-used" from what other Disney Full Length Animated Feature?:
 - Pinocchio
-Tangled is based on which of the Grimms" fairy tales?:
+Tangled is based on which of the Grimms' fairy tales?:
 - Rapunzel
-The 1932 Mickey Mouse cartoon, Mickey"s Revue included the introduction to what famous Disney character?:
+The 1932 Mickey Mouse cartoon, Mickey's Revue included the introduction to what famous Disney character?:
 - Goofy
-The Hawaiian word Kapu is written on the door to Lilo"s room, what does it mean in English?:
+The Hawaiian word Kapu is written on the door to Lilo's room, what does it mean in English?:
 - Keep Out
 The Incredibles was the first Disney Pixar film to receive a PG rating, what was the second?:
 - Up
@@ -1062,7 +1062,7 @@ The song "Little April Shower" is featured in what Disney full length animated f
 - Bambi
 The song "Middle of a Muddle" was written for a Disney Full Length Animated feature but never used. What movie was it written for?:
 - Cinderella
-The song, "Oh Sing, Sweet Nightingale" features in which Disney film?:
+The song, 'Oh Sing, Sweet Nightingale' features in which Disney film?:
 - Cinderella
 The soundtrack of what Disney animated feature includes seven Elvis Presley songs?:
 - Lilo and Stitch
@@ -1092,27 +1092,27 @@ What Disney Animated Character is considered the Treasurer for Disney according 
 - Scrooge McDuck
 What Disney Character appeared on a US $20 bill from 1865?:
 - Pocahontas
-What Disney Character comic book was almost banned in Finland because the character doesn"t wear pants?:
+What Disney Character comic book was almost banned in Finland because the character doesn't wear pants?:
 - Donald Duck
-What Disney Character from a full length animated feature was inspired by one of the animator"s sister?:
+What Disney Character from a full length animated feature was inspired by one of the animator's sister?:
 - Jasmine
-'What Disney Character said the following line: "Enough Is As Good As A Feast"?':
+"What Disney Character said the following line: \"Enough Is As Good As A Feast\"?":
 - Mary Poppins
 What Disney Character transformed himself into likenesses of Jack Nicholson, Carol Channing, and Groucho Marx?:
 - The Genie
 - Genie
-'What Disney Character was accidentally referred to by the names: Bingo, Chico, Elmo, Fabio, and Harpo?':
+"What Disney Character was accidentally referred to by the names: Bingo, Chico, Elmo, Fabio, and Harpo?":
 - Nemo
-What Disney Film is loosely based on Aesop"s fable "The Ant and the Grasshopper"?:
-- A Bug"s Life
+What Disney Film is loosely based on Aesop's fable "The Ant and the Grasshopper"?:
+- A Bug's Life
 - a bugs life
-- bug"s life
+- bug's life
 - bugs life
-What Disney Full Length Animated Feature did Susan Egan sing "I Won"t Say (I"m In Love)"?:
+What Disney Full Length Animated Feature did Susan Egan sing "I Won't Say (I'm In Love)"?:
 - Hercules
 What Disney Full Length Animated Feature did writers term the story pitch as "Bambi in Africa meets Hamlet", or "Bamlet"?:
 - The Lion King
-'What Disney Full Length Animated Feature has a song that begins with: "love is a song that never ends"?':
+"What Disney Full Length Animated Feature has a song that begins with: \"love is a song that never ends\"?":
 - Bambi
 What Disney Full Length Animated Feature is the song "Stangers Like Me" from?:
 - Tarzan
@@ -1149,9 +1149,9 @@ What Disney character is the mascot of the Environment?:
 - Jiminy Cricket
 What Disney character wears a cooking pot for a hat?:
 - Jonny Appleseed
-What Disney character"s name in Latin means "nobody" or "no one"?:
+What Disney character's name in Latin means 'nobody' or 'no one'?:
 - Nemo
-What Disney character"s name means light?:
+What Disney character's name means light?:
 - Lumiere
 What Disney film has a character named Tantor?:
 - Tarzan
@@ -1165,7 +1165,7 @@ What Disney movie character is an American White Shepherd?:
 - Bolt
 What Disney movie does the song Reflection come from?:
 - Mulan
-'What Disney movie has a song that starts with the line: "I know that your powers of retention are as wet as a warthog"s backside"?':
+"What Disney movie has a song that starts with the line: \"I know that your powers of retention are as wet as a warthog's backside\"?":
 - The Lion King
 What Disney movie has the song Little April Shower in it?:
 - Bambi
@@ -1189,13 +1189,13 @@ What actor provided the voice of John Smith in Pocahontas?:
 - Mel Gibson
 What actor was the first to receive a Golden Globe nomination for Best Actor for providing a voice in a Disney Full Length Feature Animation?:
 - Robin Williams
-'What animated character used the following line: "I shall call him Squishy"?':
+"What animated character used the following line: \"I shall call him Squishy\"?":
 - Dory
 What animated feature, created by Walt Disney, was inspired by him playing the lead role in a school play?:
 - Peter Pan
-What animated picture was called by some Disney Critics "Disney"s Folly" before it was released?:
+What animated picture was called by some Disney Critics "Disney's Folly" before it was released?:
 - Snow White and The Seven Dwarfs
-What are the missing words from this song line from Mulan? "You"re unsuited for the rage of war, so pack up, ________, you"re through!":
+What are the missing words from this song line from Mulan? "You're unsuited for the rage of war, so pack up, ________, you're through!":
 - Go Home
 What breed of dog does Lilo tell David that Stitch used to be?:
 - Collie
@@ -1207,13 +1207,13 @@ What character from Beauty and The Beast helps Belle and her father escape being
 - Chip
 What character from a Disney Full Length Animated Feature has the nickname Wonderboy?:
 - Hercules
-'What character from a Disney Full Length Animated feature says the following line: "I was first in line until the little hairball was born"?':
+"What character from a Disney Full Length Animated feature says the following line: \"I was first in line until the little hairball was born\"?":
 - Scar
 What character in Mulan always has a black eye?:
 - Yao
 What character in The Little Mermaid dresses Ariel on the beach after Ursula gives her the opportunity to become human?:
 - Scuttle
-What character in the Little Mermaid informs King Triton of Ariel"s underwater cavern?:
+What character in the Little Mermaid informs King Triton of Ariel's underwater cavern?:
 - Sebastian
 What character in the Winnie the Pooh films was added by Disney and does not appear in the original books?:
 - Gopher
@@ -1232,11 +1232,11 @@ What character was voiced by Matthew Broderick and Jonathan Taylor Thomas?:
 - Simba
 What city are the dogs lost in the Disney Movie Homeward Bound II?:
 - San Francisco
-What city does Nemo end up in after he is taken in "Finding Nemo"?:
+What city does Nemo end up in after he is taken in 'Finding Nemo'?:
 - Sydney
 What city is the setting for The Princess and the Frog?:
 - New Orleans
-What color are Dopey"s eyes?:
+What color are Dopey's eyes?:
 - Blue
 What color are the elephants that Dumbo and Timothy see after drinking from the tub?:
 - Pink
@@ -1244,25 +1244,25 @@ What color are the horses that Imperial Soldiers ride in Mulan?:
 - White
 What color hat did Timothy Mouse wear in Dumbo?:
 - Red
-What color is Dumbo"s hat?:
+What color is Dumbo's hat?:
 - Yellow
 What color is Mr. Smees hat in Peter Pan?:
 - Red
-What color is Prince Phillip"s horse?:
+What color is Prince Phillip's horse?:
 - White
 What color is Prince Phillips Horse?:
 - White
-What color is Tigger"s nose?:
+What color is Tigger's nose?:
 - Pink
 What color is the book that is given to Belle at the beginning of Beauty and the Beast?:
 - Blue
-What color is the string of beads broken by Cinderella"s stepsisters?:
+What color is the string of beads broken by Cinderella's stepsisters?:
 - Blue
 What color shoes does Mickey Mouse normally wear?:
 - Yellow
 What color was not prominently used in Pocahontas until the final scene just before the battle in order to make it more dramatic?:
 - Red
-What country almost banned Donald Duck cartoons because it was stated "he wasn"t wearing any pants"?:
+What country almost banned Donald Duck cartoons because it was stated "he wasn't wearing any pants"?:
 - Finland
 What country banned the film Snow White for children under 14 for being too scary?:
 - Holland
@@ -1273,14 +1273,14 @@ What did Michal put in his teddy bear in Peter Pan when fighting the pirates?:
 - cannonball
 What did Mrs. Darling consider Peter Pan to be?:
 - The Spirit of Youth
-What did Walt Disney consider to be America"s most important export?:
+What did Walt Disney consider to be America's most important export?:
 - Laughter
 What did Walt Disney win his first Academy Award for?:
 - Flowers and Trees
-What didn"t the owl want to be turned into in The Sword in the Stone?:
+What didn't the owl want to be turned into in The Sword in the Stone?:
 - human
-What do Bernard and Bianca use to lure Madame Medusa"s 2 crocodiles into the cage in The Rescuers?:
-- Bianca"s Perfume
+What do Bernard and Bianca use to lure Madame Medusa's 2 crocodiles into the cage in The Rescuers?:
+- Bianca's Perfume
 - perfume
 What do the gargoyles at the end of Beauty & the Beast transform into?:
 - Angels
@@ -1297,7 +1297,7 @@ What does Pocahontas think is the gold that John Smith is talking about?:
 - Corn
 What does Tantor think Tarzan is, when he is swimming in the water?:
 - Piranha
-What does Wall-E"s name stand for?:
+What does Wall-E's name stand for?:
 - Waste Allocation Load Lifter Earth-Class
 What does the beaver remove to help Lady in Lady and the Tramp?:
 - muzzle
@@ -1309,7 +1309,7 @@ What female Disney Character makes a cameo appearance in The Hunchback of Notre 
 - Belle
 What female relative of Donald Duck had her own comic book series?:
 - Grandma Duck
-What film character"s name is a clue to his characters purpose in providing comic relief and can be interpreted to mean oh laugh?:
+What film character's name is a clue to his characters purpose in providing comic relief and can be interpreted to mean oh laugh?:
 - Olaf
 What film is the song Goodbye May Seem Forever from?:
 - The Fox and the Hound
@@ -1331,9 +1331,9 @@ What full length feature animation was based on a book by T.H. White?:
 - Sword in the Stone
 What full length feature animation was based on the German story called Aschenputtel?:
 - Cinderella
-What full length feature animation"s color design was inspired by old Persian miniatures and Victorian paintings of the Middle East?:
+What full length feature animation's color design was inspired by old Persian miniatures and Victorian paintings of the Middle East?:
 - Aladdin
-What gift does Mr. Banks present to his children after he experiences a much-needed change of heart in "Mary Poppins"?:
+What gift does Mr. Banks present to his children after he experiences a much-needed change of heart in 'Mary Poppins'?:
 - kite
 What highway is depicted in the movie Cars?:
 - Route 66
@@ -1341,44 +1341,44 @@ What insect is considered good luck in China according to the film Mulan?:
 - Cricket
 What instrument does Lilo teach Stitch to play?:
 - ukelele
-What is Andy"s last name in Toy Story?:
+What is Andy's last name in Toy Story?:
 - Davis
-What is Boo"s Real name in Monsters Inc? (It is visible on one of the drawings she is making while in Mike and Sulley"s apartment):
+What is Boo's Real name in Monsters Inc? (It is visible on one of the drawings she is making while in Mike and Sulley's apartment):
 - Mary
-What is Cinderella"s last name?:
+What is Cinderella's last name?:
 - Tremaine
-What is Cinderella"s mouse friend, Gus-Gus"s real name?:
+What is Cinderella's mouse friend, Gus-Gus's real name?:
 - Octavious
-What is Donald Duck"s middle name?:
+What is Donald Duck's middle name?:
 - Fauntleroy
-What is Donald Duck"s name in his Italian comic strips?:
+What is Donald Duck's name in his Italian comic strips?:
 - Paolino Paperino
 What is Eeyore stuffed with?:
 - Sawdust
-What is Hades" hair in Hercules made of?:
+What is Hades' hair in Hercules made of?:
 - Flames
-What is Kronk"s specialty dish in The Emperor"s New Groove?:
+What is Kronk's specialty dish in The Emperor's New Groove?:
 - Spinach Puffs
-What is Kronk"s specialty food in The Emperor"s New Groove?:
+What is Kronk's specialty food in The Emperor's New Groove?:
 - Spinach Puffs
-What is Lilo"s last name from Lilo and Stitch?:
+What is Lilo's last name from Lilo and Stitch?:
 - Pelekai
-What is Linguini"s nickname for Remy in Ratatouille?:
+What is Linguini's nickname for Remy in Ratatouille?:
 - Little Chef
-What is Mrs. Incredible"s real full name?:
+What is Mrs. Incredible's real full name?:
 - Helen Parr
 What is Peter Pan searching for in the beginning of the movie?:
 - His Shadow
 - shadow
-What is Ursula"s name when she becomes human in The Little Mermaid?:
+What is Ursula's name when she becomes human in The Little Mermaid?:
 - Vanessa
-What is Wall E"s favorite film?:
+What is Wall E's favorite film?:
 - Hello Dolly
-What is on the license plate of Al"s car (from Al"s Toy Barn in Toy Story 2)?:
+What is on the license plate of Al's car (from Al's Toy Barn in Toy Story 2)?:
 - ALZTYBRN
-What is the color of the Prince"s horse in Sleeping Beauty?:
+What is the color of the Prince's horse in Sleeping Beauty?:
 - White
-What is the ending of this lyric from a song from The Little Mermaid? The seaweed is always greener, in somebody else"s __________?:
+What is the ending of this lyric from a song from The Little Mermaid? The seaweed is always greener, in somebody else's __________?:
 - Lake
 What is the ending of this song line from Mulan? "Tranquil as a ______":
 - Forest
@@ -1386,104 +1386,104 @@ What is the ending to this line from the Lion King ... Hakuna Matata, what a won
 - Phrase
 What is the ending to this line from the song "Out There" from Hunchback of Notre Dame..."Out there among the millers and weavers and their________"?:
 - Wives
-What is the ending to this song lyric from Beauty and the Beast? "Be our guest, Be our guest, Put our service to the test, Tie your napkin "round your neck, ______"?:
+What is the ending to this song lyric from Beauty and the Beast? "Be our guest, Be our guest, Put our service to the test, Tie your napkin 'round your neck, ______"?:
 - Cherie
 What is the first Disney film to have a movie soundtrack album released?:
 - Snow White and the Seven Dwarfs
 - snow white
-What is the first name of Davy Crockett"s wife?:
+What is the first name of Davy Crockett's wife?:
 - Polly
 What is the first thing Aladdin Says when he sees Jasmine?:
 - WOW
-What is the last name of Al from Al"s Toy Barn in Toy Story 2?:
+What is the last name of Al from Al's Toy Barn in Toy Story 2?:
 - McWhiggin
 What is the last word spoken by Cinderella to the Prince at the ball?:
 - Goodbye
 What is the missing word from this song lyric from The Lion King? "I Know that your powers of retention are as wet as a ___________ backside"?:
-- Warthog"s
+- Warthog's
 - warthogs
-What is the name of Aladdin"s father?:
+What is the name of Aladdin's father?:
 - Cassim
-What is the name of Alice"s cat in "Alice in Wonderland"?:
+What is the name of Alice's cat in 'Alice in Wonderland'?:
 - Dinah
-What is the name of Andy"s sister in Toy Story?:
+What is the name of Andy's sister in Toy Story?:
 - Molly
-What is the name of Ariel"s daughter in the Little Mermaid 2?:
+What is the name of Ariel's daughter in the Little Mermaid 2?:
 - Melody
-What is the name of Bambi"s true love?:
+What is the name of Bambi's true love?:
 - Faline
-"What is the name of Carl Fredricksen‚\x80\x99s wife in UP?":
+What is the name of Carl Fredricksen‚Äôs wife in UP?:
 - Ellie
-What is the name of Cruella"s hairless dog in 102 Dalmatians?:
+What is the name of Cruella's hairless dog in 102 Dalmatians?:
 - Fluffy
-What is the name of Donald Duck"s sister (Also the mother of Huey Dewey & Louie)?:
+What is the name of Donald Duck's sister (Also the mother of Huey Dewey & Louie)?:
 - Dumbella
-What is the name of Fagan"s evil boss in Oliver and Company?:
+What is the name of Fagan's evil boss in Oliver and Company?:
 - Sykes
-What is the name of Governor Radcliffe"s dog in Pocahontas?:
+What is the name of Governor Radcliffe's dog in Pocahontas?:
 - Percy
 What is the name of Hans horse in Frozen?:
 - Sitron
-What is the name of Hercules" foster father on earth?:
+What is the name of Hercules' foster father on earth?:
 - Amphitryon
-'What is the name of Jack Sparrow"s dad in Pirates of the Caribbean: At World"s End?':
+"What is the name of Jack Sparrow's dad in Pirates of the Caribbean: At World's End?":
 - Captain Teague
-What is the name of Jasmine"s Tiger in Aladdin?:
+What is the name of Jasmine's Tiger in Aladdin?:
 - Rajah
-What is the name of John Smith"s ship in Pocahontas?:
+What is the name of John Smith's ship in Pocahontas?:
 - The Susan Constant
 - Susan Constant
-What is the name of Lilo"s Sister from Lilo and Stitch?:
+What is the name of Lilo's Sister from Lilo and Stitch?:
 - Nani
-What is the name of Maleficent"s pet raven in Sleeping Beauty?:
+What is the name of Maleficent's pet raven in Sleeping Beauty?:
 - Diablo
-What is the name of Merlin"s Owl in the Sword In The Stone?:
+What is the name of Merlin's Owl in the Sword In The Stone?:
 - Archimedes
-What is the name of Mickey Mouse"s sister?:
+What is the name of Mickey Mouse's sister?:
 - Amelia Fieldmouse
-What is the name of Mike Wazowski"s small teddy bear that Boo takes from him in Monsters Inc?:
+What is the name of Mike Wazowski's small teddy bear that Boo takes from him in Monsters Inc?:
 - Little Mikey
-What is the name of Mulan"s Cricket Friend?:
+What is the name of Mulan's Cricket Friend?:
 - Cri-Kee
-What is the name of Mulan"s beheaded ancestor spirit?:
+What is the name of Mulan's beheaded ancestor spirit?:
 - Fa Deng
-What is the name of Mulan"s dog?:
+What is the name of Mulan's dog?:
 - Little Brother
-What is the name of Mulan"s horse?:
+What is the name of Mulan's horse?:
 - Khan
-What is the name of Nemo"s Father?:
+What is the name of Nemo's Father?:
 - Marlin
-What is the name of Pocahontas" father?:
+What is the name of Pocahontas' father?:
 - Chief Powhatan
-What is the name of Pocahontas"s best friend in her Indian Tribe?:
+What is the name of Pocahontas's best friend in her Indian Tribe?:
 - Nakoma
-What is the name of Prince Eric"s dog in The Little Mermaid?:
+What is the name of Prince Eric's dog in The Little Mermaid?:
 - Max
-What is the name of Prince Eric"s housekeeper in the Little Mermaid?:
+What is the name of Prince Eric's housekeeper in the Little Mermaid?:
 - Carlotta
 What is the name of Prince Phillips horse in Sleeping Beauty?:
 - Samson
-What is the name of Randall"s assistant from Monsters Inc?:
+What is the name of Randall's assistant from Monsters Inc?:
 - Fungus
-What is the name of Shan Yu"s bird in Mulan?:
+What is the name of Shan Yu's bird in Mulan?:
 - Hayabusa
-What is the name of Tarzan"s adoptive mother gorilla?:
+What is the name of Tarzan's adoptive mother gorilla?:
 - Kala
-What is the name of Ursula"s Sister in The Little Mermaid 2?:
+What is the name of Ursula's Sister in The Little Mermaid 2?:
 - Morgana
-What is the name of Wendy"s daughter in Return to Neverland?:
+What is the name of Wendy's daughter in Return to Neverland?:
 - Jane
-What is the name of Woody"s horse in Toy Story 2?:
+What is the name of Woody's horse in Toy Story 2?:
 - Bullseye
 What is the name of the Australian kangaroo mouse who joined Bernard and Bianca in The Rescuers Down Under?:
 - Jake
 What is the name of the Badger in the animated feature Robin Hood?:
 - Friar Tuck
-What is the name of the Black Widow Spider from A Bug"s Life?:
+What is the name of the Black Widow Spider from A Bug's Life?:
 - Rosie
 What is the name of the Disney Short where Donald Duck becomes the adoptive father of a kangaroo?:
 - Daddy Duck
-What is the name of the Earth cat that Jake falls in love with in Disney"s "The Cat From Outer Space"?:
+What is the name of the Earth cat that Jake falls in love with in Disney's "The Cat From Outer Space"?:
 - Lucy Belle
 What is the name of the French thief who bombed the bank at the beginning of The Incredibles?:
 - Bomb Voyage
@@ -1493,12 +1493,12 @@ What is the name of the Jester in Hunchback of Notre Dame?:
 - Clopin
 What is the name of the Multi-Headed creature that Hercules fights?:
 - Hydra
-What is the name of the Princess in A Bug"s Life who is training to be the Queen of the Colony?:
+What is the name of the Princess in A Bug's Life who is training to be the Queen of the Colony?:
 - Princess Atta
 - atta
 What is the name of the Realty Company that is selling the house in Toy Story?:
 - Virtual Realty
-What is the name of the Wicked Queen"s huntsman in Snow White and the Seven Dwarfs?:
+What is the name of the Wicked Queen's huntsman in Snow White and the Seven Dwarfs?:
 - Humbert
 What is the name of the bear cub in Brother Bear?:
 - Koda
@@ -1513,7 +1513,7 @@ What is the name of the cat that befriends Bolt?:
 - Mr Mittens
 - mr. mittens
 - mister mittens
-What is the name of the caterpillar in A Bug"s Life?:
+What is the name of the caterpillar in A Bug's Life?:
 - Heimlich
 What is the name of the chef in The Little Mermaid?:
 - Louie
@@ -1550,9 +1550,9 @@ What is the name of the green fairy in Sleeping Beauty?:
 - Fauna
 What is the name of the horse in The Aristocats?:
 - Frou Frou
-What is the name of the island where Syndrome has his base in "The Incredibles"?:
+What is the name of the island where Syndrome has his base in 'The Incredibles'?:
 - Nomanisan
-What is the name of the leader of the grasshoppers in A Bug"s Life?:
+What is the name of the leader of the grasshoppers in A Bug's Life?:
 - Hopper
 What is the name of the little boy on the tricycle in the The Incredibles?:
 - Rusty
@@ -1567,7 +1567,7 @@ What is the name of the mother dalmatian from 101 Dalmatians?:
 - Perdita
 What is the name of the mule in Old Yeller?:
 - Jumper
-'What is the name of the original novel that inspired the full length feature animation: The Hunchback of Notre Dame?':
+"What is the name of the original novel that inspired the full length feature animation: The Hunchback of Notre Dame?":
 - Notre Dame de Paris
 What is the name of the owner of the cats in Aristocats?:
 - Madame Bonfamille
@@ -1579,13 +1579,13 @@ What is the name of the pig in Toy Story?:
 - Hamm
 What is the name of the python snake in Honey I Shrunk the Audience?:
 - Gigabyte
-What is the name of the queen"s pet in A Bug"s Life?:
+What is the name of the queen's pet in A Bug's Life?:
 - Aphie
 What is the name of the restaurant in Toy Story where the aliens are found?:
 - Pizza Planet
 What is the name of the retirement village in the movie Up that sends the brochures to Carl?:
 - Shady Oaks
-What is the name of the robot that terrorizes the city at the end of "The Incredibles"?:
+What is the name of the robot that terrorizes the city at the end of 'The Incredibles'?:
 - Omnidroid
 What is the name of the school teacher in Finding Nemo?:
 - Mr Ray
@@ -1593,10 +1593,10 @@ What is the name of the school teacher in Finding Nemo?:
 - mister ray
 What is the name of the shark in The Little Mermaid that chases Ariel and Flounder?:
 - Glut
-What is the name of the ship in Walt Disney"s Movie Treasure Island?:
+What is the name of the ship in Walt Disney's Movie Treasure Island?:
 - The Hispaniola
 - Hispaniola
-What is the name of the signal the dogs used to communicate the puppies" danger in 101 Dalmatians?:
+What is the name of the signal the dogs used to communicate the puppies' danger in 101 Dalmatians?:
 - The Twilight Bark
 - twilight bark
 What is the name of the soldier strapped to an explosive by Sid in Toy Story?:
@@ -1604,7 +1604,7 @@ What is the name of the soldier strapped to an explosive by Sid in Toy Story?:
 What is the name of the song in the Aristocats that the kittens practice on the piano with Marie singing?:
 - Scales and Arpeggios
 What is the name of the song that Meg sings after she feels she is falling love with Hercules?:
-- I Won"t Say I"m in Love
+- I Won't Say I'm in Love
 What is the name of the sound system created for Fantasia?:
 - Fantasound
 What is the name of the stone formation atop which Simba is presented and from which Mufasa and Simba survey their kingdom?:
@@ -1624,25 +1624,25 @@ What is the numeric code for a contamination emergency in Monsters Inc?:
 - 2319
 What is the one thing Madam Mim hates in The Sword in the Stone?:
 - Sunshine
-What is the only Disney animated feature film that has a title character who doesn"t speak?:
+What is the only Disney animated feature film that has a title character who doesn't speak?:
 - Dumbo
 What is the only cartoon created by Walt Disney that had an Easter Theme?:
 - Funny LIttle Bunnies
 What is the only main character from a Disney Full Length Animated Feature that did not talk throughout the film?:
 - Dumbo
-What is the only year (During the 1990"s) that Disney did not release a Full Length Feature Animation?:
+What is the only year (During the 1990's) that Disney did not release a Full Length Feature Animation?:
 - 1993
 What is the only year in the 1990s that Disney did not release a full-length animated feature in?:
 - 1993
-What is the sea witch"s name from The little mermaid?:
+What is the sea witch's name from The little mermaid?:
 - Ursula
 What is the song in the beginning of The Lion King?:
 - The Circle of Life
-What is the wizard"s name in the movie The Sword in the Stone?:
+What is the wizard's name in the movie The Sword in the Stone?:
 - Merlin
 What kind of animal is Sammy in the Country Bear Jamboree?:
 - Racoon
-What kind of animal is on Captain Barbossa"s ring in Pirates of the Caribbean?:
+What kind of animal is on Captain Barbossa's ring in Pirates of the Caribbean?:
 - Bear
 What kind of animals does Pluto find himself caring for in the cartoon Mother Pluto?:
 - Chicks
@@ -1731,9 +1731,9 @@ What town is the setting for the Disney Movie "The Love Bug"?:
 - San Francisco
 What toy is Woody rescuing from the yard sale in Toy Story 2, when he himself ends up being stolen?:
 - Wheezy
-What type of animal is the Sultan"s throne shaped like in Aladdin?:
+What type of animal is the Sultan's throne shaped like in Aladdin?:
 - Elephant
-What type of flower does Mushu say the Huns pop out of the snow like in Disney"s "Mulan"?:
+What type of flower does Mushu say the Huns pop out of the snow like in Disney's "Mulan"?:
 - Daisies
 What type of insect actually providing the inspiration for Jiminy Cricket?:
 - Grasshopper
@@ -1741,17 +1741,17 @@ What type of pie does Snow White offer to bake for the dwarfs?:
 - Gooseberry
 What villain appears at the end of the Incredibles?:
 - The Underminer
-What was Daisy Duck"s original first name?:
+What was Daisy Duck's original first name?:
 - Donna
-What was Disney"s first live action film that had no animation?:
+What was Disney's first live action film that had no animation?:
 - Treasure Island
 What was Disneys second full length feature animation to be released?:
 - Pinocchio
-What was Mr. Incredible"s civilian name originally going to be before it was decided to use Robert Parr?:
+What was Mr. Incredible's civilian name originally going to be before it was decided to use Robert Parr?:
 - Bob Smith
-What was Walt Disney"s First Silly Symphony?:
+What was Walt Disney's First Silly Symphony?:
 - The Skeleton Dance
-What was Walt Disney"s family dog named?:
+What was Walt Disney's family dog named?:
 - Lady
 What was first Disney movie to feature people who have belly buttons?:
 - Mulan
@@ -1797,8 +1797,8 @@ What was the first Full Length feature animation to use closing credits?:
 What was the first Mickey Mouse cartoon made in color?:
 - The Band Concert
 What was the first Pixar feature film to include "outtakes" in the credits?:
-- A Bug"s Life
-- bug"s life
+- A Bug's Life
+- bug's life
 What was the first Pixar film to win the Best Animated Feature Award?:
 - Finding Nemo
 What was the first Pixar movie to center on mostly all human characters?:
@@ -1843,9 +1843,9 @@ What was the last film personally overseen by Walt Disney?:
 - The Jungle Book
 What was the movie Bolt originally going to be called?:
 - American Dog
-What was the name of Davey Crockett"s wife?:
+What was the name of Davey Crockett's wife?:
 - Polly
-What was the name of Disney"s first made for video animated movie?:
+What was the name of Disney's first made for video animated movie?:
 - The Return of Jafar
 What was the name of the 1992 television series which featured Goofy in it?:
 - Goof Troop
@@ -1854,15 +1854,15 @@ What was the name of the Indian Princess in Never Land in Peter Pan?:
 - tigerlily
 What was the name of the animated dragon played by Eddie Murphy in Mulan?:
 - Mushu
-What was the name of the dentist"s receptionist in Finding Nemo?:
+What was the name of the dentist's receptionist in Finding Nemo?:
 - Barbara
 What was the name of the dragon (god wanna be) in Mulan?:
 - Mushu
-'What was the name of the escaped gorilla from the 1944 cartoon titled: "Donald Duck and the Gorilla"?':
+"What was the name of the escaped gorilla from the 1944 cartoon titled: \"Donald Duck and the Gorilla\"?":
 - Ajax
 What was the name of the first color Disney comic strip?:
 - The Silly Symphonies
-What was the name of the mountain where Nemo had his initiation ceremony by the "Tank Gang"?:
+What was the name of the mountain where Nemo had his initiation ceremony by the 'Tank Gang'?:
 - Mount Wannahawkaloogie
 - Wannahawkaloogie
 - mt. Wannahawkaloogie
@@ -1901,9 +1901,9 @@ What year was Pluto created by Disney?:
 - 1930
 What year was The Walt Disney Company started?:
 - 1923
-What"s on the end of Mary Poppins" umbrella handle?:
+What's on the end of Mary Poppins' umbrella handle?:
 - Parrot
-"What‚\x80\x99s the name of Jack Skellingtons ghostly pup?":
+What‚Äôs the name of Jack Skellingtons ghostly pup?:
 - Zero
 When Bambi and his friends walk across some ice, what name do they refer to it as?:
 - Stiff Water
@@ -1938,7 +1938,7 @@ When Sully is saying good by to Boo in Monsters Inc, what is the second Disney C
 - A Nemo Doll
 - nemo
 - nemo doll
-When Ursulas takes Ariel"s voice in the Little Mermaid where does she put it for safekeeping?:
+When Ursulas takes Ariel's voice in the Little Mermaid where does she put it for safekeeping?:
 - seashell necklace
 - seashell
 - shell
@@ -1949,7 +1949,7 @@ When Walt Disney was young, what main character did he play in a school function
 - Peter Pan
 When did Mickey Mouse receive his first entry in Encyclopedia Britannica?:
 - 1934
-When does Mary Poppins say she will leave the Banks" house?:
+When does Mary Poppins say she will leave the Banks' house?:
 - When the WInd Changes
 When fighting Hercules, how many heads does the Hydra ultimately end up having?:
 - 30
@@ -1965,10 +1965,10 @@ Where does Jack Skellington reside?:
 - Halloween Town
 Where does Robin Hood live?:
 - Nottingham
-Where does Sully hide Boo"s toys in Monsters Inc.?:
+Where does Sully hide Boo's toys in Monsters Inc.?:
 - Locker
-Where is Peter Pan"s hide out?:
-- Hangman"s Tree
+Where is Peter Pan's hide out?:
+- Hangman's Tree
 Which Disney Character did the US Government originally use as a symbol for forest fire prevention before Smokey the Bear?:
 - Bambi
 Which Disney Fairy is the only one to have a star at the tip of her wand?:
@@ -1989,15 +1989,15 @@ Which Disney character makes a cameo as a stuffed animal in frozen?:
 - Mickey Mouse
 Which Disney character received an honorable discharge from the United States Army on May 19, 1984 after 42 years of service?:
 - Donald Duck
-Which Disney character sings the song "Who"s Been Painting My Rose Red"?:
+Which Disney character sings the song 'Who's Been Painting My Rose Red'?:
 - The Queen of Hearts
 - queen of hearts
 Which Disney character traveled to the future and met himself?:
 - Lewis (from Meet the Robinsons)
 - Lewis
-Which Disney film features the song "Little April Shower"?:
+Which Disney film features the song 'Little April Shower'?:
 - Bambi
-Which Disney film was an Academy Award winner for the Best Original Score and Song "A Whole New World"?:
+Which Disney film was an Academy Award winner for the Best Original Score and Song 'A Whole New World'?:
 - Aladdin
 Which Disney full length animated feature includes the most songs?:
 - Alice in Wonderland
@@ -2007,7 +2007,7 @@ Which Disney villain is known for the phrase "Off with her head!"?:
 - Queen of Hearts
 Which Disney villain is the Lord of the Underworld?:
 - Hades
-Which Full Length Animated Feature"s last line in the film is, "Well, come along, It"s time for tea"?:
+Which Full Length Animated Feature's last line in the film is, "Well, come along, It's time for tea"?:
 - Alice in Wonderland
 Which Toy Story character says he is from Mattel?:
 - Rex
@@ -2015,10 +2015,10 @@ Which animated Disney character casts a "wizard blizzard"?:
 - Merlin
 Which character does Peter Pan charge with high treason?:
 - Tinkerbell
-Which character from Disney"s Alice and Wonderland was not in the original book?:
+Which character from Disney's Alice and Wonderland was not in the original book?:
 - The Doorknob
 - doorknob
-Which character in A Bug"s Life transforms into a butterfly at the end?:
+Which character in A Bug's Life transforms into a butterfly at the end?:
 - Heimlich
 Which character in Winnie the Pooh stories does not appear in the original book and is "ding-dang glad of it"?:
 - Gopher
@@ -2043,7 +2043,7 @@ Which mouse does Cinderella save from the mousetrap?:
 Which movie features the song "I Wanna Be Like You"?:
 - The Jungle Book
 Which movie had the original planned title of Kingdom of the Sun?:
-- The Emperor"s New Groove
+- The Emperor's New Groove
 - The Emperors New Groove
 Which movie had the original working title of Trash Planet?:
 - Wall-E
@@ -2059,13 +2059,13 @@ Which of the seven dwarfs is always first in line?:
 - Doc
 Which one of the seven dwarfs wears glasses?:
 - Doc
-Which princess sang "Whistle While You Work"?:
+Which princess sang 'Whistle While You Work'?:
 - Snow White
 While The Lion King was the highest grossing movie worldwide in 1994 it was second in the United States. What movie beat it?:
 - Forrest Gump
 While on a camping trip with his son, what legendary creature do Goofy and his son Max encounter in A Goofy Movie?:
 - Bigfoot
-While the release year of "Fantasia 2000" is easy enough, what year did the original "Fantasia" debut?:
+While the release year of 'Fantasia 2000' is easy enough, what year did the original 'Fantasia' debut?:
 - 1940
 Who Said "Ah, I see you have a sword! I have one too."?:
 - Mulan
@@ -2075,7 +2075,7 @@ Who did Cinderella rescue from a rat trap?:
 - Gus
 Who does Kristen Bell provide the voice for in Frozen?:
 - Anna
-Who does Maleficent kidnap so he won"t be able to rescue Sleeping Beauty?:
+Who does Maleficent kidnap so he won't be able to rescue Sleeping Beauty?:
 - Prince Phillip
 Who has a credit card in a Full Length Feature Animation with the credit card number being VI V XI XIV XV XVI IV ?:
 - Hercules
@@ -2086,16 +2086,16 @@ Who hosts the DVD menu on The Lion King Special Edition DVD?:
 Who is "Monster of Ceremonies" at Monsters, Inc. Laugh Floor?:
 - Mike Wazowski
 - mike
-Who is Huey, Dewey and Louie"s mother?:
+Who is Huey, Dewey and Louie's mother?:
 - Dumbella
 Who is assigned to watch over Ariel in The Little Mermaid?:
 - Sebastian
-Who is considered to be Disney"s very first real animated villain who tormented Mickey in his Steamboat?:
+Who is considered to be Disney's very first real animated villain who tormented Mickey in his Steamboat?:
 - Pegleg Pete
 - Pete
-Who is considered to be Roger Rabbit"s uncle?:
+Who is considered to be Roger Rabbit's uncle?:
 - Thumper
-Who is considered to be Winnie The Pooh"s best friend?:
+Who is considered to be Winnie The Pooh's best friend?:
 - Piglet
 Who is known as being the tubby little cubby stuffed with fluff?:
 - Winnie the Pooh
@@ -2104,7 +2104,7 @@ Who is mentioned as being Roger Rabbits Uncle?:
 - Thumper
 Who is the "Biscuit Thief" in Pocahontas?:
 - Meeko
-Who is the chief of the Seeonee wolf pack in "The Jungle Book"?:
+Who is the chief of the Seeonee wolf pack in 'The Jungle Book'?:
 - Akela
 Who is the leader of the wolf pack in the Jungle Book?:
 - Akela
@@ -2128,13 +2128,13 @@ Who makes a quick appearance in Toy Story 3 as a garbage man, recognized only by
 Who needed to have jam applied to his nose in order to calm down in Alice in Wonderland?:
 - The Dormouse
 - dormouse
-Who played Ben Gates in Disney"s Film National Treasure?:
+Who played Ben Gates in Disney's Film National Treasure?:
 - Nicholas Cage
-Who played Jacob Marley"s ghost in "Mickey"s Christmas Carol"?:
+Who played Jacob Marley's ghost in "Mickey's Christmas Carol"?:
 - Goofy
-'Who played Will Turner in Pirates of the Caribbean: The Curse of the Black Pearl?':
+"Who played Will Turner in Pirates of the Caribbean: The Curse of the Black Pearl?":
 - Orlando Bloom
-Who prevents Gus from slipping the key into Cinderella"s room?:
+Who prevents Gus from slipping the key into Cinderella's room?:
 - Lucifer
 Who provided the voice for Bolt?:
 - John Travolta
@@ -2144,17 +2144,17 @@ Who provided the voice of Mulan?:
 - Ming-Na Wen
 - ming na wen
 - mingna wen
-'Who says: "Teenagers. You give them an inch, they"ll swim all over you."?':
+"Who says: \"Teenagers. You give them an inch, they'll swim all over you.\"?":
 - Sebastian
 Who sent Aladdin into the Cave of Wonders?:
 - Jafar
-Who sings the line, "If I were to truly be myself, I would break my family"s heart"?:
+Who sings the line, 'If I were to truly be myself, I would break my family's heart'?:
 - Mulan
 Who turns out to be the father of Buzz Light Year from Toy Story?:
 - Emperor Zurg
 Who wants to destroy Toontown in Who Framed Roger Rabbit?:
 - Judge Doom
-Who was Princess Aurora"s father?:
+Who was Princess Aurora's father?:
 - King Stefan
 Who was the alter ego of Don Diego de la Vega?:
 - Zorro
@@ -2171,9 +2171,9 @@ Who was the leader of the Huns in Mulan?:
 - shan yu
 Who was the second dwarf Snow White kissed on his way to work?:
 - Bashful
-Who was the star of Walt Disney"s fourth animated feature?:
+Who was the star of Walt Disney's fourth animated feature?:
 - Dumbo
-Who was the voice of Iago in "Aladdin"?:
+Who was the voice of Iago in 'Aladdin'?:
 - Gilbert Gottfried
 Who won the cross-country race in the animated short Barnyard Olympics?:
 - Mickey Mouse

--- a/redbot/trivia/lists/dota2abilities.yaml
+++ b/redbot/trivia/lists/dota2abilities.yaml
@@ -111,13 +111,13 @@ What ability is this? http://i.imgur.com/5VYGT2S.png:
 What ability is this? http://i.imgur.com/5lkslhd.png:
 - Ice Blast
 What ability is this? http://i.imgur.com/5mUEdUT.png:
-- Fiend"s Grip
+- Fiend's Grip
 What ability is this? http://i.imgur.com/5mYgGEw.png:
 - Starstorm
 What ability is this? http://i.imgur.com/5oS4p6Z.png:
 - Chronosphere
 What ability is this? http://i.imgur.com/5oihonX.png:
-- Berserker"s Call
+- Berserker's Call
 What ability is this? http://i.imgur.com/5zbDixI.png:
 - Nether Ward
 What ability is this? http://i.imgur.com/63fjMat.png:
@@ -215,13 +215,13 @@ What ability is this? http://i.imgur.com/CD69R7d.png:
 What ability is this? http://i.imgur.com/CNmLmD7.png:
 - Mana Burn
 What ability is this? http://i.imgur.com/CSH4JMc.png:
-- Gravekeeper"s Cloak
+- Gravekeeper's Cloak
 What ability is this? http://i.imgur.com/CWHpnWs.png:
 - Stasis Trap
 What ability is this? http://i.imgur.com/CbvZ4aS.png:
 - Open Wounds
 What ability is this? http://i.imgur.com/CcspPBT.png:
-- Berserker"s Rage
+- Berserker's Rage
 What ability is this? http://i.imgur.com/Cgg4m1S.png:
 - Vengeance Aura
 What ability is this? http://i.imgur.com/CjmqL6c.png:
@@ -253,7 +253,7 @@ What ability is this? http://i.imgur.com/Du6xnAD.png:
 What ability is this? http://i.imgur.com/Dz7G2Ma.png:
 - Spell Shield
 What ability is this? http://i.imgur.com/E5xrzuV.png:
-- Winter"s Curse
+- Winter's Curse
 What ability is this? http://i.imgur.com/E80vySv.png:
 - Untouchable
 What ability is this? http://i.imgur.com/E96ZJl3.png:
@@ -299,7 +299,7 @@ What ability is this? http://i.imgur.com/Gtu2ZHW.png:
 What ability is this? http://i.imgur.com/GwUQMwn.png:
 - Static Remnant
 What ability is this? http://i.imgur.com/Gzl5hkS.png:
-- Thundergod"s Wrath
+- Thundergod's Wrath
 What ability is this? http://i.imgur.com/H0eo0j3.png:
 - Caustic Finale
 What ability is this? http://i.imgur.com/H8rCDYl.png:
@@ -309,7 +309,7 @@ What ability is this? http://i.imgur.com/HG378HE.png:
 What ability is this? http://i.imgur.com/HJUyVQ2.png:
 - Unrefined Fireblast
 What ability is this? http://i.imgur.com/Hjrd8PX.png:
-- Nature"s Call
+- Nature's Call
 What ability is this? http://i.imgur.com/I2NvxE1.png:
 - Enchant Totem
 What ability is this? http://i.imgur.com/IAa1bDZ.png:
@@ -327,9 +327,9 @@ What ability is this? http://i.imgur.com/Ihhvhdx.png:
 What ability is this? http://i.imgur.com/Iu2brGN.png:
 - Avalanche
 What ability is this? http://i.imgur.com/J8iyl8n.png:
-- Fortune"s End
+- Fortune's End
 What ability is this? http://i.imgur.com/J97FNqg.png:
-- Greevil"s Greed
+- Greevil's Greed
 What ability is this? http://i.imgur.com/JJLAsfU.png:
 - Powershot
 What ability is this? http://i.imgur.com/JVJs8VI.png:
@@ -341,7 +341,7 @@ What ability is this? http://i.imgur.com/JvHLhJm.png:
 What ability is this? http://i.imgur.com/K38Heb1.png:
 - Split Shot
 What ability is this? http://i.imgur.com/K3WXdiC.png:
-- God"s Strength
+- God's Strength
 What ability is this? http://i.imgur.com/K3byHPk.png:
 - Rot
 What ability is this? http://i.imgur.com/K4WMuoN.png:
@@ -375,7 +375,7 @@ What ability is this? http://i.imgur.com/LiPZwBR.png:
 What ability is this? http://i.imgur.com/MRarlQa.png:
 - Ghost Walk
 What ability is this? http://i.imgur.com/MUv3Y5M.png:
-- Nature"s Attendants
+- Nature's Attendants
 What ability is this? http://i.imgur.com/MYC5guQ.png:
 - Shadow Dance
 What ability is this? http://i.imgur.com/Md4o99D.png:
@@ -395,7 +395,7 @@ What ability is this? http://i.imgur.com/N2Lg1Rx.png:
 What ability is this? http://i.imgur.com/N479xl0.png:
 - Macropyre
 What ability is this? http://i.imgur.com/NTLxr4U.png:
-- Reaper"s Scythe
+- Reaper's Scythe
 What ability is this? http://i.imgur.com/NXZtwjr.png:
 - Spirit Siphon
 What ability is this? http://i.imgur.com/NwrHpIF.png:
@@ -403,7 +403,7 @@ What ability is this? http://i.imgur.com/NwrHpIF.png:
 What ability is this? http://i.imgur.com/NxFVXPI.png:
 - Rearm
 What ability is this? http://i.imgur.com/O0qMgc4.png:
-- Sanity"s Eclipse
+- Sanity's Eclipse
 What ability is this? http://i.imgur.com/OFYHQxv.png:
 - Arcane Orb
 What ability is this? http://i.imgur.com/OLF3HYi.png:
@@ -487,7 +487,7 @@ What ability is this? http://i.imgur.com/RZWyifn.png:
 What ability is this? http://i.imgur.com/RcPV68i.png:
 - Exort
 What ability is this? http://i.imgur.com/RrTFspK.png:
-- Berserker"s Rage
+- Berserker's Rage
 What ability is this? http://i.imgur.com/S885568.png:
 - Void
 What ability is this? http://i.imgur.com/SJ0ae9Z.png:
@@ -497,7 +497,7 @@ What ability is this? http://i.imgur.com/SPqUual.png:
 What ability is this? http://i.imgur.com/SwcSLVf.png:
 - Drunken Brawler
 What ability is this? http://i.imgur.com/T5jvTy0.png:
-- Fate"s Edict
+- Fate's Edict
 What ability is this? http://i.imgur.com/TAqbyTQ.png:
 - Activate Fire Remnant
 What ability is this? http://i.imgur.com/TYIYW4D.png:
@@ -814,7 +814,7 @@ What ability is this? http://i.imgur.com/lS7P0QI.png:
 What ability is this? http://i.imgur.com/lUURpuL.png:
 - Lunar Blessing
 What ability is this? http://i.imgur.com/liSYifa.png:
-- Nature"s Guise
+- Nature's Guise
 What ability is this? http://i.imgur.com/m6s6gTu.png:
 - Doppelganger
 What ability is this? http://i.imgur.com/mIV1Ekb.png:
@@ -842,7 +842,7 @@ What ability is this? http://i.imgur.com/nYi9uXc.png:
 What ability is this? http://i.imgur.com/nYiXreU.png:
 - Spirits
 What ability is this? http://i.imgur.com/najZXYr.png:
-- Berserker"s Blood
+- Berserker's Blood
 What ability is this? http://i.imgur.com/nfMltKz.png:
 - Shukuchi
 What ability is this? http://i.imgur.com/niWP4HN.png:

--- a/redbot/trivia/lists/dota2items.yaml
+++ b/redbot/trivia/lists/dota2items.yaml
@@ -35,7 +35,7 @@ What item is this? http://i.imgur.com/4EIKWON.png:
 What item is this? http://i.imgur.com/5dfDXym.png:
 - Aegis of the Immortal
 What item is this? http://i.imgur.com/5eeAXJC.png:
-- Aghanim"s Scepter
+- Aghanim's Scepter
 What item is this? http://i.imgur.com/5hZUcQQ.png:
 - Magic Wand
 What item is this? http://i.imgur.com/6Bj6Eiz.png:
@@ -51,7 +51,7 @@ What item is this? http://i.imgur.com/77S9U75.png:
 What item is this? http://i.imgur.com/7MQvg5g.png:
 - Boots of Travel 1
 What item is this? http://i.imgur.com/7Sp3W66.png:
-- Eul"s Scepter of Divinity
+- Eul's Scepter of Divinity
 What item is this? http://i.imgur.com/7SvVqRK.png:
 - Ring of Basilius (Active)
 - Ring of Basilius Active
@@ -188,7 +188,7 @@ What item is this? http://i.imgur.com/NkYZgr5.png:
 What item is this? http://i.imgur.com/Nl1u43a.png:
 - Echo Sabre
 What item is this? http://i.imgur.com/NrEdGsn.png:
-- Heaven"s Halberd
+- Heaven's Halberd
 What item is this? http://i.imgur.com/O4E1IR5.png:
 - Desolator
 What item is this? http://i.imgur.com/Ov7Vjle.png:
@@ -224,7 +224,7 @@ What item is this? http://i.imgur.com/V6kBeNh.png:
 What item is this? http://i.imgur.com/VFdPRUD.png:
 - Divine Rapier
 What item is this? http://i.imgur.com/VNmfB2T.png:
-- Shiva"s Guard
+- Shiva's Guard
 What item is this? http://i.imgur.com/VtNBM6g.png:
 - Animal Courier (Radiant)
 - Courier Radiant
@@ -254,7 +254,7 @@ What item is this? http://i.imgur.com/ZjhX5T8.png:
 What item is this? http://i.imgur.com/ZoIjUQF.png:
 - Dagon 4
 What item is this? http://i.imgur.com/aQ4ZSIi.png:
-- Sage"s Mask
+- Sage's Mask
 What item is this? http://i.imgur.com/atVJCS9.png:
 - Rod of Atos
 What item is this? http://i.imgur.com/bdVdrp3.png:
@@ -303,7 +303,7 @@ What item is this? http://i.imgur.com/hF3mjT1.png:
 What item is this? http://i.imgur.com/haXACou.png:
 - Power Treads
 What item is this? http://i.imgur.com/hze6GhN.png:
-- Poor Man"s Shield
+- Poor Man's Shield
 - PMS
 What item is this? http://i.imgur.com/iYzaR71.png:
 - Bottle (Full)
@@ -346,7 +346,7 @@ What item is this? http://i.imgur.com/nXn8KhO.png:
 What item is this? http://i.imgur.com/oKhuvbG.png:
 - Gauntlets of Strength
 What item is this? http://i.imgur.com/oLgqHaR.png:
-- Linken"s Sphere
+- Linken's Sphere
 What item is this? http://i.imgur.com/oentyyC.png:
 - Null Talisman
 What item is this? http://i.imgur.com/owoQWNV.png:
@@ -395,7 +395,7 @@ What item is this? http://i.imgur.com/xemeapR.png:
 What item is this? http://i.imgur.com/xw7yLKw.png:
 - Broadsword
 What item is this? http://i.imgur.com/y8uW7V1.png:
-- Vladimir"s Offering
+- Vladimir's Offering
 What item is this? http://i.imgur.com/ycsTV7m.png:
 - Enchanted Mango
 What item is this? http://i.imgur.com/z2OZqwa.png:

--- a/redbot/trivia/lists/elements.yaml
+++ b/redbot/trivia/lists/elements.yaml
@@ -139,7 +139,7 @@ What is the element symbol of "Niobium"?:
 What is the element symbol of "Nitrogen"?:
 - N
 What is the element symbol of "Nobelium"?:
-- 'No'
+- "No"
 What is the element symbol of "Oganesson"?:
 - Og
 What is the element symbol of "Osmium"?:

--- a/redbot/trivia/lists/entertainment.yaml
+++ b/redbot/trivia/lists/entertainment.yaml
@@ -1,8 +1,8 @@
-'"He"s So Fine", "One Fine Day" and "A Love So Fine" where hits for what fine group?':
+"\"He's So Fine\", \"One Fine Day\" and \"A Love So Fine\" where hits for what fine group?":
 - The Chiffons
-'"Joy to the World" was a hit in 1971 for what band with three lead vocalists?':
+"\"Joy to the World\" was a hit in 1971 for what band with three lead vocalists?":
 - Three Dog Night
-'"White Room" was a hit off which Eric Clapton album?':
+"'White Room' was a hit off which Eric Clapton album?":
 - Cream
 A __________ helps to set and maintain your tempo while playing?:
 - Metronome
@@ -14,15 +14,15 @@ About which family are the Godfather films?:
 - Corleone
 Actor __________ Nimoy?:
 - Leonard
-'Actor: _______ Borgnine?':
+"Actor: _______ Borgnine?":
 - Ernest
-'Actor: __________ Savalas?':
+"Actor: __________ Savalas?":
 - Telly
 After who was Deana Carter named?:
 - Dean Martin
 Alvin & Simon had a brother called ____?:
 - Theodore
-Alvin & Simon"s brother was ________?:
+Alvin & Simon's brother was ________?:
 - Theo
 An Andy Panda cartoon gave birth to a famous, cantankerous bird. Name him?:
 - Woody woodpecker
@@ -40,13 +40,13 @@ As who is Terry Bollea known?:
 - Hulk Hogan
 At the end of "Planet of the Apes" what protruded from the rocks?:
 - Statue of Liberty
-'Band: " _________ And the Bad Seeds"?':
+"Band: \" _________ And the Bad Seeds\"?":
 - Nick Cave
-'Band: Elvis Costello and the ___________ ?':
+"Band: Elvis Costello and the ___________ ?":
 - Attractions
 Barbara Streisand was the female lead in "Hello, Dolly". Who was the male lead?:
 - Walter Matthau
-Beethoven"s Sixth Symphony shares it"s popular name with a method of animal farming. What is it?:
+Beethoven's Sixth Symphony shares it's popular name with a method of animal farming. What is it?:
 - Pastoral
 Before Olive Oyl met Popeye she was engaged to someone. Who was he?:
 - Ham Gravy
@@ -54,46 +54,46 @@ Before being married to Pamela Anderson what other famous actress was Tommy Lee 
 - Heather Locklear
 Benny and Cecil were at odds with whom?:
 - John
-Besides "Auld Lang Syne" and "For He"s a Jolly Good Fellow", what is the most frequently sung song in English?:
+Besides "Auld Lang Syne" and "For He's a Jolly Good Fellow", what is the most frequently sung song in English?:
 - Happy Birthday
-Besides the Stones, which group had the longest touring career until the founder"s death in 1995?:
+Besides the Stones, which group had the longest touring career until the founder's death in 1995?:
 - The Grateful Dead
-Bill Justis was a studio musician when he recorded this "sloppy" instrumental in october 1957?:
+Bill Justis was a studio musician when he recorded this 'sloppy' instrumental in october 1957?:
 - Raunchy
 Bugs always finds himself at the wrong end of a gun, usually toted by either Elmer Fudd or who?:
 - Yosemite Sam
 Casper the Friendly Ghost frolicked with which witch?:
 - Wendy
 Charles Boyer inspired a cartoon skunk. Who?:
-- Pep� Le Pew
+- PepÃ© Le Pew
 - Pepe le Pew
 Charles Laughton played Quasimodo in this film?:
 - The Hunchback of Notre Dame
-'Composer of the Brandenburg Concerti: J.S. ____?':
+"Composer of the Brandenburg Concerti: J.S. ____?":
 - Bach
 Country singer Vince ____?:
 - Gill
-Crosby, Stills and Nash"s debut album included a song about a girl and the colour of her eyes. Name that song?:
+Crosby, Stills and Nash's debut album included a song about a girl and the colour of her eyes. Name that song?:
 - Sweet Judy Blue Eyes
 Darth Vader was the villan in the movie, "____ Wars"?:
 - Star
-'Famous Phrase: Who knows The ______?':
+"Famous Phrase: Who knows The ______?":
 - Shadow
 Fat Albert and friends was created by ______ ?:
 - Bill Cosby
 Fifties rock "n" roll was revived by what greased hair, T-shirted, TV frequenting group?:
 - Sha Na Na
-'Film Title: An Officer and a _________?':
+"Film Title: An Officer and a _________?":
 - Gentleman
-'Film Title: Fahrenheit ________?':
+"Film Title: Fahrenheit ________?":
 - 451
-'Film Title: The Last Days of _________. (a city)?':
+"Film Title: The Last Days of _________. (a city)?":
 - Pompeii
-'Film Title: ______ (a number) Leagues Under the Sea.?':
+"Film Title: ______ (a number) Leagues Under the Sea.?":
 - 20000
-- '20.000'
+- "20.000"
 - 20,000
-For which ad campaign was the line "I can"t believe I ate the whole thing" used?:
+For which ad campaign was the line 'I can't believe I ate the whole thing' used?:
 - Alka Seltzer
 For which cartoon character was Beethoven a favourite composer?:
 - Shroeder
@@ -105,18 +105,18 @@ Formerly with Spencer Davis, he went on to form Traffic with Dave Mason. He is?:
 - Steve Winwood
 French impressionist Claude _______?:
 - Debussy
-From what platform does the "Chattanooga Choo Choo" leave Pennsylvania station?:
+From what platform does the 'Chattanooga Choo Choo' leave Pennsylvania station?:
 - 29
-From where was Ricky in "I Love Lucy"?:
+From where was Ricky in 'I Love Lucy'?:
 - Cuba
-From which station does the "Chattanooga Choo Choo" leave?:
+From which station does the 'Chattanooga Choo Choo' leave?:
 - Pennsylvania station
 - Pennsylvania
 Gadzookie has a large, green friend. Who is he?:
 - Godzilla
 Girlfriend of Lex Luther II?:
 - Supergirl
-Green Lantern"s alter ego?:
+Green Lantern's alter ego?:
 - Hal jordan
 Hang On Sloopy was the official rock song of which band?:
 - Ohio
@@ -136,7 +136,7 @@ He was the voice of draco the dragon in the movie Dragonheart?:
 - Sean Connery
 He wrote the operas "The Magic Flute" and "The Marriage of Figaro"?:
 - Wolfgang Amadeus Mozart
-'His films include: Giant, Written on the Wind, and A Farewell to Arms?':
+"His films include: Giant, Written on the Wind, and A Farewell to Arms?":
 - Rock Hudson
 His films include?:
 - Spartacus, The Vikings, and Ulysses.?
@@ -150,7 +150,7 @@ How many flats are in the key of B flat major?:
 How many freckles did Howdy Doody have?:
 - Forty eight
 - 48
-How many members are in the "fairfield four"?:
+How many members are in the 'fairfield four'?:
 - Five
 How many semitones are there in an octave?:
 - 12
@@ -175,34 +175,34 @@ How old was Shirley Temple when she made her last film?:
 - 21
 Ian Gillain is the singer for this legendary band?:
 - Deep Purple
-In "Coronation Street", who is Ken and Denise"s son?:
-- Daniel
 In "Gone With the Wind", Scarlett regains her wealth by investing in what type of business?:
 - Sawmill
-In "La Traviata", what does Violetta sing?:
+In 'Coronation Street', who is Ken and Denise's son?:
+- Daniel
+In 'La Traviata', what does Violetta sing?:
 - Sempre Libera
-In "La Traviata", who sings "Sempre Libera"?:
+In 'La Traviata', who sings 'Sempre Libera'?:
 - Violetta
-In "The Shining" what was the child"s imaginary friend"s name (the one who told him things that were going to happen)?:
+In 'The Shining' what was the child's imaginary friend's name (the one who told him things that were going to happen)?:
 - Tony
-In 1958, who had a pop music hit with "Willie and the Hand Jive"?:
+In 1958, who had a pop music hit with 'Willie and the Hand Jive'?:
 - Johnny Otis
 In 1962 Chubby Checker had a hit with a pop song and novelty dance that remains famous today. What was that dance?:
 - The Twist
-In 1968, who released "Carnival of life" and "Recital"?:
+In 1968, who released 'Carnival of life' and 'Recital'?:
 - Lee Michaels
 In 1975 Jack Nicholson won the best actor Oscar for his role in this film.?:
-- One Flew Over the Cuckoo"s Nest
+- One Flew Over the Cuckoo's Nest
 - one flew over the cuckoos nest
-In 1981, who won song of the year with "Sailing"?:
+In 1981, who won song of the year with 'Sailing'?:
 - Christopher Cross
-In 1987, who released her second album "Solitude Standing"?:
+In 1987, who released her second album 'Solitude Standing'?:
 - Suzanne Vega
-In a 1976 release, who wanted to "fly like an eagle"?:
+In a 1976 release, who wanted to 'fly like an eagle'?:
 - Steve Miller Band
-In late 1957, Buddy Holly"s solo release "Peggy Sue" challenged which song recorded with The Crickets?:
+In late 1957, Buddy Holly's solo release 'Peggy Sue' challenged which song recorded with The Crickets?:
 - Oh Boy
-In the "Nightmare On Elm Street" films, who played Freddy Krueger?:
+In the 'Nightmare On Elm Street' films, who played Freddy Krueger?:
 - Robert Englund
 In the 1996 version of "Romeo and Juliet", who played Juliet?:
 - Claire Danes
@@ -210,33 +210,33 @@ In the 70s Hit Captain Scarlet and the Mysterons what is the name of the company
 - Spectrum
 In the Gene Pitney how many hours was it from Tulsa?:
 - 24
-In the TV series "Seinfeld", who does Michael Richards play?:
+In the TV series 'Seinfeld', who does Michael Richards play?:
 - Kramer
-In the TV series "Seinfeld", who plays Kramer?:
+In the TV series 'Seinfeld', who plays Kramer?:
 - Michael Richards
-In the TV series "The Brady Bunch", what was Cindy"s toy doll"s name?:
+In the TV series 'The Brady Bunch', what was Cindy's toy doll's name?:
 - Kitty Carryall
-In the TV series "The Fall Guy", who did Lee Majors play?:
+In the TV series 'The Fall Guy', who did Lee Majors play?:
 - Colt Seavers
-In the TV series "The Fall Guy", who played Colt Seavers?:
+In the TV series 'The Fall Guy', who played Colt Seavers?:
 - Lee Majors
-In the TV sitcom "Married With Children", what is the dog"s name?:
+In the TV sitcom 'Married With Children', what is the dog's name?:
 - Buck
-In the cartoons who was Hokie Wolf"s sidekick?:
+In the cartoons who was Hokie Wolf's sidekick?:
 - Ding
-In the film "American Hot Wax", who did Jay Leno play?:
+In the film 'American Hot Wax', who did Jay Leno play?:
 - Mookie
-In the film "American Hot Wax", who played the "Mookie"?:
+In the film 'American Hot Wax', who played the 'Mookie'?:
 - Jay Leno
-In the film "Hackers", how old was "zero_kool" when he was first arrested?:
+In the film 'Hackers', how old was 'zero_kool' when he was first arrested?:
 - Eleven
 - 11
-In the film "Pretty Woman", for who was Goldie Hawn the body double?:
+In the film 'Pretty Woman', for who was Goldie Hawn the body double?:
 - Julia Roberts
-In the film "The Day Of The Jackal", who played the Jackal?:
+In the film 'The Day Of The Jackal', who played the Jackal?:
 - Edward Fox
-In this 1968 film the husband of an unsuspecting young wife becomes involved with a witch"s coven?:
-- Rosemary"s Baby
+In this 1968 film the husband of an unsuspecting young wife becomes involved with a witch's coven?:
+- Rosemary's Baby
 In what city does Fat Albert live?:
 - Philadelphia
 In what did someone squish her hands to make the sound of E.T. walking?:
@@ -249,11 +249,11 @@ In which Disney movie is the song "So This Is Love"?:
 - Cinderella
 In which London recording studios did The Beatles record the majority of their work?:
 - Abbey Road
-In which Verdi opera does Violetta sing "Sempre Libera"?:
+In which Verdi opera does Violetta sing 'Sempre Libera'?:
 - La Traviata
 In which film did Henry Fonda play a fallen priest?:
 - The Fugitive
-In which film did Jay Leno play "Mookie"?:
+In which film did Jay Leno play 'Mookie'?:
 - American Hot Wax
 In which film did Paul Newman and Robert Redford hold hands and jump into a river?:
 - Butch Cassidy and the Sundance Kid
@@ -283,15 +283,15 @@ Mickey Mouse is known as what in Italy?:
 - Topolino
 Miss Buckley is secretary to what commanding officer?:
 - General Halftrack
-Name Alley Oop"s girl friend?:
+Name Alley Oop's girl friend?:
 - Oola
-Name Donald Duck"s girlfriend?:
+Name Donald Duck's girlfriend?:
 - Daisy Duck
-Name Hagar the Horrible"s dog?:
+Name Hagar the Horrible's dog?:
 - Snert
-Name Jerry Garcia"s long lived group?:
+Name Jerry Garcia's long lived group?:
 - The Grateful Dead
-Name Li"l Abner"s favorite Indian drink?:
+Name Li'l Abner's favorite Indian drink?:
 - Kickapoo joy juice
 Name the Disney cartoon in which the character "Belle" appears?:
 - Beauty and the Beast
@@ -299,7 +299,7 @@ Name the European hit, now an animated series about underwater people?:
 - The Snorks
 Name the actor who played the leading role in "The Good, the Bad, and the Ugly"?:
 - Clint Eastwood
-Name the apartments the Jetson"s live in?:
+Name the apartments the Jetson's live in?:
 - The Skypad Apartments
 Name the band - songs include "Add It Up, Blister In The Sun, Kiss Off"?:
 - Violet Femmes
@@ -317,17 +317,17 @@ Name the band - songs include "Sex & Drugs & Rock & Roll, I Want To Be Straight"
 - Ian Drury and The Blockheads
 Name the band - songs include "Strange Brew, White Room"?:
 - Cream
-'Name the band: songs include "Doctor Doctor, Hold Me Now, Don"t Mess With Dr Dream"?':
+"Name the band: songs include \"Doctor Doctor, Hold Me Now, Don't Mess With Dr Dream\"?":
 - Thompson Twins
-'Name the band: songs include "Forgiven Not Forgotten, Runaway"?':
+"Name the band: songs include \"Forgiven Not Forgotten, Runaway\"?":
 - The Coors
-'Name the band: songs include "Get Down & Get With It, Mama We"re All Crazy Now"?':
+"Name the band: songs include \"Get Down & Get With It, Mama We're All Crazy Now\"?":
 - Slade
-'Name the band: songs include "Heart of Glass, The Tide is High"?':
+"Name the band: songs include \"Heart of Glass, The Tide is High\"?":
 - Blondie
-'Name the band: songs include "Let"s Stick Together, The Price of Love"?':
+"Name the band: songs include \"Let's Stick Together, The Price of Love\"?":
 - Bryan Ferry
-'Name the band: songs include "Psycho Killer, Road To Nowhere"?':
+"Name the band: songs include \"Psycho Killer, Road To Nowhere\"?":
 - Talking Heads
 Name the dog in the Yankee Doodle cartoons?:
 - Chopper
@@ -348,70 +348,70 @@ Nick Nolte and Eddie Murphy star in this 1982 film?:
 Number of new Supermen after his "death"?:
 - Four
 - 4
-On "Dragnet", who played officer Bill Gannon?:
+On 'Dragnet', who played officer Bill Gannon?:
 - Harry Morgan
-On "The Lucy Show", who played Vivian Bagley?:
+On 'The Lucy Show', who played Vivian Bagley?:
 - Vivian Vance
-On what LP Cover can we read the words "Welcome Rolling Stones"?:
-- Sergeant Pepper�s Lonely Hearts Club Band
+On what LP Cover can we read the words 'Welcome Rolling Stones'?:
+- Sergeant Pepper's Lonely Hearts Club Band
 On what T.V. show could Tom Terrific be found?:
 - Captain kangaroo
 Pancho was whose faithful sidekick?:
 - Cisco Kid
 Photographer for Daily Planet?:
 - Jimmy olsen
-Popeye"s chief adversary has two names, Bluto and ______?:
+Popeye's chief adversary has two names, Bluto and ______?:
 - Brutus
 Porky Pig had a girlfriend named _______?:
 - Petunia
 Porky Pig had a girlfriend named ________?:
 - Petunia
-'R. Kelly sings: "If I can see it then I can do it, if I just believe it, there"s nothing to it". What"s the song title?':
+"R. Kelly sings: 'If I can see it then I can do it, if I just believe it, there's nothing to it'. What's the song title?":
 - I Believe I Can Fly
-Randy Travis said his love was "deeper than the ______"?:
+Randy Travis said his love was 'deeper than the ______'?:
 - Holler
-Richard Strauss" majestic overture "Also Sprach Zarathustra" was the theme music for which Stanley Kubrick film?:
-- '2001: A Space Odyessy'
+Richard Strauss' majestic overture "Also Sprach Zarathustra" was the theme music for which Stanley Kubrick film?:
+- "2001: A Space Odyessy"
 Rolling Stones first hit was written by what group?:
 - The Beatles
 Russian modernist Igor _________?:
 - Stravinsky
 Savage Garden took 13 nominations and 10 wins at which awards?:
 - ARIA awards
-'Secret Identities: Arthur Curry?':
+"Secret Identities: Arthur Curry?":
 - Aquaman
-'Secret Identities: Boston Brand?':
+"Secret Identities: Boston Brand?":
 - Deadman
-'Secret Identities: Clark Kent?':
+"Secret Identities: Clark Kent?":
 - Superman
-'Secret Identities: Cliff Steele?':
+"Secret Identities: Cliff Steele?":
 - Robotman
-'Secret Identities: Jay Garrick?':
+"Secret Identities: Jay Garrick?":
 - The flash
 - Flash
-'Secret Identities: Jim Corrigan?':
+"Secret Identities: Jim Corrigan?":
 - The spectre
 - spectre
-'Secret Identities: Jonn Jonzz?':
+"Secret Identities: Jonn Jonzz?":
 - Martian manhunter
-'Secret Identities: Kay Challis?':
+"Secret Identities: Kay Challis?":
 - Crazy jane
-'Secret Identities: Wally West?':
+"Secret Identities: Wally West?":
 - The Flash
 - Flash
 She played Lois Lane in the 1978 film version of "Superman"?:
 - Margot Kidder
-She played a Polish refugee in "Sophie"s Choice"?:
+She played a Polish refugee in "Sophie's Choice"?:
 - Meryl Streep
-She played the lead role in "Coal Miner"s Daughter"?:
+She played the lead role in "Coal Miner's Daughter"?:
 - Sissy Spacek
 She starred in the 1952 film, "Niagara"?:
 - Marilyn Monroe
 Singing without instrumental back up is called what?:
 - a capella
-Sung by Robert Palmer, "______ to love"?:
+Sung by Robert Palmer, '______ to love'?:
 - Addicted
-Term meaning "to gradually decrease in volume"?:
+Term meaning 'to gradually decrease in volume'?:
 - Decrescendo
 Tess Trueheart married which plainclothes detective?:
 - Dick Tracy
@@ -419,7 +419,7 @@ The Hard Rock Cafe is named after a song by what band?:
 - The Doors
 The Who had a guiness world record for what?:
 - Loudest Band
-The Who"s rock musical stars Elton John. It"s called ________?:
+The Who's rock musical stars Elton John. It's called ________?:
 - Tommy
 The director of Jaws, Raiders of the Lost Ark?:
 - Stephen spielberg
@@ -427,7 +427,7 @@ The eldest sister in the TV Series Charmed, is played by who?:
 - Shannon Doherty
 The film "Crouching Tiger, Hidden Dragon" takes place in which dynasty?:
 - Ching
-The film "The Wizard Of ______"?:
+The film 'The Wizard Of ______'?:
 - Oz
 The first 18 minutes of this movie is black and white and then turns to color?:
 - Wizard of Oz
@@ -442,17 +442,17 @@ The song "Matchmaker, Matchmaker" came from which musical play?:
 - Fiddler On The Roof
 The standard major scale is also known as the _______ mode?:
 - Ionian
-The theme tune for "Monty Python"s Flying Circus" was written by which composer?:
+The theme tune for 'Monty Python's Flying Circus' was written by which composer?:
 - John Philip Sousa
 The two rival gangs in "West Side Story" were the Sharks and the _________.?:
 - Jets
 This 1974 film started a run of nostalgia culminating in the TV series "Happy Days"?:
 - American Graffiti
-This actress appeared in "St. Elmo"s Fire", "The Scarlet Letter", and "Striptease"?:
+This actress appeared in "St. Elmo's Fire", "The Scarlet Letter", and "Striptease"?:
 - Demi Moore
-This band"s highly original video for "Whip it," characterized by red flower pot hats was criticized for being both sado-masochistic and racist?:
+This band's highly original video for "Whip it," characterized by red flower pot hats was criticized for being both sado-masochistic and racist?:
 - Devo
-This electronic instrument"s creator was surnamed Moog, and his models are worth a fortune! Other brands include Roland, Korg, and Casio?:
+This electronic instrument's creator was surnamed Moog, and his models are worth a fortune! Other brands include Roland, Korg, and Casio?:
 - Synthesizer
 This female artist enjoyed sucess on both popular and country & western stations with such tunes as "Let Me Be There" and "Have You Never Been Mellow"?:
 - Olivia Newton-John
@@ -481,8 +481,8 @@ This term means to play moderately slow and gracefully?:
 - Adagio
 This term means to play smoothly?:
 - Legato
-This was the Beatle"s first film?:
-- A Hard Day"s Night
+This was the Beatle's first film?:
+- A Hard Day's Night
 - a hard days night
 This was the first 3-D film?:
 - Bwana Devil
@@ -490,13 +490,13 @@ This was the first fully synchronized sound cartoon?:
 - Steamboat Willie
 This was the sequel to "The Empire Strikes Back"?:
 - Return of the Jedi
-Through 1963 this duo"s total record sales exceeded 18 million with successes including "Cathy"s Clown" and "Wake Up Little Suzie"?:
+Through 1963 this duo's total record sales exceeded 18 million with successes including "Cathy's Clown" and "Wake Up Little Suzie"?:
 - The Everly Brothers
 Tinky-Winky, Dipsy, Laa Laa, and Po are known as what?:
 - The Teletubbies
 Tippi Hedren is best known for her lead role in which film?:
 - The Birds
-To which elemetary school did TV"s "Brady Bunch" go?:
+To which elemetary school did TV's 'Brady Bunch' go?:
 - Dixie Canyon Elementary
 Turn, Side and Why does it always rain on me are all songs from what UK band?:
 - Travis
@@ -510,11 +510,11 @@ What Procol Harem tune was based on the Bach cantata "Sleepers Awake"?:
 - A Whiter Shade of Pale
 What TV series from 1970-1974 starred Susan Dey?:
 - Partridge Family
-'What actor appeared in all three of these films: Straw Dogs, Midnight Cowboy, and The Graduate?':
+"What actor appeared in all three of these films: Straw Dogs, Midnight Cowboy, and The Graduate?":
 - Dustin Hoffman
 What actress has received the most Oscar nominations?:
 - Katherine Hepburn
-What actress"s real name was Frances Gumm?:
+What actress's real name was Frances Gumm?:
 - Judy Garland
 What album holds the world record for copies sold?:
 - Thriller
@@ -522,23 +522,23 @@ What are the separators on a guitar neck called?:
 - Frets
 What band recorded the 1978 hit album "Briefcase Full of Blues"?:
 - The Blues Brothers
-What came out of Milton"s head?:
+What came out of Milton's head?:
 - Steam
 What character did Tex Avery first create upon arriving at MGM?:
 - Screwball squirrel
-What character was banned in Finland because he didn"t wear pants?:
+What character was banned in Finland because he didn't wear pants?:
 - Donald Duck
 What city do Batman and Robin patrol?:
 - Gotham City
 What city is also known as Music City, U.S.A.?:
 - Nashville
-What city"s police force did Charlie Chan work with?:
+What city's police force did Charlie Chan work with?:
 - Honolulu
-What classic rock band sang the song "Paint It, Black"?:
+What classic rock band sang the song 'Paint It, Black'?:
 - Rolling Stones
-What color was Bullitt"s car?:
+What color was Bullitt's car?:
 - Green
-What comic strip character is Beetle Bailey"s sister?:
+What comic strip character is Beetle Bailey's sister?:
 - Lois
 What composer was working on his 10th symphony at the time of his death?:
 - Ludwig van Beethoven
@@ -554,7 +554,7 @@ What did Dagwood give up to marry Blondie?:
 - A family inheritance
 - family inheritance
 - inheritance
-What did Dorothy"s house land on in "The Wizard Of Oz"?:
+What did Dorothy's house land on in 'The Wizard Of Oz'?:
 - The Wicked Witch of the West
 - wicked witch of the west
 What did Dr. David Banner become when he got angry?:
@@ -569,13 +569,13 @@ What did Sheryl Crow do before she became a singer?:
 - Teach
 What did TVs IMF stand for?:
 - Impossible Mission Forces
-What do the initials B.B. stand for in B.B. King"s name?:
+What do the initials B.B. stand for in B.B. King's name?:
 - Blues Boy
 What do the initials of the band NIN stand for?:
 - Nine Inch Nails
 What does the Italian term "poco a poco" mean?:
 - Little by little
-What does the term "DJ" mean?:
+What does the term 'DJ' mean?:
 - Disc Jockey
 What famous animal character called "Skull Island" home?:
 - King Kong
@@ -589,59 +589,59 @@ What film featured a cat named Mr. Bigglesworth?:
 - Austin Powers
 What film is generally considered the worst film ever made?:
 - Attack of the Killer Tomatoes
-What film marked James Cagney"s return to the screen after 20 years?:
+What film marked James Cagney's return to the screen after 20 years?:
 - Ragtime
 What film starred Helen Hunt, Cary Elwes and Bill Paxton?:
 - Twister
-What film starred Rosie O"Donnell, Rita Wilson and Meg Ryan?:
+What film starred Rosie O'Donnell, Rita Wilson and Meg Ryan?:
 - Sleepless in Seattle
 What group refused to have their pictures taken while they were not in their makeup?:
 - KISS
-What group"s biggest-ever hit was Be My Baby?:
+What group's biggest-ever hit was Be My Baby?:
 - The Ronettes
-What hardcore rock group sings, "Blind" and "Clown"?:
+What hardcore rock group sings, 'Blind' and 'Clown'?:
 - Korn
 What instrument are you playing when you perform a rim shot?:
 - Drums
 What instrument does Woody Allen play?:
 - Clarinet
-What is Batman"s butler Alfred"s last name?:
+What is Batman's butler Alfred's last name?:
 - Pennyworth
-What is Blondie"s maiden name?:
+What is Blondie's maiden name?:
 - Oop
-What is Cape Town"s major choir called?:
+What is Cape Town's major choir called?:
 - Cape Town Philharmonia Choir
-What is Cher"s maiden name?:
+What is Cher's maiden name?:
 - Sarkassian
-What is Dennis the Menace"s last name?:
+What is Dennis the Menace's last name?:
 - Mitchell
-What is Dennis the Menace"s surname?:
+What is Dennis the Menace's surname?:
 - Mitchell
-What is Elton John"s real name?:
+What is Elton John's real name?:
 - Reginald Dwight
-What is Hawkeye"s full name in M.A.S.H.?:
+What is Hawkeye's full name in M.A.S.H.?:
 - Benjamin Franklin Pierce
-What is Hulk Hogan"s real name?:
+What is Hulk Hogan's real name?:
 - Terry Bollea
-What is Kenny G"s real surname?:
+What is Kenny G's real surname?:
 - Gorelick
-What is Peter Parker"s secret identity?:
+What is Peter Parker's secret identity?:
 - Spiderman
 What is Reginald Dwight known as?:
 - Elton John
-What is Smokey Stover"s job?:
+What is Smokey Stover's job?:
 - Fireman
-What is Super Chicken"s partners name?:
+What is Super Chicken's partners name?:
 - Fred
-What is Tina Turner"s real name?:
+What is Tina Turner's real name?:
 - Anne Mae Bullock
-What is Vanilla Ice"s real name?:
+What is Vanilla Ice's real name?:
 - Robert van Winkle
 What is a Hurdy-Gurdy?:
 - Fiddle
-What is a cello"s full name?:
+What is a cello's full name?:
 - Violoncello
-What is tattooed on Glen Campbell"s arm?:
+What is tattooed on Glen Campbell's arm?:
 - Dagger
 What is the Pink Panther in the Pink Pather film?:
 - A Diamond
@@ -649,34 +649,34 @@ What is the address of The Munsters?:
 - 1313 Mockingbird Lane
 What is the destination of the plane at the end of the film "Casablanca"?:
 - Lisbon
-What is the drummer"s name in "The Muppet Show"?:
+What is the drummer's name in 'The Muppet Show'?:
 - Animal
-What is the frog"s name in "The Muppet Show"?:
+What is the frog's name in 'The Muppet Show'?:
 - Kermit D Frog
 - Kermit
 What is the longest running musical in Broadway history?:
 - Cats
-What is the mother"s name in Family Circus?:
+What is the mother's name in Family Circus?:
 - Thelma
 What is the name given to the type of West Indian music made famous by artists such as Bob Marley and Peter Tosh?:
 - Reggae
-What is the name of Beetle Bailey"s sister?:
+What is the name of Beetle Bailey's sister?:
 - Lois
-What is the name of Duddley Do-Right"s horse?:
+What is the name of Duddley Do-Right's horse?:
 - Horse
-What is the name of Jaleel White"s character in the tv series "Family ties"?:
+What is the name of Jaleel White's character in the tv series 'Family ties'?:
 - Steve Urkel
-What is the name of Pierce Brosnan"s first James Bond film?:
+What is the name of Pierce Brosnan's first James Bond film?:
 - Goldeneye
-What is the name of Yogi Bear"s best freind?:
+What is the name of Yogi Bear's best freind?:
 - Boo Boo
-What is the name of the Family Circus"s dog?:
+What is the name of the Family Circus's dog?:
 - Barf
 What is the name of the Indian musical instrument made popular in western rock by The Beatles and Ravi Shankar?:
 - Sitar
 What is the name of the Volkswagen in the film, "The Love Bug"?:
 - Herbie
-What is the name of the film in which Steven Segal"s character dies?:
+What is the name of the film in which Steven Segal's character dies?:
 - Executive Decision
 What is the name of the rabbit in the film, "Bambi"?:
 - Thumper
@@ -688,11 +688,11 @@ What is the official birthplace of country music?:
 - Bristol
 What is the only X Rated film to have won the best film Oscar?:
 - Midnight Cowboy
-What is the sequel to the film "Every Which Way But Loose"?:
+What is the sequel to the film 'Every Which Way But Loose'?:
 - Every Which Way You Can
 What is the stage name of Greta Gustafson?:
 - Greta Garbo
-What is the term used for "slowly" in music?:
+What is the term used for 'slowly' in music?:
 - Lento
 What is the title of the 1996 sequel to "Terms of Endearment"?:
 - Morning Star
@@ -704,13 +704,13 @@ What kind of dog is Scooby Doo?:
 - Great dane
 What kind of eyes did the girl in "Lucy In The Sky With Diamonds" have?:
 - Kaleidoscope
-What license plate number is on the Volkswagon on the cover of The Beatles" "Abbey Road" Album?:
+What license plate number is on the Volkswagon on the cover of The Beatles' 'Abbey Road' Album?:
 - 281F
 What movie starred Nicholas Cage and John Travolta, one as a police officer, the other as a villain?:
 - Face Off
 What musical instrument did Jack Benny play?:
 - Violin
-What night club did Ricky work at on "I Love Lucy"?:
+What night club did Ricky work at on 'I Love Lucy'?:
 - The Tropicana
 What other well known singer shares the same birthday as Elvis Presley (Jan 8)?:
 - David Bowie
@@ -721,11 +721,11 @@ What song by Don McLean talks about the day Buddy Holly died?:
 What song did Aretha Franklin sing in "The Blues Brothers"?:
 - Think
 What song did Elton John and George Michael sing as a duet?:
-- Don"t Let The Sun Go Down On Me
+- Don't Let The Sun Go Down On Me
 - dont let the sun go down on me
-What song was originally "Good Morning To You" before the words were changed and it was published in 1935?:
+What song was originally 'Good Morning To You' before the words were changed and it was published in 1935?:
 - Happy Birthday To You
-What song"s words were changed and then published in 1935 as "Happy Birthday To You"?:
+What song's words were changed and then published in 1935 as 'Happy Birthday To You'?:
 - Good Morning To You
 What term is used for the speed at which a piece of music is played?:
 - Tempo
@@ -733,65 +733,65 @@ What two words are normally at the end of most movies?:
 - The End
 What type of plant does Broom Hilda sell?:
 - Venus flytrap
-What was "Rocky"s" last name?:
+What was "Rocky's" last name?:
 - Balboa
-What was Ben Stiller"s character called in "Mystery Men"?:
+What was Ben Stiller's character called in 'Mystery Men'?:
 - Mr. Furious
 - mr furious
-What was Betty Grable"s nickname?:
+What was Betty Grable's nickname?:
 - The Legs
-What was Betty Rubble"s maiden name (The Flintstones)?:
+What was Betty Rubble's maiden name (The Flintstones)?:
 - Mcbricker
-What was Citizen Kane"s dying word?:
+What was Citizen Kane's dying word?:
 - Rosebud
-What was Citizen Kane"s first name?:
+What was Citizen Kane's first name?:
 - Charles
-What was Don Rickles" nickname?:
+What was Don Rickles' nickname?:
 - Mr. Warmth
 - mr warmth
-What was Dorothy"s last name in "The Wizard of Oz"?:
+What was Dorothy's last name in "The Wizard of Oz"?:
 - Gale
-What was Eddie Murphy"s character name in "Beverley Hills Cop"?:
+What was Eddie Murphy's character name in 'Beverley Hills Cop'?:
 - Axel Foley
-What was Elvis Presley"s twin brother"s name?:
+What was Elvis Presley's twin brother's name?:
 - Garon
-What was Elvis Presley"s wife"s first name?:
+What was Elvis Presley's wife's first name?:
 - Priscilla
-What was Eric Clapton"s nickname?:
+What was Eric Clapton's nickname?:
 - Slowhand
-What was Garth"s last name in "Wayne"s World"?:
+What was Garth's last name in 'Wayne's World'?:
 - Algar
 What was George of the Jungle always running in to?:
 - A tree
 - tree
 What was Jethro Tull before donating his name to a British epic rock group?:
 - Agriculturist
-What was John Wayne"s real name?:
+What was John Wayne's real name?:
 - Marion Morrison
-What was Keanu Reeves" computer world alias in "The Matrix"?:
+What was Keanu Reeves' computer world alias in 'The Matrix'?:
 - Neo
-What was Keanu Reeves" first big film?:
+What was Keanu Reeves' first big film?:
 - Point Break
-What was Kevin Bacon"s first big hit?:
+What was Kevin Bacon's first big hit?:
 - Footloose
-What was Lucy"s maiden name on "I Love Lucy"?:
+What was Lucy's maiden name on 'I Love Lucy'?:
 - McGillicuddy
-What was Marilyn Monroe"s given name at birth?:
+What was Marilyn Monroe's given name at birth?:
 - Norma Jean Mortenson
-What was Rocky"s nickname in the ring?:
+What was Rocky's nickname in the ring?:
 - The Italian Stallion
 - italian stallion
-What was Sir Alec Guinness"s role in "Star Wars"?:
+What was Sir Alec Guinness's role in "Star Wars"?:
 - Obi-Wan Kenobi
 - obiwan kenobi
 - obi wan kenobi
-What was The Beatles" biggest hit single?:
+What was The Beatles' biggest hit single?:
 - Hey Jude
-What was Wilma Flintstone"s maiden names?:
+What was Wilma Flintstone's maiden names?:
 - Slaghoople
-What was painted on Peter Fonda"s helmet motorcycle helmet in "Easy Rider"?:
+What was painted on Peter Fonda's helmet motorcycle helmet in 'Easy Rider'?:
 - Stars and stripes
-What was the Oscar-winning theme song from "Breakfast at Tiffany"s"?:
+What was the Oscar-winning theme song from "Breakfast at Tiffany's"?:
 - Moon River
 What was the average age of United States soldiers in the Vietnam war?:
 - Nineteen
@@ -812,40 +812,40 @@ What was the last movie of the late Brandon Lee?:
 - The Crow
 What was the name given to the popular genre of rock that arose in the Pacific Northwest (Seattle) in the early 1990s?:
 - Grunge
-What was the name of Ashley Wilkes" plantation in "Gone With the Wind"?:
+What was the name of Ashley Wilkes' plantation in "Gone With the Wind"?:
 - Twelve Oaks
-What was the name of Barney and Betty Rubble"s son?:
+What was the name of Barney and Betty Rubble's son?:
 - Bam Bam
-What was the name of George of the Jungle"s pet elephant?:
+What was the name of George of the Jungle's pet elephant?:
 - Shep
-What was the name of Han Solo"s spaceship in "Star Wars"?:
+What was the name of Han Solo's spaceship in "Star Wars"?:
 - Millennium Falcon
-What was the name of Luke"s strange little advisor in "The Empire Strikes Back"?:
+What was the name of Luke's strange little advisor in "The Empire Strikes Back"?:
 - Yoda
-What was the name of Ross" pet monkey on "Friends"?:
+What was the name of Ross' pet monkey on 'Friends'?:
 - Marcel
-What was the name of Speed Racer"s car?:
+What was the name of Speed Racer's car?:
 - The mach five
-What was the name of the hit song released by "The Romantics" in February 1980?:
-- That"s What I Like About You
+What was the name of the hit song released by 'The Romantics' in February 1980?:
+- That's What I Like About You
 What was the name of the motel in the film "Psycho"?:
 - Bates Motel
 What was the name of the restaurant the TV series "Happy Days"?:
-- Arnold"s
+- Arnold's
 - Arnolds
 What was the original name of "Little Rascals"?:
 - Our Gang
-What was the original name of Paul McCartney"s fictional church cleaner "Eleanor Rigby"?:
+What was the original name of Paul McCartney's fictional church cleaner 'Eleanor Rigby'?:
 - Miss Daisy Hawkins
 What was the relationship between Superman and Supergirl?:
 - Cousins
-What was the working title for The Beatles" song, "Yesterday"?:
+What was the working title for The Beatles' song, 'Yesterday'?:
 - Scrambled Eggs
-What was used for blood in the film "Psycho"?:
+What was used for blood in the film 'Psycho'?:
 - Chocolate syrup
-What"s the name of B.B. King"s guitar?:
+What's the name of B.B. King's guitar?:
 - Lucille
-What"s the name of the Mummy in the film "The Mummy"?:
+What's the name of the Mummy in the film "The Mummy"?:
 - Imhotep
 When Tweety exclaimed, "I thought I saw a putty tat!", who did he see?:
 - Sylvester
@@ -869,49 +869,49 @@ Where does Yogi Bear Live?:
 - Jellystone Park
 Where does young Anakin Skywalker come from?:
 - Tatooine
-Which 1960"s group sang a song inspired by "Alice In Wonderland"?:
+Which 1960's group sang a song inspired by 'Alice In Wonderland'?:
 - The Jefferson Airplane
-Which 1980"s Pink Floyd album was made into a film that starred Bob Geldof, and featured the artwork of cartoonist Gerald Scarfe?:
+Which 1980's Pink Floyd album was made into a film that starred Bob Geldof, and featured the artwork of cartoonist Gerald Scarfe?:
 - The Wall
 Which Australian duo took 13 nominations and 10 wins at the ARIA awards?:
 - Savage Garden
-Which Beatle wrote The Octopus"s song?:
+Which Beatle wrote The Octopus's song?:
 - Ringo Starr
 Which British group holds the record for the album to remain in the US Billboard charts for the longest time?:
 - Pink Floyd
 Which German duo have sold over 85 million records?:
 - Modern Talking
-Which actor said, "Love means never having to say you"re sorry"?:
-- Ryan O"Neil
-Which actor won Oscars twice for "best male performance" in the "90s?:
+Which actor said, "Love means never having to say you're sorry"?:
+- Ryan O'Neil
+Which actor won Oscars twice for 'best male performance' in the '90s?:
 - Tom Hanks
-Which actress won the 2002 Academy Award for best actress in a leading role, for her part in the movie, "Monster"s Ball"?:
+Which actress won the 2002 Academy Award for best actress in a leading role, for her part in the movie, 'Monster's Ball'?:
 - Halle Berry
 Which band included rock greats Roy Orbison, Tom Petty, George Harrison, and Bob Dylan?:
 - The Travelling Wilburys
 Which band is Eddie Vedder with?:
 - Pearl Jam
-Which basketball star played a genie in "Kazaam"?:
-- Shaquille O"Neal
+Which basketball star played a genie in 'Kazaam'?:
+- Shaquille O'Neal
 Which beatle was the first to release a solo record?:
 - Ringo Starr
 Which brand of guitar is played by Jimmy Page, Slash, and Brian May?:
 - Gibson Les Paul
-Which british group recorded the 1983 hit "Owner Of A Lonely Heart"?:
-- 'Yes'
+Which british group recorded the 1983 hit 'Owner Of A Lonely Heart'?:
+- "Yes"
 Which character in "Forrest Gump" loved shrimp?:
 - Bubba
-Which character sang, "When you wish upon a star..." in Disney"s "Pinocchio"?:
+Which character sang, "When you wish upon a star..." in Disney's "Pinocchio"?:
 - Jiminy Cricket
-Which comedy duo did the famous, "Who"s on first" routine?:
+Which comedy duo did the famous, "Who's on first" routine?:
 - Abbott and Costello
 Which comic is drawn by Sam Keith?:
 - The Maxx
 Which comic strip was banned from "Stars and Stripes"?:
 - Beetle Bailey
-Which country and western singer is known as the "okie from muskogee"?:
+Which country and western singer is known as the 'okie from muskogee'?:
 - Merle Haggard
-Which film preceded "Magnum Force" and "The Enforcer"?:
+Which film preceded 'Magnum Force' and 'The Enforcer'?:
 - Dirty Harry
 Which former Beatle released the hit single "My Sweet Lord"?:
 - George Harrison
@@ -925,29 +925,29 @@ Which movie is the highest grossing movie of all time?:
 - Titanic
 Which native of Flint, Michigan, once advised us to "drive your Chevrolet through the USA"?:
 - Pat Boone
-Which of Beethoven"s symphonies was the legendary "Incomplete"?:
+Which of Beethoven's symphonies was the legendary "Incomplete"?:
 - The 9th Symphony
 - 9th
 - 9
-Which of Paul Simon"s musical characters was told to hop on the bus?:
+Which of Paul Simon's musical characters was told to hop on the bus?:
 - Gus
 Which planet was the "Planet of the Apes"?:
 - Earth
-Which singer/songwriter worked in a factory making toilets for airplanes before he recorded "Aint No Sunshine"?:
+Which singer/songwriter worked in a factory making toilets for airplanes before he recorded 'Aint No Sunshine'?:
 - Bill Withers
 Which superhero loves peace enough to kill for it?:
 - Peacemaker
-Which was the first "Indiana Jones" film?:
+Which was the first 'Indiana Jones' film?:
 - Raiders Of The Lost Ark
-Who "imagined" a better world?:
+Who 'imagined' a better world?:
 - John Lennon
 Who always tried to kill Krazy Kat?:
 - Captain Marvel
-Who appeared in "St. Elmo"s Fire", "The Scarlett Letter" and "Striptease"?:
+Who appeared in 'St. Elmo's Fire', 'The Scarlett Letter' and 'Striptease'?:
 - Demi Moore
-Who appeared solo at the Woodstock festival after leaving "The Lovin" Spoonful"?:
+Who appeared solo at the Woodstock festival after leaving 'The Lovin' Spoonful'?:
 - John Sebastian
-Who began his career with "The Yardbirds" and established himself as one of the best rock guitarists of his generation?:
+Who began his career with 'The Yardbirds' and established himself as one of the best rock guitarists of his generation?:
 - Eric Clapton
 Who began his professional career with Black Sabbath?:
 - Ozzy Osbourne
@@ -955,35 +955,35 @@ Who broke Batman?:
 - Bane
 Who co-starred with Julie Andrews in "Mary Poppins"?:
 - Dick Van Dyke
-Who collaborated with John Lennon on "Whatever Gets You Through The Night"?:
+Who collaborated with John Lennon on 'Whatever Gets You Through The Night'?:
 - Elton John
-Who did Pat Sajak play on the soapie "Days Of Our Lives"?:
+Who did Pat Sajak play on the soapie 'Days Of Our Lives'?:
 - Kevin Hathaway
-Who did Patrick Duffy portray in the TV series "Dallas"?:
+Who did Patrick Duffy portray in the TV series 'Dallas'?:
 - Bobby Ewing
-Who did Vivian Vance play on "The Lucy Show"?:
+Who did Vivian Vance play on 'The Lucy Show'?:
 - Vivian Bagley
-Who did a version of "One Bourbon, One Scotch, One Beer" on his 1977 debut album?:
+Who did a version of 'One Bourbon, One Scotch, One Beer' on his 1977 debut album?:
 - George Thorogood
-Who did the music for the 1970"s film "Saturday Night Fever"?:
+Who did the music for the 1970's film 'Saturday Night Fever'?:
 - Bee Gees
 Who did the voices of Bugs Bunny, Sylvester and Tweety Pie?:
 - Mel Blanc
-'Who directed "2001: A Space Odyssey" and "A Clockwork Orange"?':
-- Stanley Kubrick
 Who directed "Jurassic Park III"?:
 - Joe Johnston
-Who directed "The Shining"?:
+"Who directed '2001: A Space Odyssey' and 'A Clockwork Orange'?":
+- Stanley Kubrick
+Who directed 'The Shining'?:
 - Stanley Kubrick
 Who directed Citizen Kane?:
 - Orson Welles
-Who directed the Movie "Psycho" from Robert Bloch?:
+Who directed the Movie 'Psycho' from Robert Bloch?:
 - Alfred Hitchcock
-Who directed the classic thriller "The Birds"?:
+Who directed the classic thriller 'The Birds'?:
 - Alfred Hitchcock
-Who directed the film "Ordinary People"?:
+Who directed the film 'Ordinary People'?:
 - Robert Redford
-Who directed the film "The Birds" from Daphne du Maurier?:
+Who directed the film 'The Birds' from Daphne du Maurier?:
 - Alfred Hitchcock
 Who directed the movie "Blade Runner"?:
 - Ridley Scott
@@ -991,9 +991,9 @@ Who discovered gold on the Witwatersrand?:
 - George Harrison
 Who does the voice for Yoda in the Star Wars films?:
 - Frank Oz
-Who drew the comic "The Maxx"?:
+Who drew the comic 'The Maxx'?:
 - Sam Keith
-Who had, next to Samuel Jackson, a leading roll in "Unbreakable"?:
+Who had, next to Samuel Jackson, a leading roll in 'Unbreakable'?:
 - Bruce Willis
 Who hosted the 1997 Grammy Awards?:
 - Ellen DeGeneres
@@ -1005,31 +1005,31 @@ Who invented the synthesiser ?:
 - Bob Moog
 Who is Declan Patrick McManus better known as?:
 - Elvis
-Who is Donald Duck"s uncle?:
+Who is Donald Duck's uncle?:
 - Scrooge
 Who is Gordon Sumner better known as?:
 - Sting
 Who is James Bonds Recurring Foe?:
 - Ernst Stavro Blofeld
-Who is Kermit D Frog"s girlfriend?:
+Who is Kermit D Frog's girlfriend?:
 - Miss Piggy
-Who is Melanie Griffith"s mother?:
+Who is Melanie Griffith's mother?:
 - Tippi Hedren
 Who is Robert van Winkle?:
 - Vanilla Ice
-Who is Sally Brown"s sweet baboo?:
+Who is Sally Brown's sweet baboo?:
 - Linus van pelt
-Who is Scooby Doo"s nephew?:
+Who is Scooby Doo's nephew?:
 - Scrappy doo
-Who is Snoopy"s arch enemy?:
+Who is Snoopy's arch enemy?:
 - The Red Baron
 Who is Steveland Morris better known as?:
 - Stevie Wonder
-Who is Tippi Hedren"s daughter?:
+Who is Tippi Hedren's daughter?:
 - Melanie Griffith
-Who is Warren Beatty"s sister?:
+Who is Warren Beatty's sister?:
 - Shirley MacLaine
-Who is lead guitarist for Guns "n Roses?:
+Who is lead guitarist for Guns 'n Roses?:
 - Slash
 Who is married to Eddie Van Halen?:
 - Valerie Bertanelli
@@ -1037,13 +1037,13 @@ Who is married to Valerie Bertanelli?:
 - Eddie Van Halen
 Who is stationed at Camp Swampy in the comic strips?:
 - Beetle bailey
-Who is the autor of the song "Blue Suede Shoes"?:
+Who is the autor of the song 'Blue Suede Shoes'?:
 - Carl Perkins
-Who is the elder statesman of "british blues", and fronted "The Bluesbreakers"?:
+Who is the elder statesman of 'british blues', and fronted 'The Bluesbreakers'?:
 - John Mayall
 Who is the fastest mouse in all of Mexico?:
 - Speedy Gonzalez
-Who is the lead singer of "The Doors"?:
+Who is the lead singer of 'The Doors'?:
 - Jim Morrison
 Who is the lead singer of limp bizkit?:
 - Fred Durst
@@ -1051,11 +1051,11 @@ Who is the lead singer of the Rolling Stones?:
 - Mick Jagger
 Who is the lead vocalist of U2?:
 - Bono
-Who is the main character in "Touched By An Angel"?:
+Who is the main character in 'Touched By An Angel'?:
 - Monica
 Who is the male lead in the "Naked Gun" movies?:
 - Leslie Nielsen
-Who is the only singer to have no.1 hits in the 50"s, 60"s, 70"s, 80"s and 90"s?:
+Who is the only singer to have no.1 hits in the 50's, 60's, 70's, 80's and 90's?:
 - Cliff Richard
 Who is the voice of Darth Vadar?:
 - James Earl Jones
@@ -1069,55 +1069,55 @@ Who married Shania Twain?:
 - Robert "Mutt" Lange
 Who play Captian Jean-Luc Picard in Star Trek the Next Generation?:
 - Patrick Stewart
-Who played "Johnny Mnemonic"?:
+Who played "Robin" to Val Kilmer's "Batman"?:
+- Christopher O'Donnell
+Who played 'Johnny Mnemonic'?:
 - Keanu Reeves
-Who played "Robin" to Val Kilmer"s "Batman"?:
-- Christopher O"Donnell
-Who played "The Scorpion King" in the recent movie "The Mummy Returns"?:
+Who played 'The Scorpion King' in the recent movie 'The Mummy Returns'?:
 - Dwight Johnson
-Who played Bobby Ewing in the TV series "Dallas"?:
+Who played Bobby Ewing in the TV series 'Dallas'?:
 - Patrick Duffy
-Who played Brad Pitt"s cop partner in the movie "Seven"?:
+Who played Brad Pitt's cop partner in the movie "Seven"?:
 - Morgan Freeman
 Who played Charlie in Charlies Angels?:
 - John Forsythe
-Who played Clyde to Faye Dunaway"s Bonnie?:
+Who played Clyde to Faye Dunaway's Bonnie?:
 - Warren Beatty
 Who played Dorothy in "The Wizard of Oz"?:
 - Judy Garland
-Who played Dr. Frankenfurter in the pop-culture film "The Rocky Horror Picture Show?:
+Who played Dr. Frankenfurter in the pop-culture film 'The Rocky Horror Picture Show?:
 - Tim Curry
 Who played Dr. Kildare?:
 - Richard Chamberlain
-Who played Eddie in the pop-culture film "The Rocky Horror Picture Show?:
+Who played Eddie in the pop-culture film 'The Rocky Horror Picture Show?:
 - Meat Loaf
-Who played Garth in "Wayne"s World"?:
+Who played Garth in "Wayne's World"?:
 - Dana Carvey
-Who played George Costanza on "Seinfeld"?:
+Who played George Costanza on 'Seinfeld'?:
 - Jason Alexander
 Who played Hopalong Cassidy?:
 - William Boyd
-Who played Kevin Hathaway on the soapie "Days Of Our Lives"?:
+Who played Kevin Hathaway on the soapie 'Days Of Our Lives'?:
 - Pat Sajak
-Who played Louis in "Interview With The Vampire"?:
+Who played Louis in 'Interview With The Vampire'?:
 - Brad Pitt
 Who played Matt Helm in the movies?:
 - Dean Martin
-Who played Queen Amidala in the latest "Star Wars" film?:
+Who played Queen Amidala in the latest 'Star Wars' film?:
 - Natalie Portman
-Who played Scarlette O"Hara in "Gone With the Wind"?:
+Who played Scarlette O'Hara in "Gone With the Wind"?:
 - Vivien Leigh
-Who played Steve Erkel in "Family Matters"?:
+Who played Steve Erkel in 'Family Matters'?:
 - Jaleel White
-Who played commander Riker in "Star Trek"?:
+Who played commander Riker in 'Star Trek'?:
 - Jonathan Frakes
-Who played in the film "Ragtime" after 20 years offscreen?:
+Who played in the film 'Ragtime' after 20 years offscreen?:
 - James Cagney
-Who played the "Universal Soldier"?:
+Who played the 'Universal Soldier'?:
 - Jean-Claude Van Damme
-Who played the "Wicked Witch of the West" in "The Wizard of Oz"?:
+Who played the 'Wicked Witch of the West' in "The Wizard of Oz"?:
 - Margaret Hamilton
-Who played the Agent james Bond in the 1966 film "Casino Royale"?:
+Who played the Agent james Bond in the 1966 film 'Casino Royale'?:
 - David Niven
 Who played the first James Bond?:
 - Sean Connery
@@ -1135,19 +1135,19 @@ Who played the lead in the movie "The Mask"?:
 - Jim Carrey
 Who played the lead in the movie "The Matrix"?:
 - Keanu Reeves
-Who played the mayor of the munchkins in "The Wizard of Oz"?:
+Who played the mayor of the munchkins in 'The Wizard of Oz'?:
 - Charlie Becker
-Who played the murder victim in the original version of "Psycho"?:
+Who played the murder victim in the original version of 'Psycho'?:
 - Janet Leigh
-Who played the president of the U.S in "Air Force One"?:
+Who played the president of the U.S in 'Air Force One'?:
 - Harrison Ford
 Who played the role of Richard Blaine in Casablanca?:
 - Humphrey Bogart
-Who played the title role in "Mad Max"?:
+Who played the title role in 'Mad Max'?:
 - Mel Gibson
-Who played the title role in the 1978 version of "Superman"?:
+Who played the title role in the 1978 version of 'Superman'?:
 - Christopher Reeve
-Who plays many voices, such as Dr Nick, and Moe on "The Simpsons"?:
+Who plays many voices, such as Dr Nick, and Moe on 'The Simpsons'?:
 - Hank Azaria
 Who plays the character of the only escapee from Alcatraz in the movie "The Rock"?:
 - Sean Connery
@@ -1157,9 +1157,9 @@ Who portrayed Han Solo in "Star Wars"?:
 - Harrison Ford
 Who portrayed Moses in "The Ten Commandments"?:
 - Charlton Heston
-Who produced "Sgt Pepper"s Lonely Hearts Club Band"?:
+Who produced 'Sgt Pepper's Lonely Hearts Club Band'?:
 - George Martin
-Who recorded "A Boy Named Sue"?:
+Who recorded 'A Boy Named Sue'?:
 - Johnny Cash
 Who recorded the 1957 hit "Tammy"?:
 - Debby Reynolds
@@ -1167,125 +1167,125 @@ Who recorded the 1969 hit "Space Oddity"?:
 - David Bowie
 Who recorded the lengthy song "In-A-Gadda-Da-Vida" in 1969?:
 - Iron Butterfly
-Who released "Time, Love and Tenderness" in 1981?:
+Who released 'Time, Love and Tenderness' in 1981?:
 - Michael Bolton
-Who released "Tuesday Night Music Club" in 1993?:
+Who released 'Tuesday Night Music Club' in 1993?:
 - Sheryl Crow
-Who released a chart-busting album in 1976 which featured "The Lido Shuffle"?:
+Who released a chart-busting album in 1976 which featured 'The Lido Shuffle'?:
 - Boz Scaggs
-Who released the double album "Goodbye Yellow Brick Road" in 1973?:
+Who released the double album 'Goodbye Yellow Brick Road' in 1973?:
 - Elton John
-Who runs Andy Capp"s favorite pub?:
+Who runs Andy Capp's favorite pub?:
 - Jack and Jill
-Who said "you"d be surprised how much it costs to look this cheap"?:
+Who said 'you'd be surprised how much it costs to look this cheap'?:
 - Dolly Parton
-Who sang "All Right Now"?:
+Who sang 'All Right Now'?:
 - Free
-Who sang "Any Way You Want Me"?:
+Who sang 'Any Way You Want Me'?:
 - Elvis Presley
-Who sang "Bad Case Of Loving You"?:
+Who sang 'Bad Case Of Loving You'?:
 - Robert Palmer
-Who sang "Beat It"?:
+Who sang 'Beat It'?:
 - Michael Jackson
-Who sang "Beauty and the Beast"?:
+Who sang 'Beauty and the Beast'?:
 - Celine Dion
-Who sang "Born In The USA"?:
+Who sang 'Born In The USA'?:
 - Bruce Springsteen
-Who sang "Forever and Ever, Amen"?:
+Who sang 'Forever and Ever, Amen'?:
 - Randy Travis
-Who sang "I"m A Believer"?:
+Who sang 'I'm A Believer'?:
 - The Monkees
 - Monkees
-Who sang "In The Air Tonight"?:
+Who sang 'In The Air Tonight'?:
 - Phil Collins
-Who sang "Islands In The Stream" with Dolly Parton?:
+Who sang 'Islands In The Stream' with Dolly Parton?:
 - Kenny Rogers
-Who sang "Islands In The Stream" with Kenny Rogers?:
+Who sang 'Islands In The Stream' with Kenny Rogers?:
 - Dolly Parton
-Who sang "Jet Airliner"?:
+Who sang 'Jet Airliner'?:
 - Steve Miller Band
-Who sang "Mull of Kintyre"?:
+Who sang 'Mull of Kintyre'?:
 - Wings
-Who sang "Rescue Me"?:
+Who sang 'Rescue Me'?:
 - Fontella Bass
-Who sang "That"s Alright Mama"?:
+Who sang 'That's Alright Mama'?:
 - Elvis Presley
-Who sang "We"ve only just begun"?:
+Who sang 'We've only just begun'?:
 - Carpenters
-Who sang "You Can Call Me Al"?:
+Who sang 'You Can Call Me Al'?:
 - Paul Simon
-Who sang about "Commitment"?:
+Who sang about 'Commitment'?:
 - Leann Rhimes
-Who sang about "The Boogie Woogie Bugle Boy Of Company B"?:
+Who sang about 'The Boogie Woogie Bugle Boy Of Company B'?:
 - The Andrews Sisters
 Who sang about Desmond and Molly Jones?:
 - The Beatles
 Who sang the song "Pretty Woman"?:
 - Roy Orbison
-Who says, "Th-th-th-that"s all folks!"?:
+Who says, "Th-th-th-that's all folks!"?:
 - Porky pig
-Who shot Bruce Wayne"s parents?:
+Who shot Bruce Wayne's parents?:
 - Chill
 Who sings "Imitation Of Life"?:
 - R.E.M.
 - rem
-Who sings "Sweet Home Alabama"?:
+Who sings 'Sweet Home Alabama'?:
 - Lynyrd Skynyrd
-Who sings and plays the theme song for the TV show "Frasier"?:
+Who sings and plays the theme song for the TV show 'Frasier'?:
 - Kelsey Grammer
-Who starred as "ouboet" in the first TV series of "Orkney Snork Nie"?:
+Who starred as 'ouboet' in the first TV series of 'Orkney Snork Nie'?:
 - Frank Opperman
-Who starred in "Conan The Barbarian"?:
+Who starred in 'Conan The Barbarian'?:
 - Arnold Schwarzenegger
-Who starred in the 1952 film "Niagara"?:
+Who starred in the 1952 film 'Niagara'?:
 - Marilyn Monroe
-Who starred in the film "The Man With Two Brains"?:
+Who starred in the film 'The Man With Two Brains'?:
 - Steve Martin
-Who starred in the film version of "To Kill A Mockingbird"?:
+Who starred in the film version of 'To Kill A Mockingbird'?:
 - Gregory Peck
 Who starred with John Travolta in the movie "Broken Arrow"?:
 - Christian Slater
 Who took dictation from Perry Mason?:
 - Della Street
-Who wanted "a lover with a slow hand"?:
+Who wanted 'a lover with a slow hand'?:
 - The Pointer Sisters
-Who was "hooked on a feeling"?:
+Who was 'hooked on a feeling'?:
 - Blue Suede
-Who was Barney Rubble"s best friend?:
+Who was Barney Rubble's best friend?:
 - Fred Flintstone
-Who was C3PO"s sidekick in "Star Wars"?:
+Who was C3PO's sidekick in "Star Wars"?:
 - R2D2
-Who was Carl in Five Easy Pieces before going to Walton"s Mountain?:
+Who was Carl in Five Easy Pieces before going to Walton's Mountain?:
 - Waite
 Who was Chief Marshall of the Mickey Mouse Club?:
 - Walt Disney
-Who was Dick Dastardley"s pet?:
+Who was Dick Dastardley's pet?:
 - Muttley
-Who was Dick Dastardly"s pet?:
+Who was Dick Dastardly's pet?:
 - Muttley
-Who was Dr. Zhivago"s great love?:
+Who was Dr. Zhivago's great love?:
 - Lara
-Who was Fred Flinstone"s best friend?:
+Who was Fred Flinstone's best friend?:
 - Barney Rubble
-Who was John Wayne"s musical co-star in true grit?:
+Who was John Wayne's musical co-star in true grit?:
 - Glen Campbell
-Who was Lauren Bacall"s first husband?:
+Who was Lauren Bacall's first husband?:
 - Humphrey Bogart
-Who was a member of "Crosby, Stills and Nash" and "The Hollies"?:
+Who was a member of 'Crosby, Stills and Nash' and 'The Hollies'?:
 - Graham Nash
 Who was always trying to get rent from Andy Capp?:
 - Percy
 Who was born on Krypton?:
 - Superman
-Who was the Cisco Kid"s faithful sidekick?:
+Who was the Cisco Kid's faithful sidekick?:
 - Pancho
-Who was the Hulk"s first friend?:
+Who was the Hulk's first friend?:
 - Rick Jones
-Who was the Indian maiden in Johnny Preston"s "Running Bear"?:
+Who was the Indian maiden in Johnny Preston's 'Running Bear'?:
 - Little White Dove
 Who was the black assistant of Mandrake the Magician?:
 - Lothar
-Who was the director of "Terminator" and "Titanic"?:
+Who was the director of 'Terminator' and 'Titanic'?:
 - James Cameron
 Who was the first James Bond?:
 - Sean Connery
@@ -1307,7 +1307,7 @@ Who was the sexy star of Barberella?:
 - Jane Fonda
 Who were the rivals of the T-Birds in the movie "Grease"?:
 - Scorpions
-Who wrote "Roll Over Beethoven"?:
+Who wrote 'Roll Over Beethoven'?:
 - Chuck Berry
 Who wrote Tubular Bells?:
 - Mike Oldfield
@@ -1315,23 +1315,23 @@ Who wrote and preformed the soundtrack for Live and let die?:
 - Paul McCartney and Wings
 Who wrote the Nutcracker Suite?:
 - Tchaikovsky
-Who wrote the opera "The Giant"?:
+Who wrote the opera 'The Giant'?:
 - Sergei Prokofiev
-Who wrote the opera "The Masked Ball"?:
+Who wrote the opera 'The Masked Ball'?:
 - Giuseppe Verdi
-Who wrote the opera "Tosca"?:
+Who wrote the opera 'Tosca'?:
 - Giacomo Puccini
-Who wrote the opera "norma"?:
+Who wrote the opera 'norma'?:
 - Vincenzo Bellini
-Who wrote the oprea "La Traviata"?:
+Who wrote the oprea 'La Traviata'?:
 - Guiseppe Verdi
-Who wrote the song "Do They Know It"s Christmas" with Bob Geldof?:
+Who wrote the song 'Do They Know It's Christmas' with Bob Geldof?:
 - Midge Ure
-Who wrote the song "Do They Know It"s Christmas" with Midge Ure?:
+Who wrote the song 'Do They Know It's Christmas' with Midge Ure?:
 - Bob Geldof
-Who"s first release was "Talking Heads 77"?:
+Who's first release was 'Talking Heads 77'?:
 - Psycho Killer
-Whose films include "Giant", "Written On The Wind" and "A Farewell To Arms"?:
+Whose films include 'Giant', 'Written On The Wind' and 'A Farewell To Arms'?:
 - Rock Hudson
 Whose theme song was Back In The Saddle Again?:
 - Gene Autry

--- a/redbot/trivia/lists/finalfantasy.yaml
+++ b/redbot/trivia/lists/finalfantasy.yaml
@@ -1,21 +1,21 @@
-'"Final Fantasy VII: Avenged Children" is a movie. True/False?':
-- 'False'
+"'Final Fantasy VII: Avenged Children' is a movie. True/False?":
+- "False"
 (BRAVE EXVIUS) The Veritas originally comprised of how many members? (Answer without numerics):
 - Eight
-(BRAVE EXVIUS) What is Lid"s occupation?:
+(BRAVE EXVIUS) What is Lid's occupation?:
 - Airship engineer
 - Engineer
 (BRAVE EXVIUS) What is the group name of the 6 antagonists clad in black?:
 - Sworn Six of Paladia
 - Six Sworn Heroes of Paladia
 - The Veritas
-(BRAVE EXVIUS) What is the name of Lasswell"s sword?:
+(BRAVE EXVIUS) What is the name of Lasswell's sword?:
 - Purple Lightning
 - Shiden
-(BRAVE EXVIUS) What is the name of Rain"s father?:
+(BRAVE EXVIUS) What is the name of Rain's father?:
 - Raegen
 - Sir Raegen
-(BRAVE EXVIUS) What is the name of Rain"s mother?:
+(BRAVE EXVIUS) What is the name of Rain's mother?:
 - Sophia
 (BRAVE EXVIUS) Which Veritas member destroyed the Earth Crystal?:
 - Veritas of the Dark
@@ -55,7 +55,7 @@
 - Lufaine
 - Lefeinish
 (FFI) What do you present to Bahamut after clearing the Citadel of Trials?:
-- Rat"s Tail
+- Rat's Tail
 - Rat Tail
 (FFI) What is the HP of the final boss (Chaos), in the original NES version?:
 - 2,000
@@ -84,16 +84,16 @@
 (FFII) Minwu serves which family?:
 - Fynn
 (FFII) Name the key to Kashuan Keep.:
-- Goddess"s Bell
+- Goddess's Bell
 - Goddess Bell
 (FFII) Name the largest airship.:
 - Dreadnought
 (FFII) Princess Hilda is the leader of which organization?:
 - Wild Rose Rebellion
 (FFII) Sunfire can only be carried using?:
-- Egil"s Torch
+- Egil's Torch
 - Egil Torch
-(FFII) What is the Emperor"s name?:
+(FFII) What is the Emperor's name?:
 - Mateus
 (FFII) What is the only thing that can destroy the Dreadnought?:
 - Sunfire
@@ -113,13 +113,13 @@
 (FFII) Who has the ability to talk to animals?:
 - Guy
 - Gus
-(FFII) Who is Gordon"s brother?:
+(FFII) Who is Gordon's brother?:
 - Scott
-(FFII) Who is Josef"s daughter?:
+(FFII) Who is Josef's daughter?:
 - Nelly
 - Nellie
 - Molly
-(FFII) Who is Maria"s brother?:
+(FFII) Who is Maria's brother?:
 - Leon
 (FFII) Who is in love with Princess Hilda?:
 - Gordon
@@ -132,14 +132,14 @@
 - Elina
 - Elena
 - Kain
-(FFII) Who kidnapped Josef"s daughter?:
+(FFII) Who kidnapped Josef's daughter?:
 - Borghen
 - Borgan
 (FFII) Who kills Ricard?:
 - Dark Emperor
 - Emperor
 - Mateus
-(FFIII) Excluding Xande, name Noah"s two other disciples. (\_\_\_ and \_\_\_):
+(FFIII) Excluding Xande, name Noah's two other disciples. (\_\_\_ and \_\_\_):
 - Doga and Unei
 - Unei and Doga
 - Dorga and Unei
@@ -154,14 +154,14 @@
 - Nina
 (FFIII) Name the hometown of Luneth and Arc.:
 - Ur
-(FFIII) The Djinn"s curse turns people into?:
+(FFIII) The Djinn's curse turns people into?:
 - Ghosts
 - Ghost
 (FFIII) What does Gigameth turn into?:
 - Garuda
 (FFIII) What gender is the Legendary Smith?:
 - Female
-(FFIII) What gift did Xande"s mentor bestow upon him?:
+(FFIII) What gift did Xande's mentor bestow upon him?:
 - The gift of mortality
 - Mortality
 (FFIII) What is the "unknown metal" that is required to get Ultima Weapon?:
@@ -176,9 +176,9 @@
 (FFIII) Who has feelings for Ingus?:
 - Princess Sara Altney
 - Sara
-(FFIII) Who is Desch"s girlfriend?:
+(FFIII) Who is Desch's girlfriend?:
 - Salina
-(FFIII) Who is Refia"s adopted father?:
+(FFIII) Who is Refia's adopted father?:
 - Takka
 - Taca
 (FFIII) Who is known as "The Maiden of Water"?:
@@ -188,11 +188,11 @@
 (FFIII) Who mind-controlled King Gorn?:
 - Gigameth
 - Gigames
-(FFIII) Who was Xande"s mentor?:
+(FFIII) Who was Xande's mentor?:
 - Great Magus Noah
 - Noah
 (FFIV) Cecil marries Rosa. True/False?:
-- 'True'
+- "True"
 (FFIV) It was later revealed that Golbez was being mind-controlled by who?:
 - Zemus
 (FFIV) Name an airship present in the game.:
@@ -200,42 +200,42 @@
 - Falcon
 - Enterprise
 (FFIV) Rosa has feelings for Kain. True/False?:
-- 'False'
+- "False"
 (FFIV) Rydia never learns the spell, Fire, due to trauma. True/False?:
-- 'False'
+- "False"
 (FFIV) Tellah died after casting what magic spell?:
 - Meteor
 (FFIV) The elusive Pink Tail is an item drop from...?:
 - Flan Princess
-(FFIV) What crystal was exchanged for Rosa"s safety?:
+(FFIV) What crystal was exchanged for Rosa's safety?:
 - Earth Crystal
 - Earth
 (FFIV) What does Cid use to seal the entrance to the underworld?:
 - A bomb
 - Bomb
-(FFIV) What is Barbariccia"s epithet?:
+(FFIV) What is Barbariccia's epithet?:
 - Empress of the Winds
 - Empress of the Wind
-(FFIV) What is Cagnazzo"s epithet?:
+(FFIV) What is Cagnazzo's epithet?:
 - The Drowned King
 - Drowned King
-(FFIV) What is Edge"s real name?:
+(FFIV) What is Edge's real name?:
 - Edward Geraldine
 - Edward
-(FFIV) What is Golbez"s real name?:
+(FFIV) What is Golbez's real name?:
 - Theodor
-(FFIV) What is Rubicante"s epithet?:
+(FFIV) What is Rubicante's epithet?:
 - Autarch of Flame
 - Autarch of the Flame
-(FFIV) What is Scarmiglione"s epithet?:
+(FFIV) What is Scarmiglione's epithet?:
 - The Blighted Despot
 - Blighted Despot
-(FFIV) What is the name of Cecil"s son?:
+(FFIV) What is the name of Cecil's son?:
 - Ceodore Harvey
 - Ceodore
-(FFIV) What is the name of Kain"s father?:
+(FFIV) What is the name of Kain's father?:
 - Richard
-(FFIV) What is the name of Tellah"s daughter?:
+(FFIV) What is the name of Tellah's daughter?:
 - Anna
 (FFIV) What is the name of the "Home to all Eidolons"?:
 - Feymarch
@@ -248,7 +248,7 @@
 - The Whisperweed
 - Whisperweed
 - Twin Harp
-(FFIV) What item was used to cure Rosa"s desert fever?:
+(FFIV) What item was used to cure Rosa's desert fever?:
 - Sand Pearl
 (FFIV) Which castle guards the Earth Crystal?:
 - Toroia
@@ -265,10 +265,10 @@
 - Mysidia
 (FFIV) Who does Edge have a crush on?:
 - Rydia
-(FFIV) Who is Cecil"s brother?:
+(FFIV) Who is Cecil's brother?:
 - Golbez
 - Theodor
-(FFIV) Who is Cecil"s father?:
+(FFIV) Who is Cecil's father?:
 - KluYa
 (FFIV) Who is the Archfiend of Earth?:
 - Scarmiglione
@@ -283,18 +283,18 @@
 (FFIV) Who is the Queen of Eidolons?:
 - Asura
 (FFIV) Who originally summoned the Mist Dragon?:
-- Rydia"s mother
+- Rydia's mother
 - Mother of Rydia
 (FFIX) A large amount of various elements in the game draws inspiration from a famous playwright/poet, who is he?:
 - William Shakespeare
 (FFIX) Beatrix can enter Trance. True/False?:
-- 'False'
+- "False"
 (FFIX) Besides Zidane and Kuja, which other Genome possesses a soul?:
 - Mikoto
 (FFIX) Eiko gives Zidane a kiss on the cheek. True/False?:
-- 'False'
+- "False"
 (FFIX) Garnet originally had a horn. True/False?:
-- 'True'
+- "True"
 (FFIX) How many "Black Waltzes" are there? (Answer without numerics):
 - Three
 (FFIX) How many "Hilda Garde" airships are there? (Answer without numerics):
@@ -309,12 +309,12 @@
 (FFIX) In the game, who wrote the play, I Want To Be Your Canary?:
 - Lord Avon
 (FFIX) It is not possible to marry Quina with Vivi. True/False?:
-- 'False'
+- "False"
 (FFIX) Kuja does not have a tail. True/False?:
-- 'False'
+- "False"
 (FFIX) Lani eventually settles in Madain Sari. True/False?:
-- 'True'
-(FFIX) Name a character who doesn"t have a unique Trance command.:
+- "True"
+(FFIX) Name a character who doesn't have a unique Trance command.:
 - Steiner/Freya
 - Steiner
 - Freya
@@ -329,39 +329,39 @@
 (FFIX) Steiner commands a small army called the...:
 - Knights of Pluto
 (FFIX) Steiner confesses his love for Beatrix. True/False?:
-- 'True'
+- "True"
 (FFIX) The "eye in the sky" turns out to be?:
 - The Invincible
 - Invincible
 (FFIX) There is a sidequest to find every member of the Nero family. True/False?:
-- 'True'
+- "True"
 (FFIX) Vivi "expires". True/False?:
-- True, much to everyone"s dismay.
-- 'True'
-(FFIX) What cures Blank"s petrification?:
+- True, much to everyone's dismay.
+- "True"
+(FFIX) What cures Blank's petrification?:
 - Supersoft
 (FFIX) What does Blank throw to Zidane in the Evil/Petrified Forest?:
 - The World Map
 - World Map
 (FFIX) What does Kuja demand Zidane to obtain for him in exchange for the lives of his friends?:
 - Gulug Stone
-(FFIX) What is Cid"s occupation/role?:
+(FFIX) What is Cid's occupation/role?:
 - Regent of Lindblum
 - Regent
-(FFIX) What is Garnet"s nickname?:
+(FFIX) What is Garnet's nickname?:
 - Dagger
-(FFIX) What is Garnet"s true name?:
+(FFIX) What is Garnet's true name?:
 - Sarah
-(FFIX) What is Quina"s favorite food?:
+(FFIX) What is Quina's favorite food?:
 - Frogs
 - Frog
-(FFIX) What is Zidane"s race?:
+(FFIX) What is Zidane's race?:
 - Genome
-(FFIX) What is the name of Garnet"s true mother?:
+(FFIX) What is the name of Garnet's true mother?:
 - Jane
-(FFIX) What is the name of Queen Brahne"s airship?:
+(FFIX) What is the name of Queen Brahne's airship?:
 - Red Rose
-(FFIX) What is the name of Zorn and Thorn"s true form?:
+(FFIX) What is the name of Zorn and Thorn's true form?:
 - Meltigemini
 (FFIX) What is the name of the airship owned by the Tantalus Theater Troupe?:
 - Prima Vista
@@ -385,17 +385,17 @@
 - Forgotten
 (FFIX) Which moogle wears a leopard skin hood?:
 - Stiltzkin
-(FFIX) While in Trance, Amarant"s "Flair" command changes to?:
+(FFIX) While in Trance, Amarant's 'Flair' command changes to?:
 - Elan
-(FFIX) While in Trance, Eiko"s "Wht Mag" command changes to?:
+(FFIX) While in Trance, Eiko's 'Wht Mag' command changes to?:
 - Dbl Wht
-(FFIX) While in Trance, Garnet"s "Summon" command changes to?:
+(FFIX) While in Trance, Garnet's 'Summon' command changes to?:
 - Eidolon
-(FFIX) While in Trance, Quina"s "Eat" command changes to?:
+(FFIX) While in Trance, Quina's 'Eat' command changes to?:
 - Cook
-(FFIX) While in Trance, Vivi"s "Blk Mag" command changes to?:
+(FFIX) While in Trance, Vivi's 'Blk Mag' command changes to?:
 - Dbl Blk
-(FFIX) While in Trance, Zidane"s "Skill" command changes to?:
+(FFIX) While in Trance, Zidane's 'Skill' command changes to?:
 - Dyne
 (FFIX) Who adopts Eiko?:
 - Cid and Hilda
@@ -412,10 +412,10 @@
 - Quan
 (FFIX) Who does some black mages try to keep away from a chocobo egg?:
 - Quina
-(FFIX) Who is Freya"s lost love?:
+(FFIX) Who is Freya's lost love?:
 - Sir Fratley
 - Fratley
-(FFIX) Who is Garnet"s tutor/mentor?:
+(FFIX) Who is Garnet's tutor/mentor?:
 - Doctor Tot
 - Dr Tot
 - Dr. Tot
@@ -453,15 +453,15 @@
 - Dycedarg
 (FFT) In FFT:WoTL, there is a secret playable character from FFXII, who is it?:
 - Balthier
-(FFT) Name one of Ramza"s brothers.:
+(FFT) Name one of Ramza's brothers.:
 - Dycedarg or Zalbaag
 - Dycedarg
 - Zalbaag
 (FFT) Name the recruitable friendly Reaver.:
 - Byblos
-(FFT) What is Cidolfus Orlandeau"s nickname?:
+(FFT) What is Cidolfus Orlandeau's nickname?:
 - Thunder God Cid
-(FFT) What is Mustadio"s gift to Agrias for her birthday?:
+(FFT) What is Mustadio's gift to Agrias for her birthday?:
 - Tynar Rouge
 - Lip Rouge
 - Lipstick
@@ -469,14 +469,14 @@
 - Zodiac Stones
 - Zodiac Stone
 - Auracite
-(FFT) What is the name of Ramza"s father?:
+(FFT) What is the name of Ramza's father?:
 - Barbaneth Beoulve
 - Barbaneth
 - Balbanes
 (FFT) What is the name of the terrorist organization led by Wiegraf Folles?:
 - Corpse Brigade
 - Death Corps
-(FFT) When is Agrias"s birthday?:
+(FFT) When is Agrias's birthday?:
 - 1st of Cancer
 - Cancer 1
 - 1 Cancer
@@ -488,23 +488,23 @@
 (FFT) Who becomes the host of the Lucavi, Belias?:
 - Wiegraf Folles
 - Wiegraf
-(FFT) Who is Cidolfus Orlandeau"s adopted son?:
+(FFT) Who is Cidolfus Orlandeau's adopted son?:
 - Orran Durai
 - Olan Durai
 - Orran
 - Olan
-(FFT) Who is Delita"s sister?:
+(FFT) Who is Delita's sister?:
 - Tietra Heiral
 - Tietra
 - Teta
-(FFT) Who is Mustadio"s love interest?:
+(FFT) Who is Mustadio's love interest?:
 - Agrias Oaks
 - Agrias
-(FFT) Who is Princess Ovelia"s bodyguard?:
+(FFT) Who is Princess Ovelia's bodyguard?:
 - Lady Agrias Oaks
 - Agrias Oaks
 - Agrias
-(FFT) Who is known as the "Silver Prince/Demon"?:
+(FFT) Who is known as the 'Silver Prince/Demon'?:
 - Marquis Messam Elmdore
 - Marquis Elmdore
 - Marquis Messam Elmdore de Limberry
@@ -540,7 +540,7 @@
 (FFT) Who is the narrator of Final Fantasy Tactics?:
 - Arazlam Durai
 - Arazlam
-(FFT) Who is the optional boss found in the lowest level of Midlight"s Deep?:
+(FFT) Who is the optional boss found in the lowest level of Midlight's Deep?:
 - Elidibus
 - Elidibs
 (FFT) Who killed Tietra?:
@@ -565,9 +565,9 @@
 - Passing of Remedi
 - His wife died
 (FFTA) It is possible to recruit Judgemaster Cid to your clan. True/False?:
-- 'True'
+- "True"
 (FFTA) It is possible to recruit Llednar to your clan. True/False?:
-- 'False'
+- "False"
 (FFTA) It was later revealed that the dream world of Ivalice is actually a fantasy of whose?:
 - Mewt Randell
 - Mewt
@@ -578,7 +578,7 @@
 - Humans
 - Human
 (FFTA) Ritz utilizes the viera job tree. True/False?:
-- 'True'
+- "True"
 (FFTA) Ultima is the totema of which race?:
 - Nu Mou
 (FFTA) What are the lawless areas known as?:
@@ -588,16 +588,16 @@
 - Lizards
 - Lizard
 - Lizardmen
-(FFTA) What is Cid"s occupation/role?:
+(FFTA) What is Cid's occupation/role?:
 - Judgemaster
 - Judge Master
-(FFTA) What is Ritz"s natural hair color?:
+(FFTA) What is Ritz's natural hair color?:
 - White
-(FFTA) What is the game"s default Clan name?:
+(FFTA) What is the game's default Clan name?:
 - Clan Nutsy
 - Nutsy
 (FFTA) What is the name of the strongest (highest ATK) Greatbow in the game?:
-- Max"s Oathbow
+- Max's Oathbow
 - Max Oathbow
 (FFTA) What is the name of the strongest (highest ATK) Greatsword in the game?:
 - Master Sword
@@ -613,7 +613,7 @@
 (FFTA) What is the name of the strongest (highest ATK) Saber in the game?:
 - Manganese
 (FFTA) What is the name of the strongest (highest ATK) Spear in the game?:
-- Odin"s Lance
+- Odin's Lance
 - Odin Lance
 (FFTA) What is the name of the strongest (highest ATK) Sword in the game?:
 - Chirijaden
@@ -624,13 +624,13 @@
 - Ezel Berbier
 - Ezel
 - Berbier
-(FFTA) Who is Marche"s brother?:
+(FFTA) Who is Marche's brother?:
 - Doned Radiuju
 - Doned
-(FFTA) Who is Mewt"s mother?:
+(FFTA) Who is Mewt's mother?:
 - Remedi
 - Queen Remedi
-(FFTA) Who is Ritz"s closest partner/comrade?:
+(FFTA) Who is Ritz's closest partner/comrade?:
 - Shara
 (FFTA) Who is the first Totema you encounter?:
 - Famfrit
@@ -661,18 +661,18 @@
 - 254
 (FFV) What cures wind drakes from sickness?:
 - Dragon Grass
-(FFV) What is Faris"s full real name?:
+(FFV) What is Faris's full real name?:
 - Sarisa Scherwil Tycoon
-(FFV) What is the name of Bartz"s chocobo?:
+(FFV) What is the name of Bartz's chocobo?:
 - Boko
 - Boco
-(FFV) What is the name of Bartz"s mother?:
+(FFV) What is the name of Bartz's mother?:
 - Stella
-(FFV) What is the name of Cid"s grandson?:
+(FFV) What is the name of Cid's grandson?:
 - Mid
-(FFV) What is the name of Lenna"s wind drake?:
+(FFV) What is the name of Lenna's wind drake?:
 - Hiryu
-(FFV) What prevented Galuf from falling victim to Siren"s deception?:
+(FFV) What prevented Galuf from falling victim to Siren's deception?:
 - Amnesia
 (FFV) Which village has hidden vendors?:
 - Phantom Village
@@ -688,9 +688,9 @@
 - Krile
 - Cara
 - Kururu
-(FFV) Who is Faris"s childhood friend + savior + pet?:
+(FFV) Who is Faris's childhood friend + savior + pet?:
 - Syldra
-(FFV) Who is Galuf"s granddaughter?:
+(FFV) Who is Galuf's granddaughter?:
 - Krile
 (FFV) Who is the "talking turtle"?:
 - Ghido
@@ -698,7 +698,7 @@
 - Guido
 (FFV) Who is the king of Surgate?:
 - Xezat
-(FFVI) "Summons" are known as?:
+(FFVI) 'Summons' are known as?:
 - Espers
 - Esper
 (FFVI) Celes posed as who in an opera?:
@@ -706,12 +706,12 @@
 (FFVI) Deathgaze is only encountered while riding which mode of transport?:
 - Airship
 (FFVI) General Leo had a Magitek infusion. True/False?:
-- 'False'
+- "False"
 (FFVI) How many espers are there in the game?:
 - 27
 (FFVI) How many permanent playable characters are there?:
 - 14
-(FFVI) Name Setzer"s airship.:
+(FFVI) Name Setzer's airship.:
 - The Blackjack
 - Blackjack
 (FFVI) Name a character that Gau refers to as "Mr. Thou".:
@@ -734,11 +734,11 @@
 - Gladius
 (FFVI) What do you feed Cid with to help him recover in the World of Ruins?:
 - Fish
-(FFVI) What is Locke"s so-called profession?:
+(FFVI) What is Locke's so-called profession?:
 - Treasure Hunter
-(FFVI) What is Shadow"s real name?:
+(FFVI) What is Shadow's real name?:
 - Clyde
-(FFVI) What is the name of Shadow"s dog?:
+(FFVI) What is the name of Shadow's dog?:
 - Interceptor
 (FFVI) What name did Edgar go by in the World of Ruins?:
 - Gerad
@@ -747,61 +747,61 @@
 - Treasure hunt
 (FFVI) What was the command exclusive to Leo?:
 - Shock
-(FFVI) When Ultros says "Oh, that one"s a tasty morsel!" who has he set his sights on?:
+(FFVI) When Ultros says "Oh, that one's a tasty morsel!" who has he set his sights on?:
 - Terra
-(FFVI) Which one of Mog"s dances cannot be acquired in the World of Ruin?:
+(FFVI) Which one of Mog's dances cannot be acquired in the World of Ruin?:
 - Water Rondo
 (FFVI) Who does Relm call a "fuddy duddy"?:
 - Strago
 (FFVI) Who first saves Terra and removes her slave crown?:
 - Arvis
-(FFVI) Who is Edgar"s brother?:
+(FFVI) Who is Edgar's brother?:
 - Sabin
-(FFVI) Who is Terra"s father?:
+(FFVI) Who is Terra's father?:
 - Maduin
-(FFVI) Who is Terra"s mother?:
+(FFVI) Who is Terra's mother?:
 - Madeline
 - Madonna
 (FFVI) Who is the first esper you receive?:
 - Ramuh
 (FFVI) Who is the leader of The Returners?:
 - Banon
-(FFVI) Who was Shadow"s partner-in-crime?:
+(FFVI) Who was Shadow's partner-in-crime?:
 - Baram
-(FFVI) Who was responsible for awakening Terra"s esper form?:
+(FFVI) Who was responsible for awakening Terra's esper form?:
 - Valigarmanda
 - Tritoch
 (FFVI) Who was the original owner of The Falcon?:
 - Darill
 (FFVII C.C.) How many fan clubs does Genesis have? (Answer without numerics):
 - Two
-(FFVII C.C.) It"s possible for Zack to have a fan club. True/False?:
-- 'True'
-'(FFVII C.C.) The naming scheme for Angeal"s special moves is inspired by? (Hint: Christianity)':
+(FFVII C.C.) It's possible for Zack to have a fan club. True/False?:
+- "True"
+"(FFVII C.C.) The naming scheme for Angeal's special moves is inspired by? (Hint: Christianity)":
 - The Seven Deadly Sins
 - Seven Deadly Sins
 - 7 Deadly Sins
-(FFVII C.C.) What"s the name of Angeal"s fan club?:
+(FFVII C.C.) What's the name of Angeal's fan club?:
 - Keepers of Honor
-(FFVII C.C.) What"s the name of Genesis"s fan club?:
+(FFVII C.C.) What's the name of Genesis's fan club?:
 - Red Leather
 - Study Group
-(FFVII C.C.) What"s the name of Sephiroth"s fan club?:
+(FFVII C.C.) What's the name of Sephiroth's fan club?:
 - Silver Elite
-(FFVII C.C.) What"s the real full name of "Project G"?:
+(FFVII C.C.) What's the real full name of "Project G"?:
 - Project Gillian
-(FFVII C.C.) What"s the title of Genesis"s favorite book?:
+(FFVII C.C.) What's the title of Genesis's favorite book?:
 - LOVELESS
-(FFVII C.C.) What"s the true name for dumbapples?:
+(FFVII C.C.) What's the true name for dumbapples?:
 - Banora White
 (FFVII C.C.) Which real life singer served as the character design model for Genesis Rhapsodos?:
 - GACKT
-(FFVII C.C.) Who is Angeal"s mother?:
+(FFVII C.C.) Who is Angeal's mother?:
 - Gillian Hewley
 - Gillian
-(FFVII C.C.) Who is Zack"s mentor?:
+(FFVII C.C.) Who is Zack's mentor?:
 - Angeal
-(FFVII C.C.) Who is the leader of Sephiroth"s fan club?:
+(FFVII C.C.) Who is the leader of Sephiroth's fan club?:
 - Professor Hojo
 - Hojo
 (FFVII C.C.) Who operates under the codename, "Black Suit"?:
@@ -812,41 +812,41 @@
 (FFVII) Besides the Gold Chocobo, which Chocobo has the ability to traverse mountains?:
 - Black Chocobo
 (FFVII) Sephiroth is right-handed. True/False?:
-- 'False'
-(FFVII) There exists a female of Red XIII"s species. True/False?:
-- 'True'
+- "False"
+(FFVII) There exists a female of Red XIII's species. True/False?:
+- "True"
 (FFVII) Well-known katana.:
 - Masamune
-(FFVII) What is Cid"s occupation/role?:
+(FFVII) What is Cid's occupation/role?:
 - Pilot
-(FFVII) What is Red XIII"s real name?:
+(FFVII) What is Red XIII's real name?:
 - Nanaki
-(FFVII) What is the name of Aerith"s level 4 Limit Break?:
+(FFVII) What is the name of Aerith's level 4 Limit Break?:
 - Great Gospel
-(FFVII) What is the name of Barret"s level 4 Limit Break?:
+(FFVII) What is the name of Barret's level 4 Limit Break?:
 - Catastrophe
-(FFVII) What is the name of Cait Sith"s level 4 Limit Break?:
-- He doesn"t have one
+(FFVII) What is the name of Cait Sith's level 4 Limit Break?:
+- He doesn't have one
 - None
 - Nil
 - Invalid
-- Doesn"t have one
+- Doesn't have one
 - Non-existent
 - doesnt have one
-(FFVII) What is the name of Cid"s level 4 Limit Break?:
+(FFVII) What is the name of Cid's level 4 Limit Break?:
 - Highwind
-(FFVII) What is the name of Cloud"s level 4 Limit Break?:
+(FFVII) What is the name of Cloud's level 4 Limit Break?:
 - Omnislash
-(FFVII) What is the name of Red XIII"s level 4 Limit Break?:
+(FFVII) What is the name of Red XIII's level 4 Limit Break?:
 - Cosmo Memory
-(FFVII) What is the name of Tifa"s level 4 Limit Break?:
+(FFVII) What is the name of Tifa's level 4 Limit Break?:
 - Final Heaven
-(FFVII) What is the name of Vincent"s level 4 Limit Break?:
+(FFVII) What is the name of Vincent's level 4 Limit Break?:
 - Chaos
-(FFVII) What is the name of Yuffie"s level 4 Limit Break?:
+(FFVII) What is the name of Yuffie's level 4 Limit Break?:
 - All Creation
 (FFVII) What is the name of the move with the longest-running animation scene?:
-- Sephiroth"s Supernova
+- Sephiroth's Supernova
 - Supernova
 (FFVII) What is the one FFVII spin-off that never left Japan?:
 - Before Crisis
@@ -854,28 +854,28 @@
 - Knights of the Round
 (FFVII) What type of weapon does Cait Sith use?:
 - Megaphone
-(FFVII) Who is Sephiroth"s mother?:
+(FFVII) Who is Sephiroth's mother?:
 - Lucrecia Crescent
 - Lucrecia
 (FFVII) Who is the Shinra employee controlling Cait Sith?:
 - Reeve
 (FFVII) With whom is Elena in love?:
 - Tseng
-(FFVII) You get the Blue Magic, "Beta", from which monster?:
+(FFVII) You get the Blue Magic, 'Beta', from which monster?:
 - Midgar Zolom
 - Midgardsormr
-(FFVIII) "Eyes on Me" was sung by?:
+(FFVIII) 'Eyes on Me' was sung by?:
 - Faye Wong
 (FFVIII) From which tribe do the Mumbaas originate?:
 - Shumi
-(FFVIII) How many attacks are there in Squall"s Lionheart limit break?:
+(FFVIII) How many attacks are there in Squall's Lionheart limit break?:
 - 17
 (FFVIII) In the entirety of the game, Fujin only gives one-word comments. True/False?:
-- 'False'
+- "False"
 (FFVIII) In two words; what happens to Laguna when he gets nervous?:
 - Leg cramp
-(FFVIII) It is possible to use Selphie"s "The End" Limit Break on the final boss. True/False?:
-- 'True'
+(FFVIII) It is possible to use Selphie's "The End" Limit Break on the final boss. True/False?:
+- "True"
 (FFVIII) Name the 2 main members of The Forest Owls besides Rinoa. (\_\_\_ and \_\_\_):
 - Zone and Watts
 - Watts and Zone
@@ -889,52 +889,52 @@
 (FFVIII) Seifer, Fujin, and Raijin, make up what committee?:
 - Disciplinary Committee
 - Disciplinary
-(FFVIII) Squall"s character design was heavily influenced by which real life actor?:
+(FFVIII) Squall's character design was heavily influenced by which real life actor?:
 - River Phoenix
 (FFVIII) There are absolutely no moogles in Final Fantasy VIII. True/False?:
-- 'False'
+- "False"
 (FFVIII) There is a "hidden" Limit Break combat move for Zell. True/False?:
 - True (Armageddon Fist)
-- 'True'
+- "True"
 (FFVIII) There is a map of the real world somewhere in Winhill. True/False?:
-- 'True'
+- "True"
 (FFVIII) What always gets sold out in Balamb Garden cafeteria?:
 - Hotdogs
 - Hot dogs
 (FFVIII) What does GF stand for?:
 - Guardian Force
-(FFVIII) What is Cid"s occupation/role?:
+(FFVIII) What is Cid's occupation/role?:
 - Headmaster of Balamb Garden
 - Headmaster
-(FFVIII) What is General Caraway"s first name?:
+(FFVIII) What is General Caraway's first name?:
 - Fury
-(FFVIII) What is MiniMog"s role?:
+(FFVIII) What is MiniMog's role?:
 - A GF
 - GF
-(FFVIII) What is the fictional character mentioned by Seifer, "Sorceress Knight", named as?:
+(FFVIII) What is the fictional character mentioned by Seifer, 'Sorceress Knight', named as?:
 - Zefer
-(FFVIII) What is the name Rinoa"s dog?:
+(FFVIII) What is the name Rinoa's dog?:
 - Angelo
-(FFVIII) What is the name of Irvine"s ultimate Limit Break/shot?:
+(FFVIII) What is the name of Irvine's ultimate Limit Break/shot?:
 - Hyper Shot
-(FFVIII) What is the name of Quistis"s ultimate Limit Break?:
+(FFVIII) What is the name of Quistis's ultimate Limit Break?:
 - Shockwave Pulsar
-(FFVIII) What is the name of Rinoa"s ultimate Limit Break?:
+(FFVIII) What is the name of Rinoa's ultimate Limit Break?:
 - Wishing Star/Angel Wing
 - Wishing Star
 - Angel Wing
-(FFVIII) What is the name of Selphie"s ultimate Limit Break?:
+(FFVIII) What is the name of Selphie's ultimate Limit Break?:
 - The End
-(FFVIII) What is the name of Squall"s ultimate Limit Break?:
+(FFVIII) What is the name of Squall's ultimate Limit Break?:
 - Lionheart
 - Lion Heart
-(FFVIII) What is the name of Zell"s ultimate Limit Break?:
+(FFVIII) What is the name of Zell's ultimate Limit Break?:
 - My Final Heaven/Armageddon Fist
 - Final Heaven
 - Armageddon Fist
 (FFVIII) What is the name of the card game?:
 - Triple Triad
-(FFVIII) What is the name of the creature engraved in Squall"s Revolver?:
+(FFVIII) What is the name of the creature engraved in Squall's Revolver?:
 - Griever
 (FFVIII) What is the name of the dirty magazines present in the game?:
 - Girl Next Door
@@ -953,33 +953,33 @@
 (FFVIII) What is the ultimate GF?:
 - Eden
 (FFVIII) Where can Headmaster Martine be found after Galbadia Garden was overtaken?:
-- Fisherman"s Horizon
+- Fisherman's Horizon
 - Fisherman Horizon
-(FFVIII) Where is Edea"s orphanage located?:
+(FFVIII) Where is Edea's orphanage located?:
 - Cape of Good Hope
-(FFVIII) Where is Laguna"s hometown?:
+(FFVIII) Where is Laguna's hometown?:
 - Winhill
 (FFVIII) Which monster interrupted Laguna while filming?:
 - Ruby Dragon
-(FFVIII) Who are Laguna"s sidekicks? (\_\_\_ and \_\_\_):
+(FFVIII) Who are Laguna's sidekicks? (\_\_\_ and \_\_\_):
 - Ward and Kiros
 - Kiros and Ward
-(FFVIII) Who are Seifer"s sidekicks? (\_\_\_ and \_\_\_):
+(FFVIII) Who are Seifer's sidekicks? (\_\_\_ and \_\_\_):
 - Fujin and Raijin
 - Raijin and Fujin
-(FFVIII) Who is Laguna"s wife?:
+(FFVIII) Who is Laguna's wife?:
 - Raine
-(FFVIII) Who is Rinoa"s father?:
+(FFVIII) Who is Rinoa's father?:
 - General Caraway
 - Fury
 - Fury Caraway
-(FFVIII) Who is Rinoa"s mother?:
+(FFVIII) Who is Rinoa's mother?:
 - Julia Heartilly
 - Julia
-(FFVIII) Who is Squall"s father?:
+(FFVIII) Who is Squall's father?:
 - Laguna Loire
 - Laguna
-(FFVIII) Who is Squall"s mother?:
+(FFVIII) Who is Squall's mother?:
 - Raine Loire
 - Raine
 (FFVIII) Who is the headmaster of Galbadia Garden?:
@@ -992,66 +992,66 @@
 - Queen of Cards
 - Card Queen
 - Ishtar
-(FFVIII) You are never able to enter Zell"s room. True/False?:
-- 'False'
+(FFVIII) You are never able to enter Zell's room. True/False?:
+- "False"
 (FFVIII) You need a certain series of magazines in order to upgrade your weapons. True/False?:
-- 'False'
-(FFX) "Summons" are known as?:
+- "False"
+(FFX) 'Summons' are known as?:
 - Aeons
 - Aeon
 (FFX) At the end of the game, what advice does Yuna give her people regarding lost friends or faded dreams?:
 - Never forget them
 (FFX) Lulu and Wakka gets married. True/False?:
-- 'True'
-(FFX) What color is Yuna"s right eye?:
+- "True"
+(FFX) What color is Yuna's right eye?:
 - Green
 (FFX) What does Lulu wield as weapons?:
 - Dolls
 - Doll
-(FFX) What is one of Rikku"s biggest fears?:
+(FFX) What is one of Rikku's biggest fears?:
 - Lightning
 - Thunder
 - Snake
-(FFX) What is the name of Rikku"s brother?:
+(FFX) What is the name of Rikku's brother?:
 - Brother
-(FFX) What is the name of Tidus"s home blitzball team?:
+(FFX) What is the name of Tidus's home blitzball team?:
 - Zanarkand Abes
-(FFX) What is the name of Wakka"s home blitzball team?:
+(FFX) What is the name of Wakka's home blitzball team?:
 - Besaid Aurochs
 (FFX) What was the original name for The Crusaders?:
 - The Crimson Blades
 - Crimson Blades
 (FFX) Who created Sin?:
 - Yu Yevon
-(FFX) Who is Lady Yunalesca"s husband?:
+(FFX) Who is Lady Yunalesca's husband?:
 - Zaon
-(FFX) Who is Wakka"s younger brother?:
+(FFX) Who is Wakka's younger brother?:
 - Chappu
-(FFX) Who is Yuna"s father?:
+(FFX) Who is Yuna's father?:
 - Braska
 (FFX) Who is the fayth of aeon Anima?:
-- Seymour"s mother
+- Seymour's mother
 (FFX) Who is the head commander of The Crusaders?:
 - Wen Kinoc
 (FFX) Who refers to Yuna as "Yunie"?:
 - Rikku
 (FFX-2) After the events of FFX-2, Yuna & Tidus breaks up and Sin is revived. True/False?:
-- 'True'
-(FFX-2) Complete the commercial tagline - "Last time she saved the world. This time it"s \_\_\_.":
+- "True"
+(FFX-2) Complete the commercial tagline - "Last time she saved the world. This time it's \_\_\_.":
 - personal
-(FFX-2) What are the names of Leblanc"s two lackeys? (\_\_\_ and \_\_\_):
+(FFX-2) What are the names of Leblanc's two lackeys? (\_\_\_ and \_\_\_):
 - Ormi and Logos
 - Logos and Ormi
-(FFX-2) What is the name of Yuna"s signature pistols?:
+(FFX-2) What is the name of Yuna's signature pistols?:
 - Tiny Bee
-(FFX-2) What is the name of the Gullwings" airship?:
+(FFX-2) What is the name of the Gullwings' airship?:
 - The Celsius
 - Celsius
 (FFX-2) What is the name of the blitzball team of which Biggs and Wedge are a part of?:
 - Gull Wings
 (FFX-2) What is the name of the rival group to Gullwings?:
 - Leblanc Syndicate
-(FFX-2) What is the title of the song sung during Yuna"s concert?:
+(FFX-2) What is the title of the song sung during Yuna's concert?:
 - 1000 Words
 - Thousand Words
 (FFX-2) Who Yuna thought was Tidus from a sphere recording turned out to be \_\_\_.:
@@ -1066,26 +1066,26 @@
 - Six
 (FFXIII) How many possible 3-man Paradigms/Optimas are there?:
 - 56
-(FFXIII) Name Fang"s eidolon.:
+(FFXIII) Name Fang's eidolon.:
 - Bahamut
-(FFXIII) Name Hope"s eidolon.:
+(FFXIII) Name Hope's eidolon.:
 - Alexander
-(FFXIII) Name Lightning"s eidolon.:
+(FFXIII) Name Lightning's eidolon.:
 - Odin
-(FFXIII) Name Sazh"s eidolon.:
+(FFXIII) Name Sazh's eidolon.:
 - Brynhildr
-(FFXIII) Name Snow"s eidolon.:
+(FFXIII) Name Snow's eidolon.:
 - Shiva
 - Shiva sisters
 - Stiria and Nix
 - Nix and Stiria
-(FFXIII) Name Vanille"s eidolon.:
+(FFXIII) Name Vanille's eidolon.:
 - Hecatoncheir
-(FFXIII) Sazh"s weapons are named after?:
+(FFXIII) Sazh's weapons are named after?:
 - Stars & constellations
 - Constellations
 - Stars
-(FFXIII) Shiva, Ifrit, Ramuh, Leviathan, Valefor, Carbuncle, Siren. Which one of these eidolons doesn"t make an appearance in-game?:
+(FFXIII) Shiva, Ifrit, Ramuh, Leviathan, Valefor, Carbuncle, Siren. Which one of these eidolons doesn't make an appearance in-game?:
 - Leviathan
 (FFXIII) The En-spell series of spells first originated from which FF series? (Answer in FF_):
 - FFXI
@@ -1096,13 +1096,13 @@
 (FFXIII) The city, Palumpolum, is named after? (\_\_\_ and \_\_\_):
 - Palom and Porom
 - Porom and Palom
-(FFXIII) The fal"Cie, Anima, is named after a summon of the same name from which FF series? (Answer in FF_):
+(FFXIII) The fal'Cie, Anima, is named after a summon of the same name from which FF series? (Answer in FF_):
 - FFX
 - FF10
-(FFXIII) The fal"Cie, Eden, is named after a summon of the same name from which FF series? (Answer in FF_):
+(FFXIII) The fal'Cie, Eden, is named after a summon of the same name from which FF series? (Answer in FF_):
 - FFVIII
 - FF8
-(FFXIII) The fal"Cie, Kujata, is named after a summon of the same name from which FF series? (Answer in FF_):
+(FFXIII) The fal'Cie, Kujata, is named after a summon of the same name from which FF series? (Answer in FF_):
 - FFVII
 - FF7
 (FFXIII) What form does Brynhildr take in Gestalt Mode?:
@@ -1112,7 +1112,7 @@
 (FFXIII) What form does Shiva take in Gestalt Mode?:
 - Motorcycle
 - Motorbike
-(FFXIII) What is Lightning"s real name?:
+(FFXIII) What is Lightning's real name?:
 - Claire Farron
 - Eclair
 - Claire
@@ -1121,18 +1121,18 @@
 (FFXIII) What is the name of the enemy boss which resembles the Proud Clod from FFVII?:
 - The Proudclad
 - Proudclad
-(FFXIII) What is the ultimate end-goal/Focus of l"Cie?:
+(FFXIII) What is the ultimate end-goal/Focus of l'Cie?:
 - Destroy Cocoon
-(FFXIII) Where is Lightning"s l"Cie brand?:
+(FFXIII) Where is Lightning's l'Cie brand?:
 - Chest
-(FFXIII) Which fal"Cie branded Dajh?:
+(FFXIII) Which fal'Cie branded Dajh?:
 - Kujata
-(FFXIII) Which fal"Cie serves as the main source of power for Cocoon?:
+(FFXIII) Which fal'Cie serves as the main source of power for Cocoon?:
 - Orphan
 (FFXIII) Who has the ability to sense beings from Pulse?:
 - Dajh Katzroy
 - Dajh
-(FFXIII) Who is Jihl Nabaat"s right-hand man?:
+(FFXIII) Who is Jihl Nabaat's right-hand man?:
 - Yaag Rosch
 - Yaag
 - Rosch
@@ -1143,7 +1143,7 @@
 (FFXIII) \_\_\_ and \_\_\_ make up the Shiva sisters.:
 - Nix and Stiria
 - Stiria and Nix
-(FFXIII-2) What is Caius"s full name?:
+(FFXIII-2) What is Caius's full name?:
 - Paddra Ballad-Caius
 - Paddra Ballad Caius
 (FFXIV) How many dragon killers are present on the Steps of Faith? (Answer without numerics):
@@ -1156,11 +1156,11 @@
 - World of Darkness
 (FFXIV) There was an event which featured Lightning from FFXIII, what is the name of this event?:
 - Lightning Strikes
-(FFXIV) Ultros & Typhon from FFVI makes an appearance as optional bosses in which NPC"s storyline?:
+(FFXIV) Ultros & Typhon from FFVI makes an appearance as optional bosses in which NPC's storyline?:
 - Hildibrand
 (FFXIV) What does Teledji Adeledji raises as a pet?:
 - Gil Turtle
-(FFXIV) What is Bahamut Prime"s signature move?:
+(FFXIV) What is Bahamut Prime's signature move?:
 - Tera Flare
 - Teraflare
 (FFXIV) What is a Magitek Armor used as?:
@@ -1179,10 +1179,10 @@
 - Nabriales
 - Ascian Napriales
 - Napriales
-(FFXIV) Who is Livia sas Junius"s sister?:
+(FFXIV) Who is Livia sas Junius's sister?:
 - Lucia goe Junius
 - Lucia
-(FFXIV) Who is known as "The Black Wolf"?:
+(FFXIV) Who is known as 'The Black Wolf'?:
 - Gaius van Baelsar
 - Gaius
 (FFXIV) Who is the "duelist" who challenges adventurers and takes their weapons upon defeating them?:
@@ -1217,7 +1217,7 @@
 (FFXV) Biggs & Wedge are the lackeys of who?:
 - Aranea Highwind
 - Aranea
-(FFXV) Complete this quote from Ignis, "That"s it! I"ve \_\_\_!:
+(FFXV) Complete this quote from Ignis, "That's it! I've \_\_\_!:
 - Come up with a new recipe
 (FFXV) How did Gladiolus get the (additional) horizontal scar on his forehead?:
 - Fight with Gilgamesh
@@ -1230,9 +1230,9 @@
 - Protecting Noctis
 (FFXV) How many floors does the deepest sealed-door dungeon have?:
 - 100
-(FFXV) Name Lunafreya"s black dog.:
+(FFXV) Name Lunafreya's black dog.:
 - Umbra
-(FFXV) Name Lunafreya"s white dog.:
+(FFXV) Name Lunafreya's white dog.:
 - Pryna
 (FFXV) Name the character who was scrapped and replaced by Lunafreya Nox Fleuret.:
 - Stella Nox Fleuret
@@ -1250,16 +1250,16 @@
 (FFXV) The "creatures of the night" are known as?:
 - Daemons
 - Daemon
-(FFXV) The head of Ramuh"s staff is modeled after which other summon from the FF series?:
+(FFXV) The head of Ramuh's staff is modeled after which other summon from the FF series?:
 - Ixion
 (FFXV) There is a Royal Arm in the form of a gun. True/False?:
-- 'False'
+- "False"
 (FFXV) There is a real-life car modeled after the Regalia produced by which automotive company?:
 - Audi
 (FFXV) There is a sniper rifle (with useable scope) in the game. True/False?:
-- 'True'
+- "True"
 (FFXV) There is/was a glitch in the game which allowed the player to have Aranea join the party (not just assist during battle). True/False?:
-- 'True'
+- "True"
 (FFXV) Those with Lucis royal blood are able to use a skill to conjure specific weapons from thin air, what is this skill called?:
 - Armiger Arsenal
 - Armiger
@@ -1270,7 +1270,7 @@
 (FFXV) What is the most valuable item you can get from playing Justice Monsters Five?:
 - Wind-up Lord Vexxos
 - Wind up Lord Vexxos
-(FFXV) What is the name of King Regis"s car?:
+(FFXV) What is the name of King Regis's car?:
 - Regalia
 (FFXV) What is the name of the monster-bird nesting in the Rock of Ravatogh?:
 - Zu
@@ -1282,20 +1282,20 @@
 - Versus XIII
 (FFXV) Which fish is generally regarded as the hardest to catch?:
 - Pink Jade Gar
-(FFXV) Who is Gladiolus"s father?:
+(FFXV) Who is Gladiolus's father?:
 - Clarus Amicitia
 - Clarus
 (FFXV) Who is known as "The Dragoon"?:
 - Aranea Highwind
 - Aranea
 (RECORD KEEPER) "Mythril" is the in-game currency that is bought with real money. True/False?:
-- 'False'
-'(RECORD KEEPER) Final Fantasy: Record Keeper has its own unique OST album. True/False?':
-- 'True'
+- "False"
+"(RECORD KEEPER) Final Fantasy: Record Keeper has its own unique OST album. True/False?":
+- "True"
 (RECORD KEEPER) It is possible to draw a 5* (or higher) relic from the free daily draw. True/False?:
-- 'True'
+- "True"
 (RECORD KEEPER) It is possible to have a 8* relic. True/False?:
-- 'True'
+- "True"
 (RECORD KEEPER) Name a character who can use books besides Tyro.:
 - Alphinaud/Onion Knight
 - Alphinaud
@@ -1322,12 +1322,12 @@
 - FFVII
 - FF7
 (RECORD KEEPER) There is a Summon that hits more than 3x. True/False?:
-- 'True'
+- "True"
 (RECORD KEEPER) There is a secret Dress Record for Cloud in cross-dressing form. True/False?:
-- 'False'
+- "False"
 (RECORD KEEPER) There is/was an exclusive invitation-only MVP club which you could join if you spent 20,000USD or more on in-game purchases. True/False?:
 - (The condition is) False
-- 'False'
+- "False"
 (RECORD KEEPER) What does the term, BSB, stand for?:
 - Burst Soul Break
 (RECORD KEEPER) What does the term, CLSB, stand for?:
@@ -1341,14 +1341,14 @@
 - Ultra Soul Break
 (RECORD KEEPER) What is the first boss introduced for the official release of Multiplayer Raids?:
 - Gilgamesh
-(RECORD KEEPER) What is the name of the ability that has the power to reduce an enemy"s chance of inflicting debuffs?:
+(RECORD KEEPER) What is the name of the ability that has the power to reduce an enemy's chance of inflicting debuffs?:
 - Affliction Break
 (RECORD KEEPER) What is the name of the buff that prevents fatal damage once?:
 - Last Stand
 (RECORD KEEPER) What is the name of the main character?:
 - Tyro
 - Deshi
-(RECORD KEEPER) What is the official term for "costumes" which you can use to change your characters" sprite design?:
+(RECORD KEEPER) What is the official term for "costumes" which you can use to change your characters' sprite design?:
 - Dress Records
 - Dress Record
 (RECORD KEEPER) What type of Materia are bound to characters?:
@@ -1358,12 +1358,12 @@
 - Onion Knight
 (RECORD KEEPER) Who is known as "the female Tyro"?:
 - Urara
-(RECORD KEEPER) Who is the main character"s mentor?:
+(RECORD KEEPER) Who is the main character's mentor?:
 - Dr. Mog
 - Dr Mog
 (RECORD KEEPER) Who is the main character?:
 - Tyro
-(TYPE-0) Name a member of Class Zero who isn"t assigned a number.:
+(TYPE-0) Name a member of Class Zero who isn't assigned a number.:
 - Rem Tokimiya or Machina Kunagiri
 - Rem Tokimiya
 - Rem
@@ -1371,50 +1371,50 @@
 - Machina Kunagiri
 - Machina
 - Kunagiri
-(TYPE-0) What is Ace"s weapon of choice?:
+(TYPE-0) What is Ace's weapon of choice?:
 - Cards
 - Card
-(TYPE-0) What is Cater"s weapon of choice?:
+(TYPE-0) What is Cater's weapon of choice?:
 - Magicite pistol
 - Gun
 - Pistol
-(TYPE-0) What is Cinque"s weapon of choice?:
+(TYPE-0) What is Cinque's weapon of choice?:
 - Mace
-(TYPE-0) What is Deuce"s weapon of choice?:
+(TYPE-0) What is Deuce's weapon of choice?:
 - Flute
-(TYPE-0) What is Eight"s weapon of choice?:
+(TYPE-0) What is Eight's weapon of choice?:
 - Knuckles
 - Fists
 - Fist
-(TYPE-0) What is Jack"s weapon of choice?:
+(TYPE-0) What is Jack's weapon of choice?:
 - Katana
-(TYPE-0) What is Joker"s real name?:
+(TYPE-0) What is Joker's real name?:
 - Lean Hampelmann
-(TYPE-0) What is King"s weapon of choice?:
+(TYPE-0) What is King's weapon of choice?:
 - Dual guns
 - Guns
 - Gun
-(TYPE-0) What is Kurasame Susaya"s nickname?:
+(TYPE-0) What is Kurasame Susaya's nickname?:
 - Ice Reaper
-(TYPE-0) What is Machina"s weapon of choice?:
+(TYPE-0) What is Machina's weapon of choice?:
 - Twin rapiers
 - Rapiers
 - Rapier
-(TYPE-0) What is Nine"s weapon of choice?:
+(TYPE-0) What is Nine's weapon of choice?:
 - Spear
-(TYPE-0) What is Queen"s weapon of choice?:
+(TYPE-0) What is Queen's weapon of choice?:
 - Sword
-(TYPE-0) What is Rem"s weapon of choice?:
+(TYPE-0) What is Rem's weapon of choice?:
 - Twin daggers
 - Daggers
 - Dagger
-(TYPE-0) What is Seven"s weapon of choice?:
+(TYPE-0) What is Seven's weapon of choice?:
 - Whipblade
-(TYPE-0) What is Sice"s weapon of choice?:
+(TYPE-0) What is Sice's weapon of choice?:
 - Scythe
-(TYPE-0) What is Tiz"s real name?:
+(TYPE-0) What is Tiz's real name?:
 - Tohno Mahoroha
-(TYPE-0) What is Trey"s weapon of choice?:
+(TYPE-0) What is Trey's weapon of choice?:
 - Bow
 (TYPE-0) Who is No.00 of Class Zero?:
 - Joker
@@ -1633,7 +1633,7 @@ Flans are generally weak against...:
 - Black Magic
 - Magic
 Iconic painting.:
-- Lakshmi"s Portrait
+- Lakshmi's Portrait
 - Portrait of Lakshmi
 In the entire FFVII universe, how many known members of Turks are there in total?:
 - 17
@@ -1651,7 +1651,7 @@ Name one title from the main Final Fantasy series that does not feature EXP poin
 - FF10
 Name the accessory that generally grants immunity to most debuffs.:
 - Ribbon
-Name the first FF title where the logo included Yoshitaka Amano"s signature. (Answer in "FF_"):
+Name the first FF title where the logo included Yoshitaka Amano's signature. (Answer in "FF_"):
 - FFX
 - FF10
 Name the main character designer for the Final Fantasy series.:
@@ -1672,54 +1672,54 @@ THE male white mage.:
 - Mindu
 The names of Biggs & Wedge were inspired by characters sharing the same name in which popular movie & franchise?:
 - Star Wars
-The original North-America release of FFIV was actually Japan"s FFII with drastic content cut and lower difficulty. True/False?:
-- 'True'
-'There is an official version of FFIV known as "Final Fantasy IV: Easy Type". True/False?':
-- 'True'
+The original North-America release of FFIV was actually Japan's FFII with drastic content cut and lower difficulty. True/False?:
+- "True"
+"There is an official version of FFIV known as \"Final Fantasy IV: Easy Type\". True/False?":
+- "True"
 What armor does Gilgamesh wear?:
 - Genji
-What does the term, "ATB", stand for?:
+What does the term, 'ATB', stand for?:
 - Active Time Battle
-What is Alexander"s signature move?:
+What is Alexander's signature move?:
 - Divine Judgment
 - Divine Judgement
-What is Bahamut"s signature move?:
+What is Bahamut's signature move?:
 - Mega Flare
 - Giga Flare
 - Megaflare
 - Gigaflare
-What is Cactuar"s signature move?:
+What is Cactuar's signature move?:
 - 1000 Needles
 - 10000 Needles
-What is Diabolos" signature move?:
+What is Diabolos' signature move?:
 - Dark Messenger
-What is Gilgamesh"s widely known nickname?:
+What is Gilgamesh's widely known nickname?:
 - Greg
-What is Goblin"s signature move?:
+What is Goblin's signature move?:
 - Goblin Punch
-What is Ifrit"s signature move?:
+What is Ifrit's signature move?:
 - Hellfire
 - Inferno
-What is Leviathan"s signature move?:
+What is Leviathan's signature move?:
 - Tsunami
 - Tidal Wave
-What is Malboro"s signature move?:
+What is Malboro's signature move?:
 - Bad Breath
-What is Odin"s signature move?:
+What is Odin's signature move?:
 - Zantetsuken
-What is Ramuh"s signature move?:
+What is Ramuh's signature move?:
 - Judgment Bolt
 - Judgement Bolt
-What is Shiva"s signature move?:
+What is Shiva's signature move?:
 - Diamond Dust
-What is Titan"s signature move?:
-- Gaia"s Wrath
-What is Tonberry"s signature move?:
-- Everyone"s Grudge
+What is Titan's signature move?:
+- Gaia's Wrath
+What is Tonberry's signature move?:
+- Everyone's Grudge
 - Karma
-What is a moogle"s favorite food?:
+What is a moogle's favorite food?:
 - Kupo nut
-What was "Final Fantasy" originally named?:
+What was 'Final Fantasy' originally named?:
 - Fighting Fantasy
 Which FF title first featured Blue Magic? (Answer in "FF_"):
 - FFV
@@ -1727,12 +1727,12 @@ Which FF title first featured Blue Magic? (Answer in "FF_"):
 Which title from the main FF series was the first to feature voice acting? (Answer in "FF_"):
 - FFX
 - FF10
-Who is "The Man with the Machine Gun"?:
+Who is 'The Man with the Machine Gun'?:
 - Laguna
-Who is Gilgamesh"s sidekick?:
+Who is Gilgamesh's sidekick?:
 - Enkidu
-Who is the "One Winged Angel"?:
+Who is the 'One Winged Angel'?:
 - Sephiroth
-Who is widely regarded as the "Father of Final Fantasy"?:
+Who is widely regarded as the 'Father of Final Fantasy'?:
 - Hironobu Sakaguchi
 - Sakaguchi Hironobu

--- a/redbot/trivia/lists/gameofthrones.yaml
+++ b/redbot/trivia/lists/gameofthrones.yaml
@@ -46,24 +46,24 @@ What does Valar morghulis mean?:
 - All Men Must Die
 What is the customary response to Valar morghulis?:
 - Valar dohaeris
-What was the name of Arya Stark"s direwolf?:
+What was the name of Arya Stark's direwolf?:
 - Nymeria
-What was the name of Bran Stark"s direwolf?:
+What was the name of Bran Stark's direwolf?:
 - Summer
-What was the name of Jon Snow"s direwolf?:
+What was the name of Jon Snow's direwolf?:
 - Ghost
-What was the name of Rickon Stark"s direwolf?:
+What was the name of Rickon Stark's direwolf?:
 - Shaggydog
-What was the name of Robb Stark"s direwolf?:
+What was the name of Robb Stark's direwolf?:
 - Grey Wind
-What was the name of Sansa Stark"s direwolf?:
+What was the name of Sansa Stark's direwolf?:
 - Lady
 What was the name of the Valyrian Steel bastard sword of House Mormont?:
 - Longclaw
 What was the name of the Valyrian Steel blade given to Brienne of Tarth by Jaime Lannister?:
 - Oathkeeper
 What was the name of the Valyrian Steel blade given to Joffrey reforged from Ice?:
-- Widow"s Wail
+- Widow's Wail
 - widows wail
 What was the name of the Valyrian Steel blade of House Harlaw?:
 - Nightfall
@@ -81,63 +81,63 @@ What was the name of the Valyrian Steel two-handed greatsword of House Stark?:
 - Ice
 What was the name of the Valyrian Steel two-handed greatsword of House Tarly?:
 - Heartsbane
-Which House"s sigil is a black bear?:
+Which House's sigil is a black bear?:
 - House Mormont
 - Mormont
-Which House"s sigil is a bloody spear, gold on a night-black field?:
+Which House's sigil is a bloody spear, gold on a night-black field?:
 - House Slynt
 - Slynt
-Which House"s sigil is a crowned stag, black, on a golden field?:
+Which House's sigil is a crowned stag, black, on a golden field?:
 - House Baratheon
 - Baratheon
-Which House"s sigil is a flayed man?:
+Which House's sigil is a flayed man?:
 - House Bolton
 - Bolton
-Which House"s sigil is a golden kraken upon a black field?:
+Which House's sigil is a golden kraken upon a black field?:
 - House Greyjoy
 - Greyjoy
-Which House"s sigil is a golden lion upon a crimson field?:
+Which House's sigil is a golden lion upon a crimson field?:
 - House Lannister
 - Lannister
-Which House"s sigil is a golden rose on a grass-green field?:
+Which House's sigil is a golden rose on a grass-green field?:
 - House Tyrell
 - Tyrell
-Which House"s sigil is a grey direwolf on an ice-white field?:
+Which House's sigil is a grey direwolf on an ice-white field?:
 - House Stark
 - Stark
-Which House"s sigil is a leaping trout, silver, on a field of rippling blue and red?:
+Which House's sigil is a leaping trout, silver, on a field of rippling blue and red?:
 - House Tully
 - Tully
-Which House"s sigil is a mailed fist, silver on scarlet?:
+Which House's sigil is a mailed fist, silver on scarlet?:
 - House Glover
 - Glover
-Which House"s sigil is a purple lightning bolt on a black field?:
+Which House's sigil is a purple lightning bolt on a black field?:
 - House Dondarrion
 - Dondarrion
-Which House"s sigil is a red sun pierced by a golden spear?:
+Which House's sigil is a red sun pierced by a golden spear?:
 - House Martell
 - Martell
-Which House"s sigil is a roaring giant in shattered chains (four chains linked by a central ring on red in the tv show)?:
+Which House's sigil is a roaring giant in shattered chains (four chains linked by a central ring on red in the tv show)?:
 - House Umber
 - Umber
-Which House"s sigil is a striding huntsman?:
+Which House's sigil is a striding huntsman?:
 - House Tarly
 - Tarly
-Which House"s sigil is a three-headed dragon, red, on black?:
+Which House's sigil is a three-headed dragon, red, on black?:
 - House Targaryen
 - Targaryen
-Which House"s sigil is a white sun on black?:
+Which House's sigil is a white sun on black?:
 - House Karstark
 - Karstark
-Which House"s sigil is a yellow sun and crescent moon on quartered rose and azure?:
+Which House's sigil is a yellow sun and crescent moon on quartered rose and azure?:
 - House Tarth
 - Tarth
-Which House"s sigil is the moon-and-falcon, white, upon a sky blue field?:
+Which House's sigil is the moon-and-falcon, white, upon a sky blue field?:
 - House Arryn
 - Arryn
-Which House"s sigil is three dogs in the yellow of autumn grass?:
+Which House's sigil is three dogs in the yellow of autumn grass?:
 - House Clegane
 - Clegane
-Which House"s sigil is twin towers, blue on silvery grey?:
+Which House's sigil is twin towers, blue on silvery grey?:
 - House Frey
 - Frey

--- a/redbot/trivia/lists/games.yaml
+++ b/redbot/trivia/lists/games.yaml
@@ -1,13 +1,13 @@
-'"Call of Duty: Ghosts" is what number primary installment in the COD series?':
+"\"Call of Duty: Ghosts\" is what number primary installment in the COD series?":
 - Ten
 - 10
 - Tenth
 - 10th
-'"Crash Bandicoot" is set on a trio of islands southeast of where?':
+"\"Crash Bandicoot\" is set on a trio of islands southeast of where?":
 - Australia
-'"Donkey Kong 64" appeared on the Nintendo 64 in which year?':
+"\"Donkey Kong 64\" appeared on the Nintendo 64 in which year?":
 - 1999
-'"Relationship Matter" is the slogan of which social networking site?':
+"\"Relationship Matter\" is the slogan of which social networking site?":
 - Linked In
 - Linkedin
 Advertised briefly as the bloodiest video game in existence:
@@ -32,10 +32,10 @@ How many buttons (excluding the control pad) did the original NES controller hav
 - 4
 How many counters does a player start with in Backgammon?:
 - 15
-How many fighters are playable in "Street Fighter II"?:
+How many fighters are playable in 'Street Fighter II'?:
 - Eight
 - 8
-'How many levels are there in the Tower of Orthanc in "Lord of the Rings: The Two Towers"?':
+"How many levels are there in the Tower of Orthanc in \"Lord of the Rings: The Two Towers\"?":
 - 20
 - twenty
 How many possible opening moves are there in a game of draughts?:
@@ -43,7 +43,7 @@ How many possible opening moves are there in a game of draughts?:
 How many years after the events of Soulcalibur IV do the events of Soulcalibur V take place?:
 - 17
 - 17 years
-How much time does Link have to defeat Skull Kid in Majora"s Mask?:
+How much time does Link have to defeat Skull Kid in Majora's Mask?:
 - 3 days
 IN the "Final Fantasy X", where is blitzball played?:
 - Underwater
@@ -51,18 +51,18 @@ IN the official Monopoly rules, what happens when you land on "Free Parking"?:
 - Nothing
 IN which game does Mario wear the Tanooki Suit which gives him the ability to fly?:
 - Super Mario Bros 3
-If you"re killing a goomba, what game are you playing?:
+If you're killing a goomba, what game are you playing?:
 - Super Mario Bros
 - Mario
-'In "Animal Crossing: Wild World", what wildlife is found in the town observatory?':
+"In \"Animal Crossing: Wild World\", what wildlife is found in the town observatory?":
 - Owl
-'In "GTA: San Andreas", what is CJ"s older brother"s name?':
+"In \"GTA: San Andreas\", what is CJ's older brother's name?":
 - Sweet
-In "Pac-Man" for the Atari 2600, how many points were each pellet worth?:
+In "Twisted Metal 2", what does Krista Sparks drive?:
+- Grasshopper
+In 'Pac-Man' for the Atari 2600, how many points were each pellet worth?:
 - One
 - 1
-"In \"Twisted Metal 2‚\x80≥, what does Krista Sparks drive?":
-- Grasshopper
 In Chrono Trigger, who is the "Master of War?":
 - Spekkio
 In Monopoly, what is the rental on Boardwalk with one house?:
@@ -89,13 +89,13 @@ In the deathmatch mode of what game can you unlock William Shakespeare as a play
 - Medal of Honor
 In the earlier "Mario" games what is the character Princess Peach also known as?:
 - Princess Toadstool
-In the game "Chrono Trigger," what is Lucca"s mother"s name?:
+In the game "Chrono Trigger," what is Lucca's mother's name?:
 - Lara
 In the game "Paper Mario" what does the player have to collect for the main quest?:
 - Star Spirits
 In the game Joust, what animal was your mount?:
 - Ostrich
-In the original "Donkey Kong" arcade game, what was the ape"s favorite weapon to use against Mario?:
+In the original "Donkey Kong" arcade game, what was the ape's favorite weapon to use against Mario?:
 - Barrel
 - Barrels
 In the original Contra, what gun would "S" get you?:
@@ -121,7 +121,7 @@ In what year was the compact disk invented?:
 - 1965
 In which game in the "Star Fox" series was the game character based rather than flight based?:
 - Star Fox Adventures
-Mega Man"s traditional nemesis in the Mega Man series is whom?:
+Mega Man's traditional nemesis in the Mega Man series is whom?:
 - Dr. Wily
 - Dr wily
 Name of the Mad Scientist who created deformed creatures in the video game Farcry?:
@@ -153,11 +153,11 @@ The PS4, along with Xbox One and Wii U, is a part of what generation of video ga
 - 8
 - eight
 - eighth
-The Strong National Museum of Play has thousands of video games and it"s in Rochester in what state?:
+The Strong National Museum of Play has thousands of video games and it's in Rochester in what state?:
 - New York
-"The barrel roll from Star Fox 64 isn‚\x80\x99t actually a barrel roll but what?":
+The barrel roll from Star Fox 64 isn√¢‚Ç¨‚Ñ¢t actually a barrel roll but what?:
 - Aileron roll
-The first successful video game was "Pong", which was Atari"s arcade version of what game?:
+The first successful video game was "Pong", which was Atari's arcade version of what game?:
 - Table Tennis
 The game "Kingdom of Hearts" is the story of a boy of what name?:
 - Sora
@@ -168,7 +168,7 @@ What PopCap game required you to swap adjacent gems to form chains of three or m
 - Bejeweled
 What Rockstar Game was the first to feature bullet time?:
 - Max Payne
-What alternate dimension does Link find himself in in Majora"s Mask?:
+What alternate dimension does Link find himself in in Majora's Mask?:
 - Termina
 What color is the 1-up mushroom in Super Mario Bros.?:
 - Green
@@ -188,22 +188,22 @@ What game made popular the phrase "Do a barrel roll?":
 - Star Fox 64
 What game mixed both Disney characters with Final Fantasy characters?:
 - Kingdom Hearts
-What is Mario"s profession?:
+What is Mario's profession?:
 - Plumber
-What is Mario"s surname?:
+What is Mario's surname?:
 - Mario
-'What is the Helghast home planet in "Killzone: Shadowfall"?':
+"What is the Helghast home planet in \"Killzone: Shadowfall\"?":
 - Helghan
 What is the best selling game on the Nintendo Wii?:
 - Wii Sports
 What is the companion release to "Pokemon Diamond" on the Nintendo DS?:
 - Pearl
-What is the most powerful whip in "Castlevania 2"?:
+What is the most powerful whip in 'Castlevania 2'?:
 - Flame Whip
 What is the name of the Playstation controller that uses two analog joysticks?:
 - Dual Shock
 - Dualshock
-What is the name of the Star Fox Team"s cocky wingman?:
+What is the name of the Star Fox Team's cocky wingman?:
 - Falco Lombardi
 - Falco
 What is the name of the cloud-riding, glasses-wearing koopa in the Super Mario Bros. series?:
@@ -212,27 +212,27 @@ What is the name of town in Diablo?:
 - Tristram
 What is the theme of the game "Golden Nugget 64"?:
 - Gambling
-What is your character"s name in the "Legend of Zelda" series?:
+What is your character's name in the 'Legend of Zelda' series?:
 - Link
-'What kind of game is "Dementium: The Ward" on the Nintendo DS?':
+"What kind of game is \"Dementium: The Ward\" on the Nintendo DS?":
 - Survival Horror
 What member of the original StarFox team betrays the group to join StarWolf?:
 - Pigma Dengar
 - Pigma
 What mode in "Gran Turismo" do you play to unlock new cars and tracks?:
 - Simulation
-'What new 4-player co-op mode is introduced in "Call of Duty: Ghosts"?':
+"What new 4-player co-op mode is introduced in \"Call of Duty: Ghosts\"?":
 - Extinction
-What new button is featured on the PS4"s Dualshock 4 controllers?:
+What new button is featured on the PS4's Dualshock 4 controllers?:
 - SHARE
-'What number in the series is "Medal of Honor: Frontline"?':
+"What number in the series is \"Medal of Honor: Frontline\"?":
 - Fourth
 - Four
 - 4
 - 4th
 What number is the Pokemon "Scyther" in the Pokemon GameBoy games:
 - 123
-'What part of a prehistoric tree grants invulnerability in "Uncharted 2: Among Thieves"?':
+"What part of a prehistoric tree grants invulnerability in \"Uncharted 2: Among Thieves\"?":
 - Sap
 What popular PS3 game that spawned a sequel was narrated by Stephen Fry?:
 - Little Big Planet
@@ -243,7 +243,7 @@ What series is the theme "green hill zone" from?:
 - Sonic
 What video game made the Golden Gun famous?:
 - Goldeneye
-What was Mario"s original name?:
+What was Mario's original name?:
 - Jumpman
 What was the "beta version" of the Internet called?:
 - ARPAnet
@@ -265,16 +265,16 @@ What year was the Nintendo Game Boy released in the US?:
 - 1989
 What year was the first final fantasy created:
 - 1987
-What"s the first video game to become a television show:
+What's the first video game to become a television show:
 - pacman
 Which American Vice President referred to the Internet as an "Information Super Highway"?:
 - Al Gore
 Which Nintendo character is famous for being the first playable female hero in video game history?:
 - Samus
 - Samus Aran
-Which company developed the famous first person shooter game "Quake"?:
+Which company developed the famous first person shooter game 'Quake'?:
 - id Software
-Which company made the original "Donkey Kong"?:
+Which company made the original 'Donkey Kong'?:
 - Nintendo
 Which console did Nintendo release as their 3rd home console?:
 - Nintendo 64
@@ -282,40 +282,40 @@ Which famous skateboarder has his name on a skateboard video game series?:
 - Tony Hawk
 Which type of game is "Mortal Kombat"?:
 - Fighting
-Which was the first console "Duke Nukem" game?:
+Which was the first console "Duke Nukem' game?:
 - Duke Nukem 64
 Which was the second title in the "Professor Layton" series on the Nintendo DS?:
 - The Diabolical Box
 Who became the Real American Hero in the 1980s, when he battled COBRA?:
-- ''
+- ""
 - G.I. joe
 - GI Joe
-'Who created the music for N2O: Nitrous Oxide?':
+"Who created the music for N2O: Nitrous Oxide?":
 - The Crystal Method
 - Crystal Method
 Who invented Tetris?:
 - Alexey Pazhitnov
 - Alexey Pajitnov
-Who is Harry Potter"s best friend in the game "Harry Potter and the Chamber of Secrets"?:
+Who is Harry Potter's best friend in the game "Harry Potter and the Chamber of Secrets"?:
 - Ron Weasley
-Who is Mega Man"s creator?:
+Who is Mega Man's creator?:
 - Dr. Light
 - Dr Light
-Who is Mega Man"s sister?:
+Who is Mega Man's sister?:
 - Roll
-Who is Nathan Drake"s estranged wife in the "Uncharted" series?:
+Who is Nathan Drake's estranged wife in the "Uncharted" series?:
 - Elena Fisher
-'Who is the aging hippie ex-marijuana farmer in "GTA: San Andreas"?':
+"Who is the aging hippie ex-marijuana farmer in \"GTA: San Andreas\"?":
 - The Truth
 Who is the developer at Nintendo responsible for classics like Donkey Kong, Super Mario Bros., and The Legend of Zelda?:
 - Shigeru Miyamoto
 - Miyamoto
-Who is the famed musical director for Square"s Final Fantasy series?:
+Who is the famed musical director for Square's Final Fantasy series?:
 - Nobuo Uematsu
 - Uematsu
-Who is the first gym leader you fight in "Pokemon" for the Game Boy?:
+Who is the first gym leader you fight in 'Pokemon' for the Game Boy?:
 - Brock
-'Who is the main adversary in the Game Boy advance game "Zelda: The Minish Cap"?':
+"Who is the main adversary in the Game Boy advance game \"Zelda: The Minish Cap\"?":
 - Vaati
 - Vaati the Wind Mage
 Who is the main antagonist of "Battlefield 4"?:
@@ -324,21 +324,21 @@ Who is the main character from Final Fantasy IX?:
 - Zidane Tribal
 Who is the main character from Final Fantasy VII?:
 - Cloud Strife
-Who is the main character from Nintendo"s "Earthbound"?:
+Who is the main character from Nintendo's 'Earthbound'?:
 - Ness
 Who is the main character in Kingdom Hearts?:
 - Sora
-Who is the main character in the "DeathQuest" series?:
+Who is the main character in the 'DeathQuest' series?:
 - Lucretzia
-"Who is the main character of \"Battlefield 4‚\x80≥?":
+Who is the main character of "Battlefield 4"?:
 - Daniel Recker
-'Who is the main character of "GTA: San Andreas"?':
+"Who is the main character of \"GTA: San Andreas\"?":
 - CJ
 - Carl Johnson
 Who is the main character of Final Fantasy VIII?:
 - Squall Leonhart
 - Squall
-'Who is the main protagonist of "Call of Duty: Ghosts"?':
+"Who is the main protagonist of \"Call of Duty: Ghosts\"?":
 - Logan Walker
 Who is the main protagonist of "Final Fantasy X"?:
 - Tidus
@@ -346,10 +346,10 @@ Who is the owner of Lon Lon Ranch in the "Legend of Zelda" games?:
 - Talon
 Who is the son of Durotan, an Orcish chieftain in the World of Warcraft?:
 - Thrall
-Who is the third opponent in "Super Smash Brothers"?:
+Who is the third opponent in 'Super Smash Brothers'?:
 - Fox McCloud
 - Fox
-Who is the voice for 3DO"s Gex?:
+Who is the voice for 3DO's Gex?:
 - Dana Gould
 Who kisses Mario on the nose at the end of "Super Mario 64"?:
 - Princess Peach
@@ -357,10 +357,10 @@ Who must Kratos kill in "God of War"?:
 - Ares
 Who published the game "1942" on the NES?:
 - Capcom
-Who released the 2011 viral video "Friday"?:
+Who released the 2011 viral video 'Friday'?:
 - Rebecca Black
-Who was Sega"s mascot?:
+Who was Sega's mascot?:
 - Sonic the Hedgehog
 - Sonic
-Who was the main character in the original "Street Fighter"?:
+Who was the main character in the original 'Street Fighter'?:
 - Ryu

--- a/redbot/trivia/lists/general.yaml
+++ b/redbot/trivia/lists/general.yaml
@@ -1,29 +1,29 @@
-'"15, 30, 40, game" is used for the scoring system of what sport?':
+"\"15, 30, 40, game\" is used for the scoring system of what sport?":
 - Tennis
-'"Bharathanatiyam" is the national dance of what country?':
+"\"Bharathanatiyam\" is the national dance of what country?":
 - India
-'"I soiled my armor I was so scared!" is from which movie?':
+"\"I soiled my armor I was so scared!\" is from which movie?":
 - Monty Python and the Holy Grail
 - Monty Python
-'"I"ve been dead once, already. It"s very liberating." is from which movie?':
+"\"I've been dead once, already. It's very liberating.\" is from which movie?":
 - Batman
-'"Mr. Pink" is the alias of a character in which Quentin Tarantion film?':
+"\"Mr. Pink\" is the alias of a character in which Quentin Tarantion film?":
 - Reservoir Dogs
-'"Neuro" means related to the what?':
+"\"Neuro\" means related to the what?":
 - Brain
-'"Taipei" is the capital city of which country?':
+"\"Taipei\" is the capital city of which country?":
 - Taiwan
-'"The Grand Ole Opry" in America is famous for what type of music?':
+"'The Grand Ole Opry' in America is famous for what type of music?":
 - Country music
 - Country
-'"What"s up Doc" is the catchphrase of which cartoon character?':
+"'What's up Doc' is the catchphrase of which cartoon character?":
 - Bugs bunny
 A Muscovite refers to a native of what city?:
 - Moscow
-A disabling attack on a website known as a DDoS stands for a "Distributed (What of What?)"?:
+A disabling attack on a website known as a DDoS stands for a 'Distributed (What of What?)'?:
 - Denial of Service
 - distributed denial of service
-A palmiped"s feet are more commonly called what?:
+A palmiped's feet are more commonly called what?:
 - Webbed
 A prebiotic induces growth in humans (and other living hosts) of beneficial...?:
 - bacteria
@@ -40,7 +40,7 @@ A term for a dark shape against a brighter background is named after 18th centur
 - Silhouette
 A titi is what type of animal?:
 - Monkey
-According to DC Comics history, who was "Nightwing" when he was younger?:
+According to DC Comics history, who was 'Nightwing' when he was younger?:
 - Robin
 Actress Gwyneth Paltrow named her first child after which fruit?:
 - Apple
@@ -58,7 +58,7 @@ An annelid is a...?:
 - worm
 Ancient Egyptian Cleopatra was said to have been killed by what type of snake?:
 - Asp
-Angiosperm (from Greek "angeion", bottle) is a major scientific classification of land plants which have seeds and...?:
+Angiosperm (from Greek 'angeion', bottle) is a major scientific classification of land plants which have seeds and...?:
 - Flowers
 Aquae Sulis is the Roman name for what aptly renamed English spa city?:
 - Bath
@@ -110,9 +110,9 @@ British athlete Duncan Goodhew is associated with which sport?:
 - Swimming
 Characters Charlie Allnut and Rosie Sayer appeared in which classic 1951 movie?:
 - The African Queen
-'Complete the name of the American Football team: "Washington ..........."?':
+"Complete the name of the American Football team: 'Washington ...........'?":
 - Redskins
-Complete the title of the Oscar-nominated film starring Tom Cruise, "The Last ..."?:
+Complete the title of the Oscar-nominated film starring Tom Cruise, 'The Last ...'?:
 - Samurai
 Consecrated in 1962, what city is the Cathedral Church of St. Michael located in?:
 - Coventry
@@ -122,7 +122,7 @@ Convict Magwitch appears in which novel by Charles Dickens?:
 - Great Expectations
 Courgette is another name for which vegetable?:
 - Zucchini
-Curious George"s friend was The Man in the what color hat?:
+Curious George's friend was The Man in the what color hat?:
 - yellow
 Diamonds are an allotropic form of what element?:
 - Carbon
@@ -136,7 +136,7 @@ Dydd Sadwrn is Welsh for which day of the week?:
 - Saturday
 Edmonton is the capital of which province in Canada?:
 - Alberta
-English playwright Chrisopher Marlowe coined the phrase "The face that launched a thousand ships" in his tragedy Doctor Faustus when referring to which mythical Greek figure?:
+English playwright Chrisopher Marlowe coined the phrase 'The face that launched a thousand ships' in his tragedy Doctor Faustus when referring to which mythical Greek figure?:
 - Helen of Troy
 - Helen of Sparta
 - helen
@@ -158,7 +158,7 @@ Freddie Mercury was the singer of what band?:
 - Queen
 French Fries originate from which country?:
 - Belgium
-From Latin "sapo", saponification is a process of producing...?:
+From Latin 'sapo', saponification is a process of producing...?:
 - Soap
 From Latin, casein is the main protein in?:
 - Milk
@@ -233,13 +233,13 @@ How many hours are there in a year?:
 How many legs does a spider have?:
 - Eight
 - 8
-How many members in the guy group N"SYNC?:
+How many members in the guy group N'SYNC?:
 - Five
 - 5
 How many moons does Mars have?:
 - Two
 - 2
-How many of the seven dwarf"s names do not end with "y"?:
+How many of the seven dwarf's names do not end with "y"?:
 - Two
 - 2
 How many planets are between Earth and the sun?:
@@ -262,10 +262,10 @@ How many seconds are there in an hour?:
 How many seconds in an hour?:
 - 3600
 - Three thousand six hundred
-How many sides does a "icosohedron" have?:
+How many sides does a 'icosohedron' have?:
 - Twenty
 - 20
-How many squares are on a Spear"s Games Snakes and Ladders board?:
+How many squares are on a Spear's Games Snakes and Ladders board?:
 - 100
 - one hundred
 How many squares are on a chess board?:
@@ -301,27 +301,27 @@ If cats are feline, what are sheep?:
 - Ovine
 If you had pogonophobia what would you be afraid of?:
 - Beards
-If you multiply the base by the height, and then divide by 2, you"re calculating the area of what geometric figure?:
+If you multiply the base by the height, and then divide by 2, you're calculating the area of what geometric figure?:
 - Triangle
 If you want to go Stockholm, what country are you in?:
 - Sweden
-In "The Simpsons", what sort of animal is Itchy?:
+In 'The Simpsons', what sort of animal is Itchy?:
 - Mouse
 In April 1966, Bobbi Gibb became the first woman to run the entire distance of which marathon?:
 - Boston Marathon
 - boston
-In Breaking Bad, what colour are Marie"s appliances?:
+In Breaking Bad, what colour are Marie's appliances?:
 - Purple
-In British legend, what is the name of King Arthur"s sword?:
+In British legend, what is the name of King Arthur's sword?:
 - Excalibur
-In Disney"s Tangled, what was the name of Repunzel"s animal side kick?:
+In Disney's Tangled, what was the name of Repunzel's animal side kick?:
 - Pascal
 In Divergent, what is the real name of the character named "Four"?:
 - Tobias
 In Doctor Who, how many hearts does the doctor have?:
 - Two
 - 2
-In Doctor Who, what is the name of the Doctor"s tin dog?:
+In Doctor Who, what is the name of the Doctor's tin dog?:
 - K9
 In Greek mythology which monster is half goat, lion and snake?:
 - Chimera
@@ -333,11 +333,11 @@ In Japan what is Seppuku Hari Kari?:
 - Suicide
 In July 2013, who revealed that they were the secret author Robert Galbraith?:
 - J K Rowling
-- j.k. rowling"j. k. rowling
+- j.k. rowling'j. k. rowling
 - jk rowling
 In Roman mythology, Neptune is the equivalent to which Greek god?:
 - Poseidon
-In Texas Hold"em, how many cards are dealt in "The Flop"?:
+In Texas Hold'em, how many cards are dealt in 'The Flop'?:
 - Three
 - 3
 In The Simpsons, how many children does Apu have?:
@@ -365,18 +365,18 @@ In nature, Greco, Ostro, Libeccio and Sirocco are all types of what?:
 - wind
 In our solar system which is the 5th planet from the Sun?:
 - Jupiter
-In tennis, what"s the name of the point won directly with a serve?:
+In tennis, what's the name of the point won directly with a serve?:
 - Ace
-In the British sci-fi show "Doctor Who", what"s the name of the spaceship that can travel through space and time?:
+In the British sci-fi show "Doctor Who", what's the name of the spaceship that can travel through space and time?:
 - TARDIS
 In the Harry Potter series of books, what animal does Sirius Black turn into?:
 - Dog
-In the TV show "The Big Bang Theory", What is Sheldon"s catch phrase?:
+In the TV show "The Big Bang Theory", What is Sheldon's catch phrase?:
 - Bazinga
-In the children"s television show, what is the name of the yellow Teletubby?:
+In the children's television show, what is the name of the yellow Teletubby?:
 - Laa-Laa
 - laa laa
-In the first Harry Potter film, what was the name of Neville Longbottom"s pet toad?:
+In the first Harry Potter film, what was the name of Neville Longbottom's pet toad?:
 - Trevor
 In the game of Clue, what colour is the piece that represents Mrs Peacock?:
 - Blue
@@ -388,7 +388,7 @@ In the sequence 2, 3, 5, 7, 11, 13, what number comes next?:
 - 17
 In the song, Heartbreak Hotel is on which street?:
 - Lonely Street
-In what Disney movie could you listen to the song "A Whole New World"?:
+In what Disney movie could you listen to the song 'A Whole New World'?:
 - Aladdin
 In what Swiss city was the World Wide Web first developed?:
 - Geneva
@@ -400,7 +400,7 @@ In what country was Osama bin Laden found in 2011?:
 - Pakistan
 In what field sport the winner is the player who has the lowest score?:
 - Golf
-In what movie did we first hear "May the force be with you"?:
+In what movie did we first hear 'May the force be with you'?:
 - Star Wars
 In what movie does Arnold Schwarzenegger go to Mars?:
 - Total Recall
@@ -429,7 +429,7 @@ In which country did the Mau Mau uprising (1952-60) occur?:
 - Kenya
 In which country would you find the Negev desert?:
 - Israel
-In which county is the UK prime minister"s official country residence Chequers?:
+In which county is the UK prime minister's official country residence Chequers?:
 - Buckinghamshire
 In which direction does the sun set?:
 - West
@@ -440,17 +440,17 @@ In which ocean is Tahiti?:
 - Pacific
 In which year did Foinavon win the Grand National?:
 - 1967
-Isabella "Bella" Swan is the lead character in which series of vampire books?:
+Isabella 'Bella' Swan is the lead character in which series of vampire books?:
 - Twilight
 Jagger, Richards, Wyman, Jones, Watts, Stewart - members of which band?:
 - The Rolling Stones
 - Rolling Stones
-"James Augustus Hickey founded the first printed â\x80\x98whatâ\x80\x99 in India in 1780?":
+James Augustus Hickey founded the first printed â€˜whatâ€™ in India in 1780?:
 - Newspaper
 Kola, Palm, Pecan and Betel are types of...?:
 - Nuts
 - nut
-Kuala Lumpar Airport is which nation"s main air terminal?:
+Kuala Lumpar Airport is which nation's main air terminal?:
 - Malaysia
 La Giaconda is better known as what?:
 - Mona Lisa
@@ -483,9 +483,9 @@ Mocha is coffee with added...?:
 - Chocolate
 Mount Etna is on which European island?:
 - Sicily
-Name Captain Nemo"s submarine?:
+Name Captain Nemo's submarine?:
 - Nautilus
-Name a member of N"SYNC whose name does NOT start with the letter "J"?:
+Name a member of N'SYNC whose name does NOT start with the letter "J"?:
 - Chris or Lance
 - Chris
 - Lance
@@ -545,13 +545,13 @@ Siderodromophobia is the irrational fear of which mode of transport?:
 Singer Beyonce Knowles married which rapper in 2008?:
 - Jay-Z
 Sir Christopher Wren designed which famous London cathedral?:
-- "St Paulâ\x80\x99s"
+- St Paulâ€™s
 - St. Paul
 - St paul
-- st. paul"s
+- st. paul's
 Sitophilia is the use of what for sexual arousal?:
 - Food
-'Solve for X: 5x+4=24':
+"Solve for X: 5x+4=24":
 - Four
 - 4
 Suva is the capital of which South Pacific island?:
@@ -560,10 +560,10 @@ TV commercials for Campari launched the career of which actress?:
 - Lorraine Chase
 Tallow, Beeswax, Spermaceti, and Paraffin are traditionally used in making...?:
 - Candles
-The "twi" in the word twilight originally meant?:
+The 'twi' in the word twilight originally meant?:
 - Two
 - 2
-The 2015 Star Wars sequel is subtitled "The Force..."?:
+The 2015 Star Wars sequel is subtitled 'The Force...'?:
 - Awakens
 The Almeria region, driest in Europe, used for filming many famous Cowboy/Western films, is in what country?:
 - Spain
@@ -572,11 +572,11 @@ The Ancient Egyptian mummy/afterlife figure Anubis is typically half-man and hal
 - fox
 - jackal
 - wolf
-The Arabic word "al" (AL) roughly translates in English to mean...?:
+The Arabic word 'al' (AL) roughly translates in English to mean...?:
 - The
 The CAC40 is a main stock market index of which country?:
 - France
-The Cuban/Puerto Rican music/dance "Salsa" means what in Spanish?:
+The Cuban/Puerto Rican music/dance 'Salsa' means what in Spanish?:
 - Sauce
 The GalÃ¡pagos Islands are a provincial territory of which South American country, 600 miles away on the same equatorial latitude?:
 - Ecuador
@@ -586,9 +586,9 @@ The Golden Gate bridge is in which US city?:
 - San Francisco
 The Great Pyramid is in which country?:
 - Egypt
-The Han ethnic people constitute about 90% of which country"s population?:
+The Han ethnic people constitute about 90% of which country's population?:
 - China
-The Latin prefix "dino" (as in dinosaur) means?:
+The Latin prefix 'dino' (as in dinosaur) means?:
 - Terrible
 The Shatt-el-Arab (River of Arabia) is the confluence of which two other rivers?:
 - Tigris and Euphrates
@@ -609,7 +609,7 @@ The White Rose Shopping Centre is in which English city?:
 The Winter Olympic Games are celebrated every how many years?:
 - Four
 - 4
-The brunch dish of poached eggs, muffins, bacon/ham and hollandaise sauce, popularized in New York City is "Eggs..."?:
+The brunch dish of poached eggs, muffins, bacon/ham and hollandaise sauce, popularized in New York City is 'Eggs...'?:
 - Benedict
 The caber, kilts and bagpipes are all associated with with European country?:
 - Scotland
@@ -617,11 +617,11 @@ The classical composers Bach, Brahms, Handel, Strauss, and Schumann are all what
 - German
 The countries Ghana, Nigeria and Kenya are all in which continent?:
 - Africa
-The cup, or bowl, Jesus was said to have used at the Last Supper is known as "The Holy ..."?:
+The cup, or bowl, Jesus was said to have used at the Last Supper is known as 'The Holy ...'?:
 - Grail
 The dermis and cutis are parts of the human...?:
 - Skin
-The famous Ancient Roman marble statue "Venus Callipyge" or "Callipygian Venus" literally and artistically represents "Venus/Aphrodite of the beautiful..."?:
+The famous Ancient Roman marble statue 'Venus Callipyge' or 'Callipygian Venus' literally and artistically represents "Venus/Aphrodite of the beautiful..."?:
 - Buttocks
 - butt
 The famous self-styled anarchist web-hacking group founded in 2003 is called...?:
@@ -633,7 +633,7 @@ The fictional character Norville Rogers is better known by the nickname...?:
 The hook symbol joined under a letter (e.g., to the letter C, to soften the sound) is a...?:
 - Cedilla
 - cedilha
-The human body"s energy chemical is...?:
+The human body's energy chemical is...?:
 - Glucose
 The llama belongs to the family of animals commonly called what?:
 - Camels
@@ -647,8 +647,8 @@ The modern confection originally from Ancient Egypt and the Malva plant which ga
 - Marshmallow
 The most poisonous fungi, which usually kills anyone eating it, is the...?:
 - Destroying Angel
-The motor theft crime abbreviated in the UK to TWOC (hence the slang verb "twocking") stands for what?:
-- Taking Without Owner"s Consent
+The motor theft crime abbreviated in the UK to TWOC (hence the slang verb 'twocking') stands for what?:
+- Taking Without Owner's Consent
 The musical "West Side Story" is based on which Shakespeare play?:
 - Romeo and Juliet
 The planet Jupiter has how many known moons?:
@@ -656,7 +656,7 @@ The planet Jupiter has how many known moons?:
 - sixty seven
 - 67
 - sixtyseven
-The popular geeky children"s TV series about an anthropomorphic aardvark whose theme song was sung by Ziggy Marley is?:
+The popular geeky children's TV series about an anthropomorphic aardvark whose theme song was sung by Ziggy Marley is?:
 - Arthur
 The port of Dover is in which English county?:
 - Kent
@@ -676,9 +676,9 @@ Triskadeccaphobia is the fear of what?:
 Turkish Van, Chartreux, Scottish Fold and Ragdoll are types of...?:
 - Cats
 - cat
-UNHCR is the United Nation"s High Commission for what?:
+UNHCR is the United Nation's High Commission for what?:
 - Refugees
-Vaquita porpoise "maw", an illegally trafficked delicacy in Chinese cuisine, priced upwards of $10,000/kilo, is the creature"s...?:
+Vaquita porpoise 'maw', an illegally trafficked delicacy in Chinese cuisine, priced upwards of $10,000/kilo, is the creature's...?:
 - Swim bladder
 Vodka, Galliano and orange juice are used to make which classic cocktail?:
 - Harvey Wallbanger
@@ -699,12 +699,12 @@ What Latin word meaning equal expresses a quality standard/norm (on or below or 
 - Par
 What Power Ranger was the leader (color)?:
 - Red
-What U.S. city is also called "The Windy City"?:
+What U.S. city is also called 'The Windy City'?:
 - Chicago
-What actor is famous for saying "I"ll be back"?:
+What actor is famous for saying 'I'll be back'?:
 - Arnold Schwarzenegger
 - schwarzenegger
-What actress was Sam"s girlfriend in the movie Transformers 1 and 2?:
+What actress was Sam's girlfriend in the movie Transformers 1 and 2?:
 - Megan Fox
 What are Ethan Kath and Alice Glass better known as?:
 - Crystal Castles
@@ -716,13 +716,13 @@ What are Sarte, Neitzsche, Russell and Decartes?:
 What are the native people of Australia called?:
 - aborigine
 - Aborigines
-What breed of dog is known as a "Sausage dog"?:
+What breed of dog is known as a 'Sausage dog'?:
 - Dachshund
 What character says the famous salute "Live Long and Prosper"?:
 - Mr. Spock
 - mr spock
 - spock
-What character was JD"s best friend in the TV series "Scrubs"?:
+What character was JD's best friend in the TV series 'Scrubs'?:
 - Turk
 What chemical element (Cu) is named after Cyprus?:
 - Copper
@@ -734,31 +734,31 @@ What city attracted Van Gogh and Toulouse-Lautrec to its bohemian Montmartre dis
 - Paris
 What city does Batman protect?:
 - Gotham
-What color "Haze" is the title of a 1967 hit by Jimi Hendrix?:
+What color 'Haze' is the title of a 1967 hit by Jimi Hendrix?:
 - Purple
-What color are Peter Pan"s clothes?:
+What color are Peter Pan's clothes?:
 - Green
 What color are the Majestic mountains in "America the Beautiful"?:
 - Purple
-What color is Lisa"s necklace on The Simpsons?:
+What color is Lisa's necklace on The Simpsons?:
 - white
-What color is a giraffe"s tongue?:
+What color is a giraffe's tongue?:
 - black
 What color is a smurf?:
 - Blue
-What color is the "Little Corvette" in the 1983 single by Prince?:
+What color is the 'Little Corvette' in the 1983 single by Prince?:
 - Red
 What color is the center stripe on the American flag?:
 - Red
 What color reflects light from all parts of the visible spectrum?:
 - white
-What colour is Spock"s blood?:
+What colour is Spock's blood?:
 - Green
-What colour is Teletubby Po in the children"s television series Teletubbies?:
+What colour is Teletubby Po in the children's television series Teletubbies?:
 - Red
 What colour is The Old Kent Road on a Monopoly board?:
 - Brown
-What colour is superhero Batman"s Batphone?:
+What colour is superhero Batman's Batphone?:
 - Red
 What colour is the skin of a courgette?:
 - Green
@@ -777,12 +777,12 @@ What country covers an entire continent?:
 - Australia
 What country is the Aswan High Dam in?:
 - Egypt
-What creature"s name is from Greek "river horse"?:
+What creature's name is from Greek 'river horse'?:
 - Hippopotamus
 - hippo
 What day of the week does does Garfield hate?:
 - Monday
-What deceptively challenging culinary dish is named from French "lemele" (knife blade - alluding to shape)?:
+What deceptively challenging culinary dish is named from French 'lemele' (knife blade - alluding to shape)?:
 - Omelette
 What did Sir Galahad search for?:
 - The Holy Grail
@@ -796,7 +796,7 @@ What did they use for croquet mallets in "Alice in Wonderland"?:
 What digit does not exist in Roman Numerals?:
 - Zero
 - 0
-What discipline contains "asanas" including names such as Half boat, Full boat, Tree, and Happy Baby?:
+What discipline contains 'asanas' including names such as Half boat, Full boat, Tree, and Happy Baby?:
 - Yoga
 What do the Olympic rings represent?:
 - continents
@@ -837,7 +837,7 @@ What famous ancient city is on the river Tiber?:
 - Rome
 What famous author was known for "The Iliad" and "The Odyssey"?:
 - Homer
-What girl"s name beginning with A was punningly chosen first when the UK decided in 2015 to "name" its storms?:
+What girl's name beginning with A was punningly chosen first when the UK decided in 2015 to 'name' its storms?:
 - Abigail
 What hand is the most valuable in poker?:
 - Royal flush
@@ -854,14 +854,14 @@ What is 255 divided by 5?:
 - fifty one
 What is 26 in Roman numerals?:
 - XXVI
-What is Bill Clinton"s middle name?:
+What is Bill Clinton's middle name?:
 - Jefferson
-What is Canada"s national animal?:
+What is Canada's national animal?:
 - Beaver
-What is Keanu Reeves character"s Real name in "The Matrix" (1999)?:
+What is Keanu Reeves character's Real name in "The Matrix" (1999)?:
 - Thomas Anderson
 - Tom Anderson
-What is Sherlock Holmes"s brother"s first name?:
+What is Sherlock Holmes's brother's first name?:
 - Mycroft
 What is a Wyvern?:
 - A Type of dragon
@@ -876,7 +876,7 @@ What is a line called that goes straight from the center of a circle to the circ
 - Radius
 What is a perfect game scoring in bowling?:
 - 300
-What is an otter"s home called?:
+What is an otter's home called?:
 - Holt
 What is converted into alcohol during brewing?:
 - Sugar
@@ -884,14 +884,14 @@ What is infant whale commonly called?:
 - Calf
 What is removed from natural yogurt to produce Greek yogurt (also called labneh [Arabic] and strained yogurt)?:
 - Whey
-What is the "lead" in pencils made from?:
+What is the 'lead' in pencils made from?:
 - Graphite
 - carbon
 What is the French word for Thank You?:
 - Merci
 What is the Scottish word for lake?:
 - Loch
-What is the Spanish name for the South American capital which means "good air"?:
+What is the Spanish name for the South American capital which means 'good air'?:
 - Buenos Aires
 What is the USA state capital of California?:
 - Sacramento
@@ -922,7 +922,7 @@ What is the closest star to the Earth?:
 What is the colour of the bull of an archery target?:
 - Gold
 - yellow
-"What is the first name of Bill and Hillary Clintonâ\x80\x99s daughter?":
+What is the first name of Bill and Hillary Clintonâ€™s daughter?:
 - Chelsea
 What is the green pigment found in most plants that is responsible for absorbing light energy?:
 - Chlorophyll
@@ -943,7 +943,7 @@ What is the largest planet in the solar system?:
 - Jupiter
 What is the largest state by area in the USA?:
 - Alaska
-What is the last name of the family in the TV series "Family Guy"?:
+What is the last name of the family in the TV series 'Family Guy'?:
 - Griffin
 What is the longest river in North America?:
 - Missouri River
@@ -955,18 +955,18 @@ What is the name given to a word or phrase that reads the same backward and forw
 What is the name given to the change in pitch accompanied by an approaching or receeding sound source?:
 - Doppler Effect
 - Doppler
-What is the name of Batman"s sidekick and ward?:
+What is the name of Batman's sidekick and ward?:
 - Robin
-What is the name of Han Solo"s ship in "Star Wars"?:
+What is the name of Han Solo's ship in "Star Wars"?:
 - The Millennium Falcon
 - millennium falcon
-What is the name of Harry Potter"s owl?:
+What is the name of Harry Potter's owl?:
 - Hedwig
-What is the name of Iron Man"s computer assistant?:
+What is the name of Iron Man's computer assistant?:
 - Jarvis
-What is the name of Mickey Mouse"s dog?:
+What is the name of Mickey Mouse's dog?:
 - Pluto
-What is the name of Ron"s sister in "Harry Potter"?:
+What is the name of Ron's sister in "Harry Potter"?:
 - Ginny
 What is the name of a Telly Tubby and an Italian river?:
 - Po
@@ -1008,15 +1008,15 @@ What is the name of the dwarf in Game of Thrones?:
 - Tyrion
 What is the name of the dynasty in China in 15th century?:
 - Ming
-"What is the name of the fairy in the play â\x80\x98Peter Panâ\x80\x99 by J M Barrie?":
+What is the name of the fairy in the play â€˜Peter Panâ€™ by J M Barrie?:
 - Tinker Bell
 What is the name of the giant bunny in "Donnie Darko"?:
 - Frank
 What is the name of the lawyer in Breaking Bad?:
 - Saul
-What is the name of the main character in "The Legend of Zelda"?:
+What is the name of the main character in 'The Legend of Zelda'?:
 - Link
-What is the name of the monster"s creator in the 1818 novel of the same name by Mary Shelley?:
+What is the name of the monster's creator in the 1818 novel of the same name by Mary Shelley?:
 - Frankenstein
 - Victor
 What is the name of the sequel to "101 Dalmations"?:
@@ -1079,7 +1079,7 @@ What orange spice/colouring comes from the crocus plant, often associated with r
 - Saffron
 What organ processes the sodium in the body?:
 - Kidney
-What philosopher said the famous sentence "I think, therefore I am"?:
+What philosopher said the famous sentence 'I think, therefore I am'?:
 - Descartes
 What planet is the closest to the Sun?:
 - Mercury
@@ -1118,25 +1118,25 @@ What type of flesh does a pescatarian eat?:
 - Fish
 What type of monster dies from a silver bullet?:
 - Werewolf
-What unit of sound intensity commemorates an inventor"s last name?:
+What unit of sound intensity commemorates an inventor's last name?:
 - Decibel
-What was Eminem"s first album called?:
+What was Eminem's first album called?:
 - Infinite
-What was Indiana Jones"s real first name?:
+What was Indiana Jones's real first name?:
 - Henry
-What was Muhammed Ali"s real name?:
+What was Muhammed Ali's real name?:
 - Cassius Clay
-What was Sleeping Beauty"s given name?:
+What was Sleeping Beauty's given name?:
 - Aurora
-"What was South Vietnamâ\x80\x99s Ho Chi Minh City called before 1976?":
+What was South Vietnamâ€™s Ho Chi Minh City called before 1976?:
 - Saigon
-What was Spock"s race?:
+What was Spock's race?:
 - Vulcan
 What was Walter White known as by the drug cartels in Breaking Bad?:
 - Heisenberg
 What was disestablished as the state religion of Japan after WWII?:
 - Shinto
-What was the Russian city of Stalingrad renamed in 1961, after Europe"s longest river?:
+What was the Russian city of Stalingrad renamed in 1961, after Europe's longest river?:
 - Volgograd
 What was the first movie produced by Pixar?:
 - Toy Story
@@ -1162,55 +1162,55 @@ What year was the movie Ben Hur with Charlton Heston made?:
 - 1959
 What year were PopTarts invented?:
 - 1964
-What"s the abreviation of "picture element"?:
+What's the abreviation of 'picture element'?:
 - Pixel
-What"s the adjective used for the planes flying faster than the speed of sound?:
+What's the adjective used for the planes flying faster than the speed of sound?:
 - Supersonic
-What"s the band that has won the most Grammy awards?:
+What's the band that has won the most Grammy awards?:
 - U2
-What"s the biggest mammal?:
+What's the biggest mammal?:
 - Whale
-What"s the capital of the Netherlands?:
+What's the capital of the Netherlands?:
 - Amsterdam
-What"s the chemical symbol of salt?:
+What's the chemical symbol of salt?:
 - NaCl
-What"s the common term for the layout of a computer keyboard?:
+What's the common term for the layout of a computer keyboard?:
 - QWERTY keyboard
 - qwerty
-What"s the most abundant element in the atmosphere?:
+What's the most abundant element in the atmosphere?:
 - Nitrogen
-What"s the most abundant element in the earth"s crust?:
+What's the most abundant element in the earth's crust?:
 - Oxygen
-What"s the most abundant element in the universe?:
+What's the most abundant element in the universe?:
 - Hydrogen
-What"s the name of Snoopy"s owner?:
+What's the name of Snoopy's owner?:
 - Charlie Brown
-What"s the name of the bar tender in The Simpsons?:
+What's the name of the bar tender in The Simpsons?:
 - Moe
-What"s the name of the cup of the National Hockey League?:
+What's the name of the cup of the National Hockey League?:
 - Stanley Cup
 - Stanley
-What"s the name of the dance step popularized by Michael Jackson?:
+What's the name of the dance step popularized by Michael Jackson?:
 - Moonwalk
-What"s the name of the instrument used to measure atmospheric pressure?:
+What's the name of the instrument used to measure atmospheric pressure?:
 - Barometer
-What"s the name of the lead singer of the band Radiohead?:
+What's the name of the lead singer of the band Radiohead?:
 - Thom Yorke
-What"s the name of the princess from Beauty:
+What's the name of the princess from Beauty:
 - Belle
-What"s the name of the protagonist in the TV series "Breaking Bad"?:
+What's the name of the protagonist in the TV series "Breaking Bad"?:
 - Walter White
-What"s the name of the traditional Japanese art of paper folding?:
+What's the name of the traditional Japanese art of paper folding?:
 - Origami
-What"s the official language of Brazil?:
+What's the official language of Brazil?:
 - Portuguese
-What"s the oldest university in the USA?:
+What's the oldest university in the USA?:
 - Harvard
-What"s the only country to have played in every World Cup soccer tournament?:
+What's the only country to have played in every World Cup soccer tournament?:
 - Brazil
-What"s the primary color with the shortest name?:
+What's the primary color with the shortest name?:
 - Red
-What"s the square root of 144?:
+What's the square root of 144?:
 - 12
 When measuring acidity and alkalinity, what does "pH" stand for?:
 - per hydroxide
@@ -1225,7 +1225,7 @@ Which 2009 animated film features a floating house suspended by helium balloons?
 - Up
 Which American state is nearest to the former Soviet Union?:
 - Alaska
-"Which Asian country is known as the â\x80\x98Land of Smilesâ\x80\x99?":
+Which Asian country is known as the â€˜Land of Smilesâ€™?:
 - Thailand
 Which Bond villain has been played by Telly Savalas, Donald Pleasance, Charles Gray, and Max Von Sydow?:
 - Blofeld
@@ -1233,7 +1233,7 @@ Which Briton won an ice-skating Gold at the Lake Placid Olympics?:
 - Robin Cousins
 Which European city had the Roman name Lutetia?:
 - Paris
-Which Latin term, usually applied to legal evidence, means "at first sight"?:
+Which Latin term, usually applied to legal evidence, means 'at first sight'?:
 - Prima Facie
 Which Roman god had two faces?:
 - Janus
@@ -1245,7 +1245,7 @@ Which US singer is known by the nickname J Lo?:
 - Jennifer Lopez
 Which animal is depicted as the face of breakfast cereal Coco Pops?:
 - Monkey
-Which animal is known as "The Ship of the Desert"?:
+Which animal is known as 'The Ship of the Desert'?:
 - Camel
 Which animal represents the deadly sin of envy?:
 - Snake
@@ -1256,7 +1256,7 @@ Which body of water connects England and France?:
 - english channel
 Which character has been played by the most actors?:
 - Sherlock Holmes
-Which children"s classic book was written by Anna Sewell?:
+Which children's classic book was written by Anna Sewell?:
 - Black Beauty
 Which company is owned by Bill Gates?:
 - Microsoft
@@ -1274,15 +1274,15 @@ Which domestic animal was worshipped by the ancient Egyptians?:
 - cat
 Which famous artist spent four years painting the ceiling of the Sistine Chapel in Rome?:
 - Michelangelo
-Which fictional character uses the expression "Eat my shorts"?:
+Which fictional character uses the expression 'Eat my shorts'?:
 - Bart Simpson
 Which fictional superhero goes by the name of Bruce Wayne?:
 - Batman
-Which fictional superhero is known as "The Man of Steel"?:
+Which fictional superhero is known as 'The Man of Steel'?:
 - Superman
 Which fruit from Seville in Spain is usually used to make marmalade?:
 - Orange
-Which is Canada"s largest province?:
+Which is Canada's largest province?:
 - Quebec
 Which is the financial centre and main city of Switzerland?:
 - Zurich
@@ -1294,11 +1294,11 @@ Which is the only bird that can fly backwards?:
 - Hummingbird
 Which is the only mammal in the world unable to burp?:
 - Horse
-'Which is the only planet in our solar system to have water in three states of matter: solid, liquid and gas?':
+"Which is the only planet in our solar system to have water in three states of matter: solid, liquid and gas?":
 - Earth
 Which is the smallest member of the flute family?:
 - Piccolo
-Which legendary English outlaw "stole from the rich to give to the poor"?:
+Which legendary English outlaw 'stole from the rich to give to the poor'?:
 - Robin Hood
 Which letter is furthest to the right on a top letter row on a computer keyboard?:
 - P
@@ -1331,9 +1331,9 @@ Which sea is known by its high levels of salt?:
 - Dead Sea
 Which sign of the Zodiac is represented by the fish?:
 - Pisces
-'Which singer joined Mel Gibson in the movie Mad Max: Beyond The Thunderdome?':
+"Which singer joined Mel Gibson in the movie Mad Max: Beyond The Thunderdome?":
 - Tina Turner
-Which spice is known as the "Master Spice"?:
+Which spice is known as the 'Master Spice'?:
 - Pepper
 Which sport features line-outs, scrums and conversions?:
 - Rugby
@@ -1343,14 +1343,14 @@ Which state is known as the potato state?:
 - Idaho
 Which substance makes bread rise?:
 - Yeast
-Who captained Jules Verne"s submarine Nautilus?:
+Who captained Jules Verne's submarine Nautilus?:
 - Captain Nemo
 - nemo
 Who co-starred with Jackie Chan in Rush Hour 2?:
 - Chris Tucker
-'Who composed the music for the film "Tron: Legacy"?':
+"Who composed the music for the film 'Tron: Legacy'?":
 - Daft Punk
-Who controversially interviewed the on-the-run Mexican drug lord "El Chapo" Guzman for Rolling Stone Magazine just before his 2015 capture?:
+Who controversially interviewed the on-the-run Mexican drug lord 'El Chapo' Guzman for Rolling Stone Magazine just before his 2015 capture?:
 - Sean Penn
 Who created Mickey Mouse?:
 - Walt Disney
@@ -1369,15 +1369,15 @@ Who invented the revolver (handgun)?:
 Who invented the telephone?:
 - Alexander Graham Bell
 - Bell
-Who invented the world"s first successful airplane?:
+Who invented the world's first successful airplane?:
 - Wright brothers
-Who is Bart Simpson"s best friend?:
+Who is Bart Simpson's best friend?:
 - Milhouse
 Who is Bruce Wayne?:
 - Batman
-Who is Mario"s brother?:
+Who is Mario's brother?:
 - Luigi
-Who is Ned Stark"s youngest daughter in the TV series "Game of Thrones"?:
+Who is Ned Stark's youngest daughter in the TV series 'Game of Thrones'?:
 - Arya Stark
 - Arya
 Who is Peeta Mellark in love with?:
@@ -1385,14 +1385,14 @@ Who is Peeta Mellark in love with?:
 - Katniss
 Who is Spider-Man?:
 - Peter Parker
-Who is SpongeBob SquarePants" best friend?:
+Who is SpongeBob SquarePants' best friend?:
 - Patrick Star
 - Patrick
-Who is Superman"s sweetheart?:
+Who is Superman's sweetheart?:
 - Lois Lane
-Who is Thor"s Father?:
+Who is Thor's Father?:
 - Odin
-Who is famous for saying "Make my day"?:
+Who is famous for saying 'Make my day'?:
 - Clint Eastwood
 - eastwood
 Who is the "black sheep" in Family Guy?:
@@ -1412,7 +1412,7 @@ Who is the king of the gods in Greek mythology?:
 - Zeus
 Who is the main character in "The Lion King"?:
 - Simba
-Who is the main character in Grey"s Anatomy?:
+Who is the main character in Grey's Anatomy?:
 - Dr. Meredith Grey
 - Meredith grey
 - meredith
@@ -1428,7 +1428,7 @@ Who is the swimmer that has won 28 Olympic medals?:
 - Michael Phelps
 Who is the voice of Princess Fiona in the Shrek series of films?:
 - Cameron Diaz
-Who is the writer of "Game of Thrones"?:
+Who is the writer of 'Game of Thrones'?:
 - George R.R. Martin
 - George R R  Martin
 - GRRM
@@ -1436,13 +1436,13 @@ Who made his debut in Action Comics No.1?:
 - Superman
 Who or what lives in a formicarium?:
 - Ants
-Who played Captain Jack Sparrow in the "Pirates of the Caribbean" series of films?:
+Who played Captain Jack Sparrow in the 'Pirates of the Caribbean' series of films?:
 - Johnny Depp
-Who played Han Solo in the "Star Wars" series of films?:
+Who played Han Solo in the 'Star Wars' series of films?:
 - Harrison Ford
-Who plays the crazy person in the movie "12 Monkeys"?:
+Who plays the crazy person in the movie '12 Monkeys'?:
 - Brad Pitt
-Who released the album "AM"?:
+Who released the album 'AM'?:
 - Arctic Monkeys
 Who said "Time is a flat circle"?:
 - Nietzsche
@@ -1455,9 +1455,9 @@ Who stars in the movie "I am legend"?:
 - Will Smith
 Who voiced Woody in the "Toy Story" trilogy?:
 - Tom Hanks
-Who was Brad Pitt"s first wife?:
+Who was Brad Pitt's first wife?:
 - Jennifer Aniston
-Who was Brad Pitt"s partner in the 1995 film "Se7en"?:
+Who was Brad Pitt's partner in the 1995 film 'Se7en'?:
 - Morgan Freeman
 Who was the father of English monarch Elizabeth I?:
 - Henry VIII
@@ -1473,7 +1473,7 @@ Who was the main actor in the movie Click?:
 - Adam Sandler
 Who was the only actor to win an Oscar afterhis death?:
 - Heath Ledger
-Who was the philosopher who said "I only know that I know nothing"?:
+Who was the philosopher who said 'I only know that I know nothing'?:
 - Socrates
 Who were the first users of papyrus?:
 - Egyptians
@@ -1490,30 +1490,30 @@ Who wore the number 23 for the Chicago Bulls?:
 Who wrote Les MisÃ©rables?:
 - Victor Hugo
 - Hugo
-Who wrote the novel "The Adventures of Huckleberry Finn"?:
+Who wrote the novel 'The Adventures of Huckleberry Finn'?:
 - Mark Twain
 Who wrote the novel Nineteen Eighty-Four?:
 - George Orwell
 - Orwell
 Who wrote/directed the movies The Hateful Eight and Inglourious Basterds?:
 - Quentin Tarantino
-Whose 1988 autobiography is entitled "Moonwalk"?:
+Whose 1988 autobiography is entitled 'Moonwalk'?:
 - Michael Jackson
 Whose album is ARTPOP?:
 - Lady Gaga
-Whose motto is "We are a legion. We don"t forgive. We don"t forget"?:
+Whose motto is 'We are a legion. We don't forgive. We don't forget'?:
 - Anonymous
 Whose nose grew when he told a lie?:
 - Pinocchio
-Whose painting is used on Woody Allen"s "Midnight in Paris" movie poster?:
+Whose painting is used on Woody Allen's 'Midnight in Paris' movie poster?:
 - Van Gogh
 - Vincent van Gogh
 Whose quote is "fly like a butterfly sting like a bee"?:
 - Muhammad Ali
-Wikipedia"s spherical logo features what symbol for Greek W, also a fatty acid name?:
+Wikipedia's spherical logo features what symbol for Greek W, also a fatty acid name?:
 - Omega
 - Î©
-With over one billion registered users, China"s (claimed) largest smartphone messaging app is...?:
+With over one billion registered users, China's (claimed) largest smartphone messaging app is...?:
 - WeChat
 Yeomen Warders at the Tower of London are commonly known by what other name?:
 - Beefeaters
@@ -1523,5 +1523,5 @@ Zeus created warriors called Myrmidons out of what creatures?:
 Zika disease, identified 1947 and epidemic in S America commencing 2015, is mainly transmitted by infected...?:
 - Mosquitoes
 - mosquito
-"â\x80\x98Blue Mondayâ\x80\x99, said to be the most depressing day of the year, falls during which month?":
+â€˜Blue Mondayâ€™, said to be the most depressing day of the year, falls during which month?:
 - January

--- a/redbot/trivia/lists/greekmyth.yaml
+++ b/redbot/trivia/lists/greekmyth.yaml
@@ -1,4 +1,4 @@
-According to Hesiod"s "Theogeny", who was born from Uranus" penis which had been cut off?:
+According to Hesiod's "Theogeny", who was born from Uranus' penis which had been cut off?:
 - Aphrodite
 From whom did Hermes steal cattle?:
 - Apollo
@@ -8,7 +8,7 @@ What creature was half bull and half man?:
 - Minotaur
 What monster encountered by Odysseus was on one side of a narrow channel of water and associated as a beautiful serpentine maiden?:
 - Scylla
-What monster looks like a lion with the head of a goat on its back and a tail with a snake"s head?:
+What monster looks like a lion with the head of a goat on its back and a tail with a snake's head?:
 - Chimera
 What monster was half woman and half snake?:
 - Echidna
@@ -164,7 +164,7 @@ Who are the children of Zeus and Themis?:
 - fates
 Who boasted that her daughter Andromeda was more beautiful than the Nereids?:
 - Cassiopeia
-Who bragged that her many children were better than Leto"s two (Apollo and Artemis) and was punished by Apollo killing all of her sons and Artemis killing all of her daughters?:
+Who bragged that her many children were better than Leto's two (Apollo and Artemis) and was punished by Apollo killing all of her sons and Artemis killing all of her daughters?:
 - Niobe
 Who created mankind?:
 - Prometheus
@@ -184,27 +184,27 @@ Who had an affair on her husband with Ares?:
 - Aphrodite
 Who had the power of prophecy but was cursed so that no one would believe her prophecies?:
 - Cassandra
-Who is Achilles" companion who is killed by Hector while wearing Achilles" armor?:
+Who is Achilles' companion who is killed by Hector while wearing Achilles' armor?:
 - Patroclus
-Who is Amiphitrite"s husband?:
+Who is Amiphitrite's husband?:
 - Poseidon
-Who is Apollo and Artemis" mother?:
+Who is Apollo and Artemis' mother?:
 - Leto
-Who is Apollo"s twin?:
+Who is Apollo's twin?:
 - Artemis
-Who is Hades" wife?:
+Who is Hades' wife?:
 - Persephone
 Who is Helen of Troy married to?:
 - Menelaus
-Who is Hera"s husband?:
+Who is Hera's husband?:
 - Zeus
-Who is Persephone"s father?:
+Who is Persephone's father?:
 - Zeus
-Who is Persephone"s mother?:
+Who is Persephone's mother?:
 - Demeter
 Who is Queen of the Gods?:
 - Hera
-Who is Troy"s greatest warrior in the Trojan War?:
+Who is Troy's greatest warrior in the Trojan War?:
 - Hector
 Who is punished in Tartarus by being forced to roll a boulder up a hill for an eternity?:
 - Sisyphus
@@ -332,7 +332,7 @@ Who led the expedition for the Golden Fleece?:
 - Jason
 Who lost the contest for Athens to Athena?:
 - Poseidon
-Who made Apollo"s lyre?:
+Who made Apollo's lyre?:
 - Hermes
 Who punished Minos for refusing to sacrifice a white bull?:
 - Poseidon
@@ -346,15 +346,15 @@ Who stole fire from Mount Olympus?:
 - Prometheus
 Who threw the Apple of Discord?:
 - Eris
-Who was Castor"s twin?:
+Who was Castor's twin?:
 - Pollux
-Who was Dionysus" mother?:
+Who was Dionysus' mother?:
 - Semele
-Who was Pegasus" mother?:
+Who was Pegasus' mother?:
 - Medusa
 Who was abducted by Zeus in the form of a white bull?:
 - Europa
-Who was born from Zeus" head?:
+Who was born from Zeus' head?:
 - Athena
 Who was punished and condemned to forever hold up the sky?:
 - Atlas

--- a/redbot/trivia/lists/harrypotter.yaml
+++ b/redbot/trivia/lists/harrypotter.yaml
@@ -2,11 +2,11 @@ A bezoar is a stone taken from the stomach of a ...?:
 - goat
 A wizard who can transform himself into an animal at will is called what?:
 - animagus
-According to "The Life and Lies of Albus Dumbledore", What was Doge"s nickname?:
+According to 'The Life and Lies of Albus Dumbledore', What was Doge's nickname?:
 - dogbreath
-Educational Decree No. 30 declared that what wasn"t allowed in the corridors?:
+Educational Decree No. 30 declared that what wasn't allowed in the corridors?:
 - Music
-'Fill in the blank: "Holy _________, you"re Harry Potter!!" - Hermione Granger?':
+"Fill in the blank: \"Holy _________, you're Harry Potter!!\" - Hermione Granger?":
 - cricket
 From who does Hagrid borrow the flying motorbike he uses to deliver Harry to the Dursleys?:
 - Sirius Black
@@ -14,10 +14,10 @@ Hermione hides what artifact through most of the 3rd book/film?:
 - Time turner
 How does one put Fluffy to sleep?:
 - music
-How many Chocolate Frog cards does Ron estimate he has in Harry Potter and the Philosopher"s Stone?:
+How many Chocolate Frog cards does Ron estimate he has in Harry Potter and the Philosopher's Stone?:
 - 500
 - five hundred
-How many Horcruxes of Voldemort"s are there?:
+How many Horcruxes of Voldemort's are there?:
 - 7
 - seven
 How many Sickles are in a Galleon?:
@@ -32,7 +32,7 @@ How many brothers does Ron have?:
 How many goal posts are there on a Quidditch pitch?:
 - six
 - 6
-How many muggles see the flying car in Harry Potter and the Chamber of Secrets on Ron and Harry"s way to Hogwarts?:
+How many muggles see the flying car in Harry Potter and the Chamber of Secrets on Ron and Harry's way to Hogwarts?:
 - 7
 - seven
 How many players are on a Quidditch pitch at one time in a match?:
@@ -41,7 +41,7 @@ How many players are on a Quidditch pitch at one time in a match?:
 How many points is the Golden Snitch worth?:
 - 150
 - one hundred and fifty
-How many students are picked to become prefects from each house"s fifth year house?:
+How many students are picked to become prefects from each house's fifth year house?:
 - 2
 - two
 How much Veela does Fleur DeLacour have in her?:
@@ -50,7 +50,7 @@ How much Veela does Fleur DeLacour have in her?:
 How much was Dobby paid a month in the Hogwarts kitchen?:
 - one galleon
 - 1 galleon
-In Harry Potter and the Philosopher"s Stone which Gringotts vault was the Philosopher"s Stone kept in?:
+In Harry Potter and the Philosopher's Stone which Gringotts vault was the Philosopher's Stone kept in?:
 - 713
 - seven hundred and thirteen
 In Harry Potter and the Prisoner of Azkaban, who orders a cherry syrup and soda with ice and umbrella from the Three Broomsticks?:
@@ -65,9 +65,9 @@ In the movies Neville gives Harry Gillyweed before the Second Task. However, who
 - Dobby
 In what country is Voldemort said to be hiding in from books 2-4?:
 - Albania
-In which month of the year is Harry Potter"s birthday?:
+In which month of the year is Harry Potter's birthday?:
 - July
-Into how many pieces did Ron tear Percy"s letter of congratulations on becoming a prefect before throwing it into the fire?:
+Into how many pieces did Ron tear Percy's letter of congratulations on becoming a prefect before throwing it into the fire?:
 - 8
 - eight
 Many of the recipes used at Hogwarts are those of ___?:
@@ -80,34 +80,34 @@ Sirius Black sends Harry what type of broom?:
 The Fat Friar was the Ghost of which house?:
 - Hufflepuff
 The Hogwarts Express leaves which London station?:
-- "Kingâ\x80\x99s Cross"
+- Kingâ€™s Cross
 The Slytherin common room is located where?:
 - dungeons
 - the dungeons
-"To get into the Ministry of Magic via the visitorâ\x80\x99s entrance, what number must be dialed?":
+To get into the Ministry of Magic via the visitorâ€™s entrance, what number must be dialed?:
 - 62442
 - MAGIC
 What Animagus form is taken by Sirius Black?:
 - dog
-What animal"s tail hair is the elder wand made of?:
+What animal's tail hair is the elder wand made of?:
 - Thestral
-What are draco"s parents" names?:
+What are draco's parents' names?:
 - Lucious and Narcissa
 - Narcissa and Lucious
 What book does Hermione insist Ron and Harry read?:
 - Hogwarts, A History
-What breed was Hagrid"s pet dragon?:
+What breed was Hagrid's pet dragon?:
 - Norwegian Ridgeback
 What color are unicorn foals?:
 - pale gold
 - gold
 What color bubbles does Professor Flitwick make for Christmas in the first book?:
 - Gold
-What color is Tonks"s hair when Harry first meets her?:
+What color is Tonks's hair when Harry first meets her?:
 - purple
 What color were the flames that came out of the Goblet of Fire?:
 - blue
-What creature is hatched by putting a toad over a chicken"s egg?:
+What creature is hatched by putting a toad over a chicken's egg?:
 - basilisk
 What creature is known to become violent when insulted?:
 - hippogriff
@@ -123,17 +123,17 @@ What did Dumbledore leave in his will for Ron?:
 - deluminator
 What did Dumbledore teach before he was Headmaster?:
 - Transfiguration
-What did Hermione squeeze in Fred and George"s room that punched her?:
+What did Hermione squeeze in Fred and George's room that punched her?:
 - telescope
 What did Katie Bell touch that put her in Saint Mungos in year 6?:
 - opal necklace
 What did Lavender Brown call Ron?:
 - won-won
 - won won
-"What do Hermioneâ\x80\x99s parents do for a living?":
+What do Hermioneâ€™s parents do for a living?:
 - dentists
 - dentist
-What do Ron and Hermione use to destroy Helga Hufflepuff"s cup?:
+What do Ron and Hermione use to destroy Helga Hufflepuff's cup?:
 - basilisk fang
 What does N.E.W.T stand for in examinations at Hogwarts School?:
 - Nastily Exhausting Wizarding Test
@@ -141,7 +141,7 @@ What does O.W.L. stand for?:
 - Ordinary Wizarding Level
 What does Professor Lupin give Harry to eat after his encounter with a Dementor?:
 - chocolate
-What does the sign on Weasley"s Wizard Wheezes say?:
+What does the sign on Weasley's Wizard Wheezes say?:
 - You-Know-Poo
 What flavor of ice cream does Hagrid buy Harry?:
 - chocolate and raspberry
@@ -161,47 +161,47 @@ What house was Tonks in?:
 What is  the symbol for Slytherin house?:
 - snake
 - a snake
-What is Buckbeak"s alias?:
+What is Buckbeak's alias?:
 - Witherwings
-What is Cho Chang"s Patronus?:
+What is Cho Chang's Patronus?:
 - swan
-What is Dumbeldore"s patronus?:
+What is Dumbeldore's patronus?:
 - phoenix
-What is Dumbledore"s sister"s name?:
+What is Dumbledore's sister's name?:
 - ariana
-What is Harry"s youngest son"s name?:
+What is Harry's youngest son's name?:
 - albus
-What is Hermione"s middle name?:
+What is Hermione's middle name?:
 - jean
-What is Luna Lovegood"s fathers name?:
+What is Luna Lovegood's fathers name?:
 - Xenophilius Lovegood
 - xenophilius
-What is Mr. Malfoy"s first name?:
+What is Mr. Malfoy's first name?:
 - lucius
-What is Padma Patil"s Boggart?:
+What is Padma Patil's Boggart?:
 - cobra
-What is Professor Mcgonagall"s transfiguraton form?:
+What is Professor Mcgonagall's transfiguraton form?:
 - cat
 - a cat
-What is Ron Weasley"s middle name?:
+What is Ron Weasley's middle name?:
 - Billius
-What is Rowena Ravenclaw"s aughter"s name?:
+What is Rowena Ravenclaw's aughter's name?:
 - Helena
-What is Severus Snape"s mother"s first name?:
+What is Severus Snape's mother's first name?:
 - eileen
-What is Tonks"s first name?:
+What is Tonks's first name?:
 - Nymphadora
-What is considered Harry"s "trademark spell"?:
+What is considered Harry's 'trademark spell'?:
 - Expelliarmus.
 What is the Hogwarts School motto in English?:
 - Never Tickle a Sleeping Dragon
 What is the age requirement for an Apparation License?:
 - 17
-What is the core of Cedric"s wand?:
+What is the core of Cedric's wand?:
 - Unicorn tail hair
-What is the core of Krum"s wand?:
+What is the core of Krum's wand?:
 - dragon heartstring
-What is the form of Hermione"s patronus?:
+What is the form of Hermione's patronus?:
 - otter
 What is the incantation for the spell that stuns people?:
 - Stupefy
@@ -212,32 +212,32 @@ What is the last name of the three brothers who origanally owned the Deathly Hal
 What is the name for the Hogwarts lake?:
 - Black Lake
 - the black lake
-What is the name for the house for people who didn"t fit in any of the other houses?:
+What is the name for the house for people who didn't fit in any of the other houses?:
 - hufflepuff
-What is the name of Draco"s son?:
+What is the name of Draco's son?:
 - scorpius
-What is the name of Dumbledore"s phoenix?:
+What is the name of Dumbledore's phoenix?:
 - fawkes
-What is the name of Filch"s cat?:
+What is the name of Filch's cat?:
 - Mrs. Norris
-"What is the name of Harry Potterâ\x80\x99s pet owl?":
+What is the name of Harry Potterâ€™s pet owl?:
 - Hedwig
-What is the name of Harry"s aunt?:
+What is the name of Harry's aunt?:
 - petunia dursley
-What is the name of Harry"s uncle?:
+What is the name of Harry's uncle?:
 - vernon dursley
-What is the name of Hermione"s cat?:
+What is the name of Hermione's cat?:
 - Crookshanks
-What is the name of Neville"s grandmother?:
+What is the name of Neville's grandmother?:
 - augusta
 - augusta longbottom
-What is the name of Ron"s brother who works for Gringotts?:
+What is the name of Ron's brother who works for Gringotts?:
 - bill weasley
 - bill
-What is the name of Ron"s father?:
+What is the name of Ron's father?:
 - arthur
 - Arthur Weasley
-What is the name of Voldemort"s prized snake?:
+What is the name of Voldemort's prized snake?:
 - nagini
 What is the name of the Charms Master at Hogwarts School?:
 - Filius Flitwick
@@ -266,7 +266,7 @@ What is the name of the house that Luna Lovegood is in?:
 - ravenclaw
 What is the name of the landlord of the Leaky Cauldrons?:
 - tom
-What is the name of the place filled with witches and wizards and (if you can"t apparate or haven"t got any floo powder handy) can only be entered through the Leaky Cauldron?:
+What is the name of the place filled with witches and wizards and (if you can't apparate or haven't got any floo powder handy) can only be entered through the Leaky Cauldron?:
 - Diagon Alley
 What is the name of the school Victor Krum attended?:
 - durmstrang
@@ -284,7 +284,7 @@ What is the name of the twin that dies in the last book?:
 What is the name of the twin that loses his ear in the last book?:
 - george weasley
 - george
-What is the name of the vicious tree that Harry and Ron drove into in "Harry Potter and the Chamber of Secrets"?:
+What is the name of the vicious tree that Harry and Ron drove into in 'Harry Potter and the Chamber of Secrets'?:
 - The Whomping Willow
 What is the name of the werewolf who bit Lupin?:
 - fenrir greyback
@@ -311,7 +311,7 @@ What is the theme of the tapestry near the Room of Requirement?:
 - trolls
 What is the title of the third Harry Potter book?:
 - The Prisoner of Azkaban
-What is voldemort"s real full name?:
+What is voldemort's real full name?:
 - Tom Marvolo Riddle
 What kind of creature is Buckbeak?:
 - hippogriff
@@ -319,11 +319,11 @@ What kind of ice cream treat did Harry Get at the zoo in the 1st book?:
 - lemon ice pop
 What magical plant does Harry use to breathe underwater in the 4th book?:
 - gillyweed
-"What make and model is the Weasley familyâ\x80\x99s flying car?":
+What make and model is the Weasley familyâ€™s flying car?:
 - Ford Anglia
-What month is Ron"s birthday?:
+What month is Ron's birthday?:
 - March
-What page does Snape tell Harry"s Defense Against the Dark Arts Class to turn to?:
+What page does Snape tell Harry's Defense Against the Dark Arts Class to turn to?:
 - 394
 What patronus does Luna Lovegood have?:
 - rabbit
@@ -335,13 +335,13 @@ What spell removes your memory?:
 - Obliviate
 What subject does Professor McGonagall teach?:
 - Transfiguration
-What was Harry"s first broomstick?:
+What was Harry's first broomstick?:
 - nimbus 2000
-What was James Potter"s school nickname?:
+What was James Potter's school nickname?:
 - Prongs
-What was Tom Riddle"s mother"s maiden name?:
+What was Tom Riddle's mother's maiden name?:
 - Gaunt
-What was the name of Hagrid"s half-giant brother?:
+What was the name of Hagrid's half-giant brother?:
 - grawp
 What was the name of the charming young witch who was friends with Snape?:
 - lily evans
@@ -356,13 +356,13 @@ Where does Hagrid take Harry to buy his school supplies?:
 - Diagon Alley
 Where is the Hufflepuff common room?:
 - kitchen
-Where was the Voldemort"s horcrux ring hidden?:
+Where was the Voldemort's horcrux ring hidden?:
 - Gaunt Shack
 Which Quidditch team does Cho Chang support?:
 - Tutshill Tornadoes
 Which animal is Hagrid allergic to?:
 - Cats
-Which animal is James Potter"s "Patronus"?:
+Which animal is James Potter's 'Patronus'?:
 - stag
 - A stag
 Which arm is the dark mark on?:
@@ -371,7 +371,7 @@ Which house was Umbridge in?:
 - Ravenclaw
 Which late actor played Albus Dumbledore in the first two Harry potter films?:
 - Richard Harris
-Which of Ron"s brothers is a Gryffindor Prefect in Harry"s first year?:
+Which of Ron's brothers is a Gryffindor Prefect in Harry's first year?:
 - Percy
 - Percy Weasley
 Which of the Hogwarts founders created the Chamber of Secrets?:
@@ -430,9 +430,9 @@ Who has a famous acid-green Quik-Quotes Quill?:
 Who in the 3rd year class wrote an essay on werewolves?:
 - hermione
 - hermione granger
-Who is Harry"s cousin?:
+Who is Harry's cousin?:
 - Dudley Dursley
-Who is Voldemort"s servant?:
+Who is Voldemort's servant?:
 - peter pettigrew
 - pettigrew
 Who is also known as Padfoot?:
@@ -440,16 +440,16 @@ Who is also known as Padfoot?:
 Who is caretaker of Hogwarts?:
 - Filch
 - argus filch
-'Who is it: Deputy Headmisstress of Hogwarts?':
+"Who is it: Deputy Headmisstress of Hogwarts?":
 - professor mcgonagall
 - mcgonagall
 - minerva mcgonagall
-'Who is it: Keeper of Keys and Grounds at Hogwarts?':
+"Who is it: Keeper of Keys and Grounds at Hogwarts?":
 - Hagrid
 Who is the 5th year Defense aganst the Dark Arts teacher?:
 - Dolores Umbridge
 - professor umbridge
-Who is the Blacks" house elf?:
+Who is the Blacks' house elf?:
 - Kreacher
 Who is the Head of Hufflepuff?:
 - professor sprout
@@ -467,7 +467,7 @@ Who is the only one Peeves is afraid of?:
 - The Bloody Baron
 Who is the poltergist at Hogwarts?:
 - peeves
-Who is unanimously elected leader of Dumbledore"s Army?:
+Who is unanimously elected leader of Dumbledore's Army?:
 - harry potter
 - harry
 Who killed Alastor Moody?:
@@ -478,16 +478,16 @@ Who killed Bellatrix Lestrange?:
 Who kills Dumbledore?:
 - snape
 - severus snape
-Who put Harry"s name in the Goblet of Fire?:
+Who put Harry's name in the Goblet of Fire?:
 - Barty Crouch Jr
 - barty crouch jr.
-'Who said it: "We did it, we bashed them!"?':
+"Who said it: 'We did it, we bashed them!\"?":
 - Peeves
-Who tells Harry and Ron that people can be a "bit stupid" about their pets?:
+Who tells Harry and Ron that people can be a 'bit stupid' about their pets?:
 - hagrid
-Who was Dumbledore"s predecessor as headmaster at Hogwarts?:
+Who was Dumbledore's predecessor as headmaster at Hogwarts?:
 - Armando Dippet
-Who was Harry"s first crush?:
+Who was Harry's first crush?:
 - Cho Chang
 Who was a werewolf also known as mooney?:
 - remus lupin

--- a/redbot/trivia/lists/leagueoflegends.yaml
+++ b/redbot/trivia/lists/leagueoflegends.yaml
@@ -1,25 +1,25 @@
-'...is scared of Jinx because she always wants to hug him?':
+"...is scared of Jinx because she always wants to hug him?":
 - Ziggs
-According to the dating service run by Blitzcrank, what is Rammus" best match?:
+According to the dating service run by Blitzcrank, what is Rammus' best match?:
 - A cactus
 - cactus
 Against which neutral mob does crowd control last twice as long?:
 - Rift Scuttler
-Ahri"s release celebrated the launch of servers in which country?:
+Ahri's release celebrated the launch of servers in which country?:
 - South Korea
 As a reference to The Little Mermaid, searching what word in the shop will show Boots of Speed for Nami?:
 - Hat
-As the Tidecaller, it is Nami"s duty to retrieve what from the landdwellers?:
+As the Tidecaller, it is Nami's duty to retrieve what from the landdwellers?:
 - Moonstone
 Aside from Evelynn, which champion could theoretically stay stealthed forever?:
 - Teemo
-Aside from Kindred, who else"s champion design is based on the idea of "Yin and Yang"?:
+Aside from Kindred, who else's champion design is based on the idea of "Yin and Yang"?:
 - Karma
 Aside from Lee Sin, who else is blind?:
 - Lissandra
 Between "The Blood Brothers", who is older?:
 - Darius
-During one April Fools, Wriggle"s lantern gained the passive to taunt which champion?:
+During one April Fools, Wriggle's lantern gained the passive to taunt which champion?:
 - Jax
 Glaive Warrrior Pantheon was released to celebrate the server for which country?:
 - Romania
@@ -33,7 +33,7 @@ If Urfrider Corki crits, what does Urf throw?:
 - Spatula
 If you search for Urf in champion select, whose name pops up?:
 - Warwick
-If you were to destroy this champion"s blades, he/she would die (according to lore)?:
+If you were to destroy this champion's blades, he/she would die (according to lore)?:
 - Irelia
 In the Bittersweet Lulu skin, what does her Whimsy turn her enemies into?:
 - Cupcakes
@@ -43,9 +43,9 @@ In the original lore, who did Professor Stanwick Pididly resurrect?:
 In their original lore, who cut Urgot in half?:
 - Garen
 Name a champion whose voice-over has no actual spoken words?:
-- Rek"sai or Bard
+- Rek'sai or Bard
 - Bard
-- Rek"sai
+- Rek'sai
 - Reksai
 - rek sai
 Name a champion with a non-ultimate ability that cannot be taken at level 1?:
@@ -92,8 +92,8 @@ Name one of the two champions with the highest movement speed in the game?:
 - Master Yi
 - masteryi
 Name one of the two female champions without a humanoid form?:
-- Anivia or Rek"sai
-- Rek"sai
+- Anivia or Rek'sai
+- Rek'sai
 - Reksai
 - Rek sai
 - Anivia
@@ -115,12 +115,12 @@ The Mythic Cassiopeia skin was released to celebrate the release of the server f
 - Greek
 Warwick betrayed Soraka to get her heart for who?:
 - Singed
-What accessory reduces the amount of damage done by Leona"s passive by 1?:
+What accessory reduces the amount of damage done by Leona's passive by 1?:
 - sunglasses
-What are Rakan"s wings disguised as to blend in with humans?:
+What are Rakan's wings disguised as to blend in with humans?:
 - His Cloak
 - cloak
-What are the names of Miss Fortune"s pistols?:
+What are the names of Miss Fortune's pistols?:
 - Shock and Awe
 What champion has the same voice actress as Kayle?:
 - Soraka
@@ -143,7 +143,7 @@ What does Ivern find scary?:
 - Rift Herald
 What does Jax use for a weapon (classic skin)?:
 - Lamppost
-What does Kled"s secondary bar measure?:
+What does Kled's secondary bar measure?:
 - Courage
 What does Pax Jax weild as a weapon?:
 - Cardboard Tube
@@ -151,120 +151,120 @@ What does Pax Jax weild as a weapon?:
 What faction is Leona a part of?:
 - The Solari
 - Solari
-What immortal species is Kled"s mount?:
+What immortal species is Kled's mount?:
 - desert drakalops
 What in-game item is Sejuani wearing in her Classic splash art?:
-- Seeker"s Armguard
+- Seeker's Armguard
 - seekers armguard
-What is Baron Nashor"s movement speed?:
+What is Baron Nashor's movement speed?:
 - 300
 - three hundred
-What is Camille"s last name?:
+What is Camille's last name?:
 - Ferros
 What is Dr. Mundo use as a weapon on his Pool Party skin?:
 - Ukelele
-What is Dr. Mundo"s first name?:
+What is Dr. Mundo's first name?:
 - Edmundo
-What is Fiora"s last name?:
+What is Fiora's last name?:
 - Laurent
-What is Garen and Lux"s family name?:
+What is Garen and Lux's family name?:
 - Crownguard
-What is Graves" first name?:
+What is Graves' first name?:
 - Malcolm
-What is Heimerdinger"s first name?:
+What is Heimerdinger's first name?:
 - Cecil
-What is Janna"s last name?:
+What is Janna's last name?:
 - Windforce
-What is Kayn"s first name?:
+What is Kayn's first name?:
 - Shieda
-What is Miss Fortune"s first name?:
+What is Miss Fortune's first name?:
 - Sarah
-What is Orianna"s last name?:
+What is Orianna's last name?:
 - Reveck
-What is Orianna"s occupation?:
+What is Orianna's occupation?:
 - Dancer
-What is Poppy"s favorite food?:
+What is Poppy's favorite food?:
 - Lollipops
 - Lollypop
 - lollipop
-What is Rakan"s favorite human food?:
+What is Rakan's favorite human food?:
 - Chocolate
-What is Sona"s last name?:
+What is Sona's last name?:
 - Buvelle
-What is Swain"s first name?:
+What is Swain's first name?:
 - Jericho
-What is Taliyah"s favorite ice cream flavor?:
+What is Taliyah's favorite ice cream flavor?:
 - Rocky Road
-What is Twisted Fate"s real name?:
+What is Twisted Fate's real name?:
 - Tobias Foxtrot
-What is Vayne"s first name?:
+What is Vayne's first name?:
 - Shauna
-What is Vladimir"s blood type?:
+What is Vladimir's blood type?:
 - AB+
 - AB positive
 - AB
 - AB +
-What is Yorick"s last name?:
+What is Yorick's last name?:
 - Mori
-What is the Roman numeral carved into Ekko"s bat?:
+What is the Roman numeral carved into Ekko's bat?:
 - XII
 - 12
 - twelve
 What is the capital city of Freljord?:
 - Rakelstake
-What is the name of Fiora"s brother?:
+What is the name of Fiora's brother?:
 - Ammdar
-What is the name of Fizz"s shark?:
+What is the name of Fizz's shark?:
 - Chomper
-What is the name of Graves" new gun?:
+What is the name of Graves' new gun?:
 - New Destiny
-What is the name of Graves" old gun?:
+What is the name of Graves' old gun?:
 - Destiny
-What is the name of Ivern"s summoned sentinel?:
+What is the name of Ivern's summoned sentinel?:
 - Daisy
-What is the name of Janna"s bird companion?:
+What is the name of Janna's bird companion?:
 - Zephyr
-What is the name of Jhin"s gun?:
+What is the name of Jhin's gun?:
 - Whisper
-What is the name of Jinx"s bigger gun?:
+What is the name of Jinx's bigger gun?:
 - Fishbones
-What is the name of Jinx"s smaller gun?:
+What is the name of Jinx's smaller gun?:
 - Pow-pow
 - pow pow
-What is the name of Kayn"s weapon?:
+What is the name of Kayn's weapon?:
 - Rhaast
-What is the name of Kled"s friend and mount?:
+What is the name of Kled's friend and mount?:
 - Skaarl
-What is the name of Lulu"s fae spirit companion?:
+What is the name of Lulu's fae spirit companion?:
 - Pix
-What is the name of Miss Fortune"s ship?:
+What is the name of Miss Fortune's ship?:
 - The Syren
 - Syren
-What is the name of Mordekaiser"s mace?:
+What is the name of Mordekaiser's mace?:
 - Nightfall
-What is the name of Quinn"s dead brother?:
+What is the name of Quinn's dead brother?:
 - Caleb
-What is the name of Quinn"s eagle?:
+What is the name of Quinn's eagle?:
 - Valor
-What is the name of Rumble"s robot?:
+What is the name of Rumble's robot?:
 - Tristy
-What is the name of Sejuani"s boar?:
+What is the name of Sejuani's boar?:
 - Bristle
-What is the name of Sona"s weapon?:
+What is the name of Sona's weapon?:
 - etwahl
-What is the name of Star Guardian Jinx"s black gun?:
+What is the name of Star Guardian Jinx's black gun?:
 - Kuro
-What is the name of Star Guardian Jinx"s white gun?:
+What is the name of Star Guardian Jinx's white gun?:
 - Shiro
-What is the name of Swain"s raven?:
+What is the name of Swain's raven?:
 - Beatrice
-What is the name of Tristana"s Dragon in her Dragon Trainer Tristana skin?:
+What is the name of Tristana's Dragon in her Dragon Trainer Tristana skin?:
 - Riggle
-What is the name of Tristana"s Gun?:
+What is the name of Tristana's Gun?:
 - Boomer
-What is the name of Trundle"s club?:
+What is the name of Trundle's club?:
 - Boneshiver
-What is the name of Yasuo"s brother?:
+What is the name of Yasuo's brother?:
 - Yone
 What is the name of the Viking ghost shopkeeper on the Howling Abyss?:
 - Greyor
@@ -272,7 +272,7 @@ What is the name of the continent that League of Legends is located on?:
 - Valoran
 What is the name of the flying robot owned by the Hermit on the Howling Abyss (hint:named after a Rioter)?:
 - Geeves
-'What is the name of the hermit shopkeeper on the Howling Abyss (hint: named after a Rioter)?':
+"What is the name of the hermit shopkeeper on the Howling Abyss (hint: named after a Rioter)?":
 - Lyte
 What is the name of the spider that lives in the Twisted Treeline?:
 - Vilemaw
@@ -293,8 +293,8 @@ What species is Lissandra?:
 - Iceborn
 What species is Maokai?:
 - Treant
-What species is Rek"sai?:
-- Xer"Sai
+What species is Rek'sai?:
+- Xer'Sai
 - Xersai
 - Xer sai
 What species is Trundle?:
@@ -306,15 +306,15 @@ What tribe do Rakan and Xayah belong to?:
 What type of poison does Teemo use in his blowgun?:
 - Arjunta
 What type of weapon does Yorick weild?:
-- Monk"s Spade
+- Monk's Spade
 - monks spade
 - spade
-What was Fiddlesticks" original occupation?:
+What was Fiddlesticks' original occupation?:
 - Executioner
-What was Orianna"s father"s name?:
+What was Orianna's father's name?:
 - Corin Reveck
 - Corin
-What was the name of Lucian"s wife?:
+What was the name of Lucian's wife?:
 - Senna
 What weapon does Arctic Ops Kennen use?:
 - Kunai
@@ -338,7 +338,7 @@ Where was Yorick born?:
 Which Demacian disapproves of Shyvana due to her lack of self-control?:
 - Garen
 Which Voidborn has dwelt the longest in Runeterra?:
-- Rek"sai
+- Rek'sai
 - Reksai
 - Rek sai
 Which champion has 3 legendary skins?:
@@ -368,7 +368,7 @@ Which neutral mob gives +58 gold when killed?:
 - Blue Sentinel
 Which neutral mob gives +62 gold when killed?:
 - Gromp
-Which neutral mob gives the buff "Doom"s Eve"?:
+Which neutral mob gives the buff "Doom's Eve"?:
 - Rift Herald
 Which neutral mob is the only mob with scaling armor and magic resistance after level 9?:
 - Dragon
@@ -382,7 +382,7 @@ Who augmented Warwick?:
 - Singed
 Who betrayed Azir?:
 - Xerath
-Who bound the Viking"s ghost to the Howling Abyss?:
+Who bound the Viking's ghost to the Howling Abyss?:
 - Avarosa
 Who brought Udyr to Ionia to calm his rage and meet the animal spirits that he uses?:
 - Lee Sin
@@ -393,33 +393,33 @@ Who can continuously increase their AP by using a skill?:
 - Veigar
 Who can have the most movable pets on the map?:
 - Elise
-Who can you get a free skin for by subscribing to Riot"s twitter?:
+Who can you get a free skin for by subscribing to Riot's twitter?:
 - Garen
 Who can you get a free skin for if you like Riot on Facebook?:
 - Tristana
 Who cannot damage any non-epic neutral monsters?:
 - Ivern
-Who captured Kassadin"s daughter?:
+Who captured Kassadin's daughter?:
 - Malzahar
 Who carries two ninjato?:
 - Shen
 Who constructed Blitzcrank?:
 - Viktor
-Who crafted Braum"s Enchanted Ram Door?:
+Who crafted Braum's Enchanted Ram Door?:
 - Ornn
-Who crafted Fizz"s Seastone Trident?:
+Who crafted Fizz's Seastone Trident?:
 - Ornn
 Who crafted The Howling Abyss and the bridge above it?:
 - Ornn
-Who created Corki"s plane?:
+Who created Corki's plane?:
 - Heimerdinger
 Who created Galio?:
 - Durand
-Who created Master Yi"s goggles?:
+Who created Master Yi's goggles?:
 - Heimerdinger
 Who created Tryndamere (in the lore)?:
 - Aatrox
-Who created Wukong"s staff?:
+Who created Wukong's staff?:
 - Doran
 Who creates the stars?:
 - Aurelion Sol
@@ -427,14 +427,14 @@ Who creates the stars?:
 Who cut Urgot in the mines?:
 - Baron Voss
 - Voss
-Who did Professor Stanwick steal credit for creating Blitzcrank"s sentience from?:
+Who did Professor Stanwick steal credit for creating Blitzcrank's sentience from?:
 - Viktor
 Who did Trundle get his club from?:
 - Lissandra
 Who did Xayah and Rakan fight in the "Wild Magic" Promo video?:
 - Zed
 Who did rengar lose an eye to?:
-- Kha"zix
+- Kha'zix
 - Khazix
 - Kha zix
 Who does Captain Gangplank say "Prepare to be boarded." to?:
@@ -461,7 +461,7 @@ Who does Syndra have an alliance with?:
 - Zed
 Who does Taric supposedly have a crush on?:
 - Ezreal
-Who does Valor (Quinn"s eagle) not respect?:
+Who does Valor (Quinn's eagle) not respect?:
 - Garen
 Who does Vayne refer to as "the Horned Woman"?:
 - Evelynn
@@ -477,7 +477,7 @@ Who established the Order of the Shadow?:
 - Zed
 Who felled the God Willow?:
 - Ivern
-Who found Wriggle"s Lantern?:
+Who found Wriggle's Lantern?:
 - Ezreal
 Who froze Brand for many years?:
 - Lissandra
@@ -486,7 +486,7 @@ Who froze Gnar?:
 Who gains +1 movement speed when on the same team as Zyra?:
 - Maokai
 Who gains 3.141592 (pi) AD per level?:
-- Vel"koz
+- Vel'koz
 - vel koz
 - velkoz
 Who gave Yasuo the thread he uses to tie up his hair?:
@@ -495,12 +495,12 @@ Who gets the buff Eureka! when they get a pentakill?:
 - Heimerdinger
 Who guards the Pit of Pallas?:
 - Varus
-Who had a skin released to celebrate League of Legends" first anniversary in Korea?:
+Who had a skin released to celebrate League of Legends' first anniversary in Korea?:
 - Shaco
 Who had romantic feelings for a girl named Tabia, a girl who tried to stop their transformation?:
 - Xerath
 Who has a Badger skin?:
-- ''
+- ""
 Who has a Challenger skin made to celebrate the start of the 2016 season?:
 - Nidalee
 Who has a Corporate skin?:
@@ -539,7 +539,7 @@ Who has a Leprechaun skin?:
 Who has a Little Knight skin?:
 - Amumu
 Who has a Loch Ness skin?:
-- Cho"gath
+- Cho'gath
 - chogath
 - cho gath
 Who has a Lunar Goddess skin?:
@@ -571,7 +571,7 @@ Who has a Red Card skin?:
 Who has a Redeemed skin?:
 - Riven
 Who has a Reindeer skin?:
-- Kog"maw
+- Kog'maw
 - kogmaw
 - Kog maw
 Who has a Runeborn skin?:
@@ -598,7 +598,7 @@ Who has a Wildfire skin?:
 - Zyra
 Who has a championship skin that was released to celebrate the 2013 Season 3 World Championship?:
 - Thresh
-Who has a free skin obtained by subscribing to Riot"s Youtube channel?:
+Who has a free skin obtained by subscribing to Riot's Youtube channel?:
 - Alistar
 Who has a kunai in their head?:
 - Sion
@@ -615,7 +615,7 @@ Who has a skill called "Arcanopulse"?:
 - Xerath
 Who has a skill called "Battle Dance"?:
 - Rakan
-Who has a skill called "Blade"s Reach"?:
+Who has a skill called "Blade's Reach"?:
 - Kayn
 Who has a skill called "Bladework"?:
 - Fiora
@@ -666,7 +666,7 @@ Who has a skill called "Fracture"?:
 Who has a skill called "Justice Punch"?:
 - Galio
 Who has a skill called "Leap"?:
-- Kha"zix
+- Kha'zix
 - Khazix
 - kha zix
 Who has a skill called "Majestic Roar"?:
@@ -686,7 +686,7 @@ Who has a skill called "Neurotoxin"?:
 Who has a skill called "Pierce"?:
 - Kalista
 Who has a skill called "Prey Seeker"?:
-- Rek"sai
+- Rek'sai
 - Reksai
 - Rek sai
 Who has a skill called "Renewal"?:
@@ -713,7 +713,7 @@ Who has a skill called "flamespitter"?:
 - Rumble
 Who has a skill named "Relentless Assault"?:
 - Jax
-'Who has a skill that says "You have opened the box. Your prize: death." in the Death Recap?':
+"Who has a skill that says \"You have opened the box. Your prize: death.\" in the Death Recap?":
 - Thresh
 Who has a skin released to celebrate the release of the League of Legends Mac client?:
 - Blitzcrank
@@ -763,7 +763,7 @@ Who has an Imperial skin?:
 Who has an Outback skin which references Crocodile Dundee?:
 - Renekton
 Who has an ability called "Icathian Surprise"?:
-- Kog"maw
+- Kog'maw
 - kogmaw
 - Kog maw
 Who has an ability called "Pale Cascade"?:
@@ -857,64 +857,64 @@ Who helped Shyvana kill the dragon who killed her father?:
 - j4
 Who impersonated Jarvan IV?:
 - Leblanc
-Who incurred Zed"s wrath after ransacking the Temple of the Jagged Knife?:
+Who incurred Zed's wrath after ransacking the Temple of the Jagged Knife?:
 - Gangplank
 Who inspired Galio to leave his silent purgatory to fight for the will of Demacia?:
 - Poppy
-Who invented the weapon used to destroy Master Yi"s home village?:
+Who invented the weapon used to destroy Master Yi's home village?:
 - Singed
-Who is "Valoran"s first fully functioning homicidal comic"?:
+Who is "Valoran's first fully functioning homicidal comic"?:
 - Shaco
 Who is "the Terror of the Void"?:
-- Cho"gath
+- Cho'gath
 - chogath
 - cho gath
 Who is Ashe married to?:
 - Tryndamere
-Who is Avarosa" descendant?:
+Who is Avarosa' descendant?:
 - Ashe
-Who is Caitlyn"s partner?:
+Who is Caitlyn's partner?:
 - Vi
-Who is Darius" brother?:
+Who is Darius' brother?:
 - Draven
-Who is Freljord"s League Emissary?:
+Who is Freljord's League Emissary?:
 - Nunu
-Who is Gangplank"s ex-girlfriend?:
+Who is Gangplank's ex-girlfriend?:
 - Illaoi
-Who is Garen"s love interest?:
+Who is Garen's love interest?:
 - Katarina
-Who is Gragas" drinking buddy?:
+Who is Gragas' drinking buddy?:
 - Jax
-Who is Jayce"s nemesis?:
+Who is Jayce's nemesis?:
 - Viktor
-Who is Katarina"s sister?:
+Who is Katarina's sister?:
 - Cassiopeia
-Who is Kayle"s sister?:
+Who is Kayle's sister?:
 - Morgana
-Who is Kha"zix"s rival?:
+Who is Kha'zix's rival?:
 - Rengar
-Who is Lucian"s enemy?:
+Who is Lucian's enemy?:
 - Thresh
 Who is Lux supposedly dating?:
 - Ezreal
-Who is Nasus" brother?:
+Who is Nasus' brother?:
 - Renekton
 Who is Olaf allied with?:
 - Sejuani
-Who is Orianna"s pet and protector?:
+Who is Orianna's pet and protector?:
 - The Ball
 - Ball
 Who is Sivir related to?:
 - Azir
-Who is Talon"s rival?:
+Who is Talon's rival?:
 - Quinn
-Who is Tryndamere"s nemesis?:
+Who is Tryndamere's nemesis?:
 - Aatrox
-Who is Twisted Fate"s ex-girlfriend?:
+Who is Twisted Fate's ex-girlfriend?:
 - Evelynn
 Who is Vayne rumored to be investigating?:
 - Leblanc
-Who is Vel"koz searching for?:
+Who is Vel'koz searching for?:
 - Zilean
 Who is a Hemomancer?:
 - Vladimir
@@ -935,7 +935,7 @@ Who is allied with Maokai?:
 - Malphite
 Who is also known as "The Crystal Vanguard"?:
 - Skarner
-Who is also known as "The Great Hussar", "The Mountain Admiral", "The High General Marshal Sergeant", "Lord Colonel Major Centurion", "Rear Forward Brigadier Admiral", "Forward Admiral Major", "Sir Admiral Major", "Lieutenant Sergeant Commodore", "Sergeant General Colonel", "Sergeant Double Admiral", "High Major Commodore of the First Legion Third Multiplication Double Admiral Artillery Vanguard Company", and "Lord Major Admiral of the Second Legion"s Forward Artillery-Cavalary Multiplication"?:
+Who is also known as "The Great Hussar", "The Mountain Admiral", "The High General Marshal Sergeant", "Lord Colonel Major Centurion", "Rear Forward Brigadier Admiral", "Forward Admiral Major", "Sir Admiral Major", "Lieutenant Sergeant Commodore", "Sergeant General Colonel", "Sergeant Double Admiral", "High Major Commodore of the First Legion Third Multiplication Double Admiral Artillery Vanguard Company", and "Lord Major Admiral of the Second Legion's Forward Artillery-Cavalary Multiplication"?:
 - Kled
 Who is also known as "The Purifier"?:
 - Lucian
@@ -947,9 +947,9 @@ Who is also known as "the Shield of Valoran"?:
 - Taric
 Who is also known as "the Uncaged Wrath of Zaun"?:
 - Warwick
-Who is also known as Demacia"s Wings?:
+Who is also known as Demacia's Wings?:
 - Quinn
-'Who is also known as Subject #1088?':
+"Who is also known as Subject #1088?":
 - Warwick
 Who is also known as the "Artisan of War"?:
 - Pantheon
@@ -1000,14 +1000,14 @@ Who is also known as the "Unforgiven"?:
 Who is also known as the "Virtuoso"?:
 - Jhin
 Who is also known as the "Void Burrower"?:
-- Rek"sai
+- Rek'sai
 - Reksai
 - Rek sai
 Who is also known as the "Walking National Monument"?:
 - Galio
-Who is also known as the "Winter"s Wrath"?:
+Who is also known as the "Winter's Wrath"?:
 - Sejuani
-Who is also known as the Blade"s Shadow?:
+Who is also known as the Blade's Shadow?:
 - Talon
 Who is also known as the Steel Shadow?:
 - Camille
@@ -1043,10 +1043,10 @@ Who is known as the "Rabble Rouser"?:
 - Gragas
 Who is known as the "Revered Inventor"?:
 - Heimerdinger
-Who is known as the "Storm"s Fury"?:
+Who is known as the "Storm's Fury"?:
 - Janna
 Who is known as the "Voidreaver"?:
-- Kha"zix
+- Kha'zix
 - Khazix
 - kha zix
 Who is known as the "Will of the Blades"?:
@@ -1059,7 +1059,7 @@ Who is related to the Ruined King (Blade of the Ruined King)?:
 - Kalista
 Who is responsible for reviving Irelia and binding her life force to her blades?:
 - Soraka
-Who is rumored to be Teemo"s girlfriend?:
+Who is rumored to be Teemo's girlfriend?:
 - Tristana
 Who is the "Exemplar of Demacia"?:
 - Jarvan IV
@@ -1074,7 +1074,7 @@ Who is the "Hand of Noxus"?:
 Who is the "Heart of the Tempest"?:
 - Kennen
 Who is the "Mouth of the Abyss"?:
-- Kog"maw
+- Kog'maw
 - kogmaw
 - Kog maw
 Who is the Dean of Demolitions at the Yordle Academy in Piltover?:
@@ -1089,7 +1089,7 @@ Who is the Zaun Amorphous Combatant?:
 - ZAC
 Who is the antithesis to Diana?:
 - Leona
-Who is the band Pentakill"s back up singer?:
+Who is the band Pentakill's back up singer?:
 - Kayle
 Who is the champion in the tutorial?:
 - Ashe
@@ -1110,7 +1110,7 @@ Who is the leader of the Iron Order?:
 Who is the leader of the Kinkou order?:
 - Shen
 Who is the only Voidborn champion without a True Damage component to their skillset?:
-- Kha"zix
+- Kha'zix
 - Khazix
 - kha zix
 Who is the only Yordle with a tail?:
@@ -1120,7 +1120,7 @@ Who is the only champion from Zaun who was raised by two loving parents?:
 Who is the only champion from the Glade?:
 - Lulu
 Who is the only champion from the Void with more than 6 letters in their name?:
-- Cho"gath
+- Cho'gath
 - chogath
 - cho gath
 Who is the only champion in game to have a target skill that can be self-cast but not ally-cast?:
@@ -1142,11 +1142,11 @@ Who is the only champion with a Polymorph?:
 Who is the only champion with a stealth ability who is not classified as an assassin?:
 - Wukong
 Who is the only champion with two Legendary skins available for purchase in the store on a regular basis?:
-- Cho"gath
+- Cho'gath
 - chogath
 - cho gath
 Who is the only female Voidborn?:
-- Rek"sai
+- Rek'sai
 - Reksai
 - Rek sai
 Who is the only female champion with a Riot skin?:
@@ -1169,20 +1169,20 @@ Who joined the league to find a cure for chrono-displasia?:
 - Zilean
 Who killed Kalista?:
 - Hecarim
-Who killed Miss Fortune"s parents?:
+Who killed Miss Fortune's parents?:
 - Gangplank
-Who killed Shen"s father?:
+Who killed Shen's father?:
 - Zed
-Who killed Udyr"s predecessor and mentor?:
+Who killed Udyr's predecessor and mentor?:
 - Lissandra
 Who killed Urf?:
 - Warwick
-Who killed Vayne"s parents?:
+Who killed Vayne's parents?:
 - Evelynn
 Who killed the Ionian elder that Yasuo was trying to protect?:
 - Riven
 Who learns about Valoran by disintegrating subjects?:
-- Vel"koz
+- Vel'koz
 - vel koz
 - velkoz
 Who lit themselves on fire to protest Noxus?:
@@ -1201,7 +1201,7 @@ Who occasionally plays cards with Twisted Fate?:
 - Ezreal
 Who owned a bakery in Noxus called "Sinful Succulence" that was shut down by the Valoran Department of Health and now runs a food cart?:
 - Morgana
-Who owns Freljord"s Avarosa Iceflow Glacier?:
+Who owns Freljord's Avarosa Iceflow Glacier?:
 - Gragas
 Who performed the ritual to resurrect Sion?:
 - Vladimir
@@ -1211,9 +1211,9 @@ Who plays a Sakuhachi (type of flute) in their dance animation?:
 - Yasuo
 Who plays guitar for the band "Pentakill"?:
 - Mordekaiser
-Who plays the bass in the band "Pentakill"?:
+Who plays the bass in the band 'Pentakill'?:
 - Yorick
-Who plays the drums in the band "Pentakill"?:
+Who plays the drums in the band 'Pentakill'?:
 - Olaf
 Who releases Renekton and Xerath?:
 - Cassiopeia
@@ -1229,13 +1229,13 @@ Who says "Another unworthy opponent." while attacking?:
 - Akali
 Who says "Are you my nightmare, or am I yours?"?:
 - Nocturne
-Who says "Are... You sure you"re not in the wrong league?" as a taunt?:
+Who says "Are... You sure you're not in the wrong league?" as a taunt?:
 - Kayle
 Who says "As I live, all will die!"?:
 - Renekton
 Who says "Bring down the sun."?:
 - Diana
-Who says "Don"t you trust me?" when picked in champion select?:
+Who says "Don't you trust me?" when picked in champion select?:
 - Ahri
 Who says "Embrace the darkness." when picked in champion select?:
 - Nocturne
@@ -1253,7 +1253,7 @@ Who says "Here comes the boom!" in game?:
 - Tristana
 Who says "I accidentally did that on purpose."?:
 - Jinx
-Who says "I ain"t got time to bleed."?:
+Who says "I ain't got time to bleed."?:
 - Graves
 Who says "I am forsaken" in game?:
 - Varus
@@ -1279,22 +1279,22 @@ Who says "I will be free." when picked in champion select?:
 - Xerath
 Who says "I will swallow your soul."?:
 - Veigar
-Who says "I"ll be right under their noses." in game?:
+Who says "I'll be right under their noses." in game?:
 - Twitch
-Who says "I"ll show them a watery grave."?:
+Who says "I'll show them a watery grave."?:
 - Fizz
-Who says "I"m moving as fast as I can." in game?:
+Who says "I'm moving as fast as I can." in game?:
 - Malphite
-Who says "I"m not ugly, but they"re about to be!" in game?:
+Who says "I'm not ugly, but they're about to be!" in game?:
 - Trundle
-Who says "I"m on a short fuse." in game?:
+Who says "I'm on a short fuse." in game?:
 - Brand
-Who says "If you"re buying, I"m in!" when picked at champion select?:
+Who says "If you're buying, I'm in!" when picked at champion select?:
 - Gragas
 Who says "Insolent peasants!"?:
 - Fiora
 Who says "Knowledge through... disintegration." when picked in champion select?:
-- Vel"koz
+- Vel'koz
 - vel koz
 - velkoz
 Who says "Leave nothing behind!" when picked in champion select?:
@@ -1303,11 +1303,11 @@ Who says "Let the storm follow in my wake." when picked in champion select?:
 - Volibear
 Who says "Let us hunt those who have fallen to darkness." when picked in champion select?:
 - Vayne
-Who says "Let"s find some friends." in game?:
+Who says "Let's find some friends." in game?:
 - Amumu
-Who says "Let"s get in the fight!" when picked in champion select?:
+Who says "Let's get in the fight!" when picked in champion select?:
 - Rumble
-Who says "Man, I"m good."?:
+Who says "Man, I'm good."?:
 - Draven
 Who says "Mmm, the taste of coward." in game?:
 - Nidalee
@@ -1336,18 +1336,18 @@ Who says "Savor the misery."?:
 Who says "Swallowed you whole!" in game?:
 - Nunu
 Who says "Terror coming...daddy coming!"?:
-- Kog"maw
+- Kog'maw
 - kogmaw
 - Kog maw
 Who says "The daylight! It burns!" in game?:
-- Cho"gath
+- Cho'gath
 - chogath
 - cho gath
 Who says "The endless march." in game?:
 - Nautilus
 Who says "The eyes never lie." when picked during champion select?:
 - Kennen
-Who says "The joke"s on you!" in game?:
+Who says "The joke's on you!" in game?:
 - Shaco
 Who says "The rivers will run red." when picked in champion select?:
 - Vladimir
@@ -1360,7 +1360,7 @@ Who says "This battle will be won."?:
 - Irelia
 Who says "This is my path" in game?:
 - Soraka
-Who says "This"ll be a slaughter" when picked in champion select?:
+Who says "This'll be a slaughter" when picked in champion select?:
 - Tryndamere
 Who says "Time for a shakedown." in game?:
 - Caitlyn
@@ -1378,9 +1378,9 @@ Who says "We all have a place among the divine. We have only to accept it."?:
 - Karthus
 Who says "We are the vanguard."?:
 - Garen
-Who says "We"ll bring them pain." when picked during champion select?:
+Who says "We'll bring them pain." when picked during champion select?:
 - Morgana
-Who says "Who"s following me?" as a reference to the website twitch.tv?:
+Who says "Who's following me?" as a reference to the website twitch.tv?:
 - Twitch
 Who says "You are null and void."?:
 - Kassadin
@@ -1393,7 +1393,7 @@ Who says "You will never suffer enough!"?:
 Who says "Your bidding, master" when picked during champion selection?:
 - Fiddlesticks
 Who says "change is good"?:
-- Kha"zix
+- Kha'zix
 - khazix
 - kha zix
 Who says "ok."?:
@@ -1414,7 +1414,7 @@ Who thinks that other Yordles are fluffy and disorganized?:
 - Poppy
 Who tried to kill Gnar when he first awoke?:
 - Rengar
-Who tried to steal Bandle City"s Mothership?:
+Who tried to steal Bandle City's Mothership?:
 - Veigar
 Who used to be known as the "Rogue Mage"?:
 - Ryze
@@ -1426,30 +1426,30 @@ Who used to wield fans?:
 - Karma
 Who uses cupcakes as a weapon?:
 - Caitlyn
-Who was Graves" partner in crime?:
+Who was Graves' partner in crime?:
 - Twisted Fate
-Who was Leona"s childhood friend?:
+Who was Leona's childhood friend?:
 - Pantheon
-Who was Poppy"s mentor (the original owner of the hammer)?:
+Who was Poppy's mentor (the original owner of the hammer)?:
 - Orlon
 Who was Soraka betrayed by?:
 - Warwick
-Who was Talon"s old partner in crime?:
+Who was Talon's old partner in crime?:
 - Kavyn
-Who was Urf"s Corpse sold to?:
+Who was Urf's Corpse sold to?:
 - Butcher Urgot
 - Urgot
-Who was born in the Guardian"s Sea?:
+Who was born in the Guardian's Sea?:
 - Fizz
 Who was named after the Riot Games CEO?:
 - Tryndamere
-Who was once a member of Zed"s Order of Shadows?:
+Who was once a member of Zed's Order of Shadows?:
 - Akali
 Who was once known as "the Cruel"?:
 - Ivern
 Who was punished with the Crown of Stone?:
 - Taric
-Who was rescued by Jarvan IV"s grandfather?:
+Who was rescued by Jarvan IV's grandfather?:
 - Xin Zhao
 Who was responsible for capturing and imprisoning Jhin?:
 - Shen
@@ -1486,7 +1486,7 @@ Who woke up Skarner?:
 - Zilean
 Who yells his own name after standing in a bush for a period of time (reference to Pokemon)?:
 - Skarner
-Who"s a member of the Gumiho species?:
+Who's a member of the Gumiho species?:
 - Ahri
 Whose actions caused Riven to decide to wander in self-imposed exile?:
 - Singed
@@ -1496,23 +1496,23 @@ Whose champion design is based on an axolotl?:
 - Fizz
 Whose champion design is based on the samurai?:
 - Yasuo
-Whose dance is a reference to Beyonce"s Single Ladies dance?:
+Whose dance is a reference to Beyonce's Single Ladies dance?:
 - Akali
 Whose dance is a reference to Gangnam Style by Psy?:
 - Twisted Fate
-Whose dance is a reference to Kirby"s victory dance?:
+Whose dance is a reference to Kirby's victory dance?:
 - Urgot
-Whose dance is a reference to Snoop Dogg"s "Drop it like it"s hot" dance?:
+Whose dance is a reference to Snoop Dogg's "Drop it like it's hot" dance?:
 - Nasus
 Whose dance is a reference to an airflare?:
 - Kennen
 Whose dance is a reference to the "Macarena"?:
 - Blitzcrank
 Whose dance is based on the Michigan J. Frog dance?:
-- Kog"maw
+- Kog'maw
 - kogmaw
 - Kog maw
-Whose dance is based on the dance from Run Devil Run by Girl"s Generation (SNSD)?:
+Whose dance is based on the dance from Run Devil Run by Girl's Generation (SNSD)?:
 - Ahri
 Whose dance is from Beauty and the Beast?:
 - Galio
@@ -1570,7 +1570,7 @@ Whose name translates to "Beast" in Norwegian?:
 Whose occupation is "Goat Herder"?:
 - Braum
 Whose occupation is "Knowledge Seeker"?:
-- Vel"koz
+- Vel'koz
 - vel koz
 - velkoz
 Whose occupation is "Night Hunter"?:
@@ -1591,7 +1591,7 @@ Whose passive is called "Cursed Touch"?:
 - Amumu
 Whose passive is called "Staggering Blow"?:
 - Nautilus
-Whose passive is called "Traveler"s Call"?:
+Whose passive is called "Traveler's Call"?:
 - Bard
 Whose passive makes them stealth for 1 second?:
 - Leblanc
@@ -1610,12 +1610,12 @@ Whose shape resembles a Falcon after being in the Temple of the Falcon?:
 - Azir
 Whose species is a scarecrow?:
 - Fiddlesticks
-Whose taunt is "You can"t milk those."?:
+Whose taunt is "You can't milk those."?:
 - Alistar
 Whose taunt is the "Ali Shuffle"?:
 - Vi
 Whose title is the name of their old ultimate?:
-- Evelynn (Agony"s Embrace)
+- Evelynn (Agony's Embrace)
 - Evelynn
 Whose ult makes the corpses of small champions disappear?:
 - Fizz

--- a/redbot/trivia/lists/leagueults.yaml
+++ b/redbot/trivia/lists/leagueults.yaml
@@ -1,293 +1,293 @@
-'Which champion"s ultimate is named: Absolute Zero?':
+"Which champion's ultimate is named: Absolute Zero?":
 - Nunu
-'Which champion"s ultimate is named: Abyssal Voyage?':
+"Which champion's ultimate is named: Abyssal Voyage?":
 - Tahm Kench
 - tahmkench
-'Which champion"s ultimate is named: Ace in the Hole?':
+"Which champion's ultimate is named: Ace in the Hole?":
 - Caitlyn
-'Which champion"s ultimate is named: Aspect of the Cougar?':
+"Which champion's ultimate is named: Aspect of the Cougar?":
 - Nidalee
-'Which champion"s ultimate is named: Assault and Battery?':
+"Which champion's ultimate is named: Assault and Battery?":
 - Vi
-'Which champion"s ultimate is named: Behind Enemy Lines?':
+"Which champion's ultimate is named: Behind Enemy Lines?":
 - Quinn
-'Which champion"s ultimate is named: Blade of the Exile?':
+"Which champion's ultimate is named: Blade of the Exile?":
 - Riven
-'Which champion"s ultimate is named: Bullet Time?':
+"Which champion's ultimate is named: Bullet Time?":
 - Miss Fortune
-'Which champion"s ultimate is named: Buster Shot?':
+"Which champion's ultimate is named: Buster Shot?":
 - Tristana
-'Which champion"s ultimate is named: Call of the Forge God?':
+"Which champion's ultimate is named: Call of the Forge God?":
 - Ornn
-'Which champion"s ultimate is named: Cannon Barrage?':
+"Which champion's ultimate is named: Cannon Barrage?":
 - Gangplank
-'Which champion"s ultimate is named: Cataclysm?':
+"Which champion's ultimate is named: Cataclysm?":
 - Jarvan
-'Which champion"s ultimate is named: Chaaaaaaaarge!!! ?':
+"Which champion's ultimate is named: Chaaaaaaaarge!!! ?":
 - Kled
-'Which champion"s ultimate is named: Chain of Corruption?':
+"Which champion's ultimate is named: Chain of Corruption?":
 - Varus
-'Which champion"s ultimate is named: Chaos Storm?':
+"Which champion's ultimate is named: Chaos Storm?":
 - Viktor
-'Which champion"s ultimate is named: Children of the Grave?':
+"Which champion's ultimate is named: Children of the Grave?":
 - Mordekaiser
-'Which champion"s ultimate is named: Chronobreak?':
+"Which champion's ultimate is named: Chronobreak?":
 - Ekko
-'Which champion"s ultimate is named: Chronoshift?':
+"Which champion's ultimate is named: Chronoshift?":
 - Zilean
-'Which champion"s ultimate is named: Chum the Waters?':
+"Which champion's ultimate is named: Chum the Waters?":
 - Fizz
-'Which champion"s ultimate is named: Collateral Damage?':
+"Which champion's ultimate is named: Collateral Damage?":
 - Graves
-'Which champion"s ultimate is named: Command: Shockwave?':
+"Which champion's ultimate is named: Command: Shockwave?":
 - Orianna
-'Which champion"s ultimate is named: Cosmic Radiance?':
+"Which champion's ultimate is named: Cosmic Radiance?":
 - Taric
-'Which champion"s ultimate is named: Crescendo?':
+"Which champion's ultimate is named: Crescendo?":
 - Sona
-'Which champion"s ultimate is named: Crescent Sweep?':
+"Which champion's ultimate is named: Crescent Sweep?":
 - Xin Zhao
 - xinzhao
-'Which champion"s ultimate is named: Crowstorm?':
+"Which champion's ultimate is named: Crowstorm?":
 - Fiddlesticks
-'Which champion"s ultimate is named: Curse of the Sad Mummy?':
+"Which champion's ultimate is named: Curse of the Sad Mummy?":
 - Amumu
-'Which champion"s ultimate is named: Curtain Call?':
+"Which champion's ultimate is named: Curtain Call?":
 - Jhin
-'Which champion"s ultimate is named: Cyclone?':
+"Which champion's ultimate is named: Cyclone?":
 - Wukong
-'Which champion"s ultimate is named: Daisy!?':
+"Which champion's ultimate is named: Daisy!?":
 - Ivern
-'Which champion"s ultimate is named: Death Lotus?':
+"Which champion's ultimate is named: Death Lotus?":
 - Katarina
-'Which champion"s ultimate is named: Death Mark?':
+"Which champion's ultimate is named: Death Mark?":
 - Zed
-'Which champion"s ultimate is named: Demacian Justice?':
+"Which champion's ultimate is named: Demacian Justice?":
 - Garen
-'Which champion"s ultimate is named: Depth Charge?':
+"Which champion's ultimate is named: Depth Charge?":
 - Nautilus
-'Which champion"s ultimate is named: Destiny?':
+"Which champion's ultimate is named: Destiny?":
 - Twisted Fate
-'Which champion"s ultimate is named: Dominus?':
+"Which champion's ultimate is named: Dominus?":
 - Renekton
-'Which champion"s ultimate is named: Dragon"s Descent?':
+"Which champion's ultimate is named: Dragon's Descent?":
 - Shyvana
-'Which champion"s ultimate is named: Dragon"s Rage?':
+"Which champion's ultimate is named: Dragon's Rage?":
 - Lee Sin
 - leesin
-'Which champion"s ultimate is named: Emperor"s Divide?':
+"Which champion's ultimate is named: Emperor's Divide?":
 - Azir
-'Which champion"s ultimate is named: Enchanted Crystal Arrow?':
+"Which champion's ultimate is named: Enchanted Crystal Arrow?":
 - Ashe
-'Which champion"s ultimate is named: Eulogy of the Isles?':
+"Which champion's ultimate is named: Eulogy of the Isles?":
 - Yorick
-'Which champion"s ultimate is named: Explosive Cask?':
+"Which champion's ultimate is named: Explosive Cask?":
 - Gragas
-'Which champion"s ultimate is named: Fate"s Call?':
+"Which champion's ultimate is named: Fate's Call?":
 - Kalista
-'Which champion"s ultimate is named: Fear Beyond Death?':
+"Which champion's ultimate is named: Fear Beyond Death?":
 - Urgot
-'Which champion"s ultimate is named: Feast?':
-- Cho"gath
+"Which champion's ultimate is named: Feast?":
+- Cho'gath
 - cho gath
 - chogath
-'Which champion"s ultimate is named: Featherstorm?':
+"Which champion's ultimate is named: Featherstorm?":
 - Xayah
-'Which champion"s ultimate is named: Final Hour?':
+"Which champion's ultimate is named: Final Hour?":
 - Vayne
-'Which champion"s ultimate is named: Final Spark?':
+"Which champion's ultimate is named: Final Spark?":
 - Lux
-'Which champion"s ultimate is named: Frozen Tomb?':
+"Which champion's ultimate is named: Frozen Tomb?":
 - Lissandra
-'Which champion"s ultimate is named: Fury of the Sands?':
+"Which champion's ultimate is named: Fury of the Sands?":
 - Nasus
-'Which champion"s ultimate is named: GNAR!':
+"Which champion's ultimate is named: GNAR!":
 - Gnar
-'Which champion"s ultimate is named: Glacial Fissure?':
+"Which champion's ultimate is named: Glacial Fissure?":
 - Braum
-'Which champion"s ultimate is named: Glacial Prison?':
+"Which champion's ultimate is named: Glacial Prison?":
 - Sejuani
-'Which champion"s ultimate is named: Glacial Storm?':
+"Which champion's ultimate is named: Glacial Storm?":
 - Anivia
-'Which champion"s ultimate is named: Grand Challenge?':
+"Which champion's ultimate is named: Grand Challenge?":
 - Fiora
-'Which champion"s ultimate is named: Grand Skyfall?':
+"Which champion's ultimate is named: Grand Skyfall?":
 - Pantheon
-'Which champion"s ultimate is named: Grandmaster"s Might?':
+"Which champion's ultimate is named: Grandmaster's Might?":
 - Jax
-'Which champion"s ultimate is named: Hallucinate?':
+"Which champion's ultimate is named: Hallucinate?":
 - Shaco
-'Which champion"s ultimate is named: Hemoplague?':
+"Which champion's ultimate is named: Hemoplague?":
 - Vladimir
-'Which champion"s ultimate is named: Hero"s Entrance?':
+"Which champion's ultimate is named: Hero's Entrance?":
 - Galio
-'Which champion"s ultimate is named: Hextech Ultimatum?':
+"Which champion's ultimate is named: Hextech Ultimatum?":
 - Camille
-'Which champion"s ultimate is named: Highlander?':
+"Which champion's ultimate is named: Highlander?":
 - Master Yi
-'Which champion"s ultimate is named: Impale?':
+"Which champion's ultimate is named: Impale?":
 - Skarner
-'Which champion"s ultimate is named: Infinite Duress?':
+"Which champion's ultimate is named: Infinite Duress?":
 - Warwick
-'Which champion"s ultimate is named: Insanity Potion?':
+"Which champion's ultimate is named: Insanity Potion?":
 - Singed
-'Which champion"s ultimate is named: Intervention?':
+"Which champion's ultimate is named: Intervention?":
 - Kayle
-'Which champion"s ultimate is named: Keeper"s Verdict?':
+"Which champion's ultimate is named: Keeper's Verdict?":
 - Poppy
-'Which champion"s ultimate is named: Lamb"s Respite?':
+"Which champion's ultimate is named: Lamb's Respite?":
 - Kindred
-'Which champion"s ultimate is named: Last Breath?':
+"Which champion's ultimate is named: Last Breath?":
 - Yasuo
-'Which champion"s ultimate is named: Last Caress?':
+"Which champion's ultimate is named: Last Caress?":
 - Evelynn
-'Which champion"s ultimate is named: Leap of Faith?':
+"Which champion's ultimate is named: Leap of Faith?":
 - Illaoi
-'Which champion"s ultimate is named: Let"s Bounce!':
+"Which champion's ultimate is named: Let's Bounce!":
 - Zac
-'Which champion"s ultimate is named: Life Form Disintegration Ray?':
-- Vel"koz
+"Which champion's ultimate is named: Life Form Disintegration Ray?":
+- Vel'koz
 - vel koz
 - velkoz
-'Which champion"s ultimate is named: Living Artillery?':
-- Kog"maw
+"Which champion's ultimate is named: Living Artillery?":
+- Kog'maw
 - kogmaw
 - kog maw
-'Which champion"s ultimate is named: Lunar Rush?':
+"Which champion's ultimate is named: Lunar Rush?":
 - Diana
-'Which champion"s ultimate is named: Mantra?':
+"Which champion's ultimate is named: Mantra?":
 - Karma
-'Which champion"s ultimate is named: Massacre?':
+"Which champion's ultimate is named: Massacre?":
 - Aatrox
-'Which champion"s ultimate is named: Mega Inferno Bomb?':
+"Which champion's ultimate is named: Mega Inferno Bomb?":
 - Ziggs
-'Which champion"s ultimate is named: Mercury Cannon/Mercury Hammer?':
+"Which champion's ultimate is named: Mercury Cannon/Mercury Hammer?":
 - Jayce
-'Which champion"s ultimate is named: Mimic?':
+"Which champion's ultimate is named: Mimic?":
 - Leblanc
-'Which champion"s ultimate is named: Missile Barrage?':
+"Which champion's ultimate is named: Missile Barrage?":
 - Corki
-'Which champion"s ultimate is named: Monsoon?':
+"Which champion's ultimate is named: Monsoon?":
 - Janna
-'Which champion"s ultimate is named: Nether Grasp?':
+"Which champion's ultimate is named: Nether Grasp?":
 - Malzahar
-'Which champion"s ultimate is named: Noxian Guillotine?':
+"Which champion's ultimate is named: Noxian Guillotine?":
 - Darius
-'Which champion"s ultimate is named: Noxious Trap?':
+"Which champion's ultimate is named: Noxious Trap?":
 - Teemo
-'Which champion"s ultimate is named: On The Hunt?':
+"Which champion's ultimate is named: On The Hunt?":
 - Sivir
-'Which champion"s ultimate is named: Onslaught of Shadows?':
+"Which champion's ultimate is named: Onslaught of Shadows?":
 - Hecarim
-'Which champion"s ultimate is named: Paranoia?':
+"Which champion's ultimate is named: Paranoia?":
 - Nocturne
-'Which champion"s ultimate is named: Petrifying Gaze?':
+"Which champion's ultimate is named: Petrifying Gaze?":
 - Cassiopeia
-'Which champion"s ultimate is named: Pheonix Stance?':
+"Which champion's ultimate is named: Pheonix Stance?":
 - Udyr
-'Which champion"s ultimate is named: Primordial Burst?':
+"Which champion's ultimate is named: Primordial Burst?":
 - Veigar
-'Which champion"s ultimate is named: Pyroclasm?':
+"Which champion's ultimate is named: Pyroclasm?":
 - Brand
-'Which champion"s ultimate is named: Ragnarok?':
+"Which champion's ultimate is named: Ragnarok?":
 - Olaf
-'Which champion"s ultimate is named: Rat-Ta-Tat-Tat?':
+"Which champion's ultimate is named: Rat-Ta-Tat-Tat?":
 - Twitch
-'Which champion"s ultimate is named: Ravenous Flock?':
+"Which champion's ultimate is named: Ravenous Flock?":
 - Swain
-'Which champion"s ultimate is named: Realm Warp?':
+"Which champion's ultimate is named: Realm Warp?":
 - Ryze
-'Which champion"s ultimate is named: Requiem?':
+"Which champion's ultimate is named: Requiem?":
 - Karthus
-'Which champion"s ultimate is named: Riftwalk?':
+"Which champion's ultimate is named: Riftwalk?":
 - Kassadin
-'Which champion"s ultimate is named: Rite of the Arcane?':
+"Which champion's ultimate is named: Rite of the Arcane?":
 - Xerath
-'Which champion"s ultimate is named: Sadism?':
+"Which champion's ultimate is named: Sadism?":
 - Dr. Mundo
 - dr mundo
 - mundo
 - drmundo
-'Which champion"s ultimate is named: Shadow Assault?':
+"Which champion's ultimate is named: Shadow Assault?":
 - Talon
-'Which champion"s ultimate is named: Shadow Dance?':
+"Which champion's ultimate is named: Shadow Dance?":
 - Akali
-'Which champion"s ultimate is named: Slicing Maelstrom?':
+"Which champion's ultimate is named: Slicing Maelstrom?":
 - Kennen
-'Which champion"s ultimate is named: Solar Flare?':
+"Which champion's ultimate is named: Solar Flare?":
 - Leona
-'Which champion"s ultimate is named: Soul Shackles?':
+"Which champion's ultimate is named: Soul Shackles?":
 - Morgana
-'Which champion"s ultimate is named: Spider Form/Human Form?':
+"Which champion's ultimate is named: Spider Form/Human Form?":
 - Elise
-'Which champion"s ultimate is named: Spirit Rush?':
+"Which champion's ultimate is named: Spirit Rush?":
 - Ahri
-'Which champion"s ultimate is named: Stand United?':
+"Which champion's ultimate is named: Stand United?":
 - Shen
-'Which champion"s ultimate is named: Static Field?':
+"Which champion's ultimate is named: Static Field?":
 - Blitzcrank
-'Which champion"s ultimate is named: Stranglethorns?':
+"Which champion's ultimate is named: Stranglethorns?":
 - Zyra
-'Which champion"s ultimate is named: Subjugate?':
+"Which champion's ultimate is named: Subjugate?":
 - Trundle
-'Which champion"s ultimate is named: Summon: Tibbers?':
+"Which champion's ultimate is named: Summon: Tibbers?":
 - Annie
-'Which champion"s ultimate is named: Super Mega Death Rocket!':
+"Which champion's ultimate is named: Super Mega Death Rocket!":
 - Jinx
-'Which champion"s ultimate is named: Tempered Fate?':
+"Which champion's ultimate is named: Tempered Fate?":
 - Bard
-'Which champion"s ultimate is named: The Box?':
+"Which champion's ultimate is named: The Box?":
 - Thresh
-'Which champion"s ultimate is named: The Culling?':
+"Which champion's ultimate is named: The Culling?":
 - Lucian
-'Which champion"s ultimate is named: The Equalizer?':
+"Which champion's ultimate is named: The Equalizer?":
 - Rumble
-'Which champion"s ultimate is named: The Quickness?':
+"Which champion's ultimate is named: The Quickness?":
 - Rakan
-'Which champion"s ultimate is named: Thrill of the Hunt?':
+"Which champion's ultimate is named: Thrill of the Hunt?":
 - Rengar
-'Which champion"s ultimate is named: Thunder Claws?':
+"Which champion's ultimate is named: Thunder Claws?":
 - Volibear
-'Which champion"s ultimate is named: Tidal Wave?':
+"Which champion's ultimate is named: Tidal Wave?":
 - Nami
-'Which champion"s ultimate is named: Transcendent Blades?':
+"Which champion's ultimate is named: Transcendent Blades?":
 - Irelia
-'Which champion"s ultimate is named: Tremors?':
+"Which champion's ultimate is named: Tremors?":
 - Rammus
-'Which champion"s ultimate is named: Trueshot Barrage?':
+"Which champion's ultimate is named: Trueshot Barrage?":
 - Ezreal
-'Which champion"s ultimate is named: UPGRADE!!!':
+"Which champion's ultimate is named: UPGRADE!!!":
 - Heimerdinger
-'Which champion"s ultimate is named: Umbral Trespass?':
+"Which champion's ultimate is named: Umbral Trespass?":
 - Kayn
-'Which champion"s ultimate is named: Unbreakable Will?':
+"Which champion's ultimate is named: Unbreakable Will?":
 - Alistar
-'Which champion"s ultimate is named: Undying Rage?':
+"Which champion's ultimate is named: Undying Rage?":
 - Tryndamere
-'Which champion"s ultimate is named: Unleashed Power?':
+"Which champion's ultimate is named: Unleashed Power?":
 - Syndra
-'Which champion"s ultimate is named: Unstoppable Force?':
+"Which champion's ultimate is named: Unstoppable Force?":
 - Malphite
-'Which champion"s ultimate is named: Unstoppable Onslaught?':
+"Which champion's ultimate is named: Unstoppable Onslaught?":
 - Sion
-'Which champion"s ultimate is named: Vengeful Maelstrom?':
+"Which champion's ultimate is named: Vengeful Maelstrom?":
 - Maokai
-'Which champion"s ultimate is named: Voice of Light?':
+"Which champion's ultimate is named: Voice of Light?":
 - Aurelion Sol
 - aurelionsol
-'Which champion"s ultimate is named: Void Assault?':
-- Kha"zix
+"Which champion's ultimate is named: Void Assault?":
+- Kha'zix
 - khazix
 - kha zix
-'Which champion"s ultimate is named: Void Rush?':
-- Rek"sai
+"Which champion's ultimate is named: Void Rush?":
+- Rek'sai
 - rek sai
 - reksai
-'Which champion"s ultimate is named: Weaver"s Wall?':
+"Which champion's ultimate is named: Weaver's Wall?":
 - Taliyah
-'Which champion"s ultimate is named: Whirling Death?':
+"Which champion's ultimate is named: Whirling Death?":
 - Draven
-'Which champion"s ultimate is named: Wild Growth?':
+"Which champion's ultimate is named: Wild Growth?":
 - Lulu
-'Which champion"s ultimate is named: Wish?':
+"Which champion's ultimate is named: Wish?":
 - Soraka

--- a/redbot/trivia/lists/nba.yaml
+++ b/redbot/trivia/lists/nba.yaml
@@ -52,7 +52,7 @@ How many teams are in the NBA?:
 How many times did Michael Jordan win All-Star game MVP?:
 - 3
 - three
-How many times did Shaquille O"Neal win All-Star MVP?:
+How many times did Shaquille O'Neal win All-Star MVP?:
 - 1
 - one
 How many times has Kobe Bryant won All-Star MVP?:
@@ -237,7 +237,7 @@ What college did Nate Robinson go to?:
 What college did Richard Hamilton go to?:
 - University of Connecticut
 - Connecticut
-What college did Shaquille O"Neal go to?:
+What college did Shaquille O'Neal go to?:
 - Louisiana State University
 - LSU
 What college did Steve Francis go to?:
@@ -269,9 +269,9 @@ What franchise has the highest winning percentage in history?:
 What franchise has the most championships in NBA history?:
 - Boston Celtics
 - Celtics
-What is Kawhi Leonard"s career high points as of Jan 23, 2016?:
+What is Kawhi Leonard's career high points as of Jan 23, 2016?:
 - 41
-What is Vince Carter"s nickname?:
+What is Vince Carter's nickname?:
 - Vinsanity
 What is the first team to win a championship?:
 - Minneapolis Lakers
@@ -331,17 +331,17 @@ What team was Bill Walton on when he won MVP?:
 What team won a championship in 1989, 1990 and 2004?:
 - Detroit Pistons
 - Pistons
-What was Andre Kirilenko"s nickname?:
+What was Andre Kirilenko's nickname?:
 - AK-47
-What was Gary Payton"s nickname?:
+What was Gary Payton's nickname?:
 - The Glove
-What was Glen Davis" nickname?:
+What was Glen Davis' nickname?:
 - Big Baby
-What was Shawn Marion"s nickname?:
+What was Shawn Marion's nickname?:
 - The Matrix
-What was the Golden State Warrior"s record in the 2015-16 season?:
+What was the Golden State Warrior's record in the 2015-16 season?:
 - 73-9
-- '73:9'
+- "73:9"
 - 73 to 9
 What was the longest losing streak by a team in a regular season?:
 - 28
@@ -353,7 +353,7 @@ When did the Spurs retire number 21(MMDDYY)?:
 - December 18, 2015
 - 12/18/2015
 - 12182015
-"When was the Larry O\x92Brien trophy created?":
+When was the Larry O’Brien trophy created?:
 - 1977
 When was the most recent blow out in the NBA Finals?:
 - 2007
@@ -413,12 +413,12 @@ Who is the oldest player to be drafted?:
 Who is the oldest player to have 20+ assists in a game?:
 - Steve Nash
 Who is the oldest player to win MVP?:
-- Shaquille O"Neal
+- Shaquille O'Neal
 - Shaq
 Who is the only Canadian player that was selected in the 2016 NBA Draft?:
 - Jamal Murray
 Who is the only player other than Michael Jordan to win Finals MVP in 3 consecutive years?:
-- Shaquille O"Neal
+- Shaquille O'Neal
 - Shaq
 Who is the only player to Finals MVP as a rookie?:
 - Magic Johnson
@@ -465,15 +465,15 @@ Who is the youngest player to win All-Star MVP?LeBron James:
 - LeBron
 Who is the youngest player to win Finals MVP?:
 - Magic Johnson
-Who was known as "Agent Zero"?:
+Who was known as 'Agent Zero'?:
 - Gilbert Arenas
-Who was known as "The Answer"?:
+Who was known as 'The Answer'?:
 - Allen Iverson
-Who was known as "The Iceman"?:
+Who was known as 'The Iceman'?:
 - George Gervin
-Who was known as "The Mailman"?:
+Who was known as 'The Mailman'?:
 - Karl Malone
-Who was known as "The Worm"?:
+Who was known as 'The Worm'?:
 - Dennis Rodman
 Who was selected 12th overall by the Sacramento Kings in the 2016 NBA Draft?:
 - Georgios Papagiannis
@@ -500,7 +500,7 @@ Who won MVP in 1993?:
 Who won ROTY in 1987?:
 - Chuck Person
 Who won ROTY in 1993?:
-- "Shaquille O\x92Neal"
+- Shaquille O’Neal
 - Shaq
 Who won ROTY in 1998?:
 - Tim Duncan

--- a/redbot/trivia/lists/overwatch.yaml
+++ b/redbot/trivia/lists/overwatch.yaml
@@ -1,6 +1,6 @@
 Do omnics and humans live as equals in Numbani?:
-- 'Yes'
-During the ARG which company"s CEO did the hero want to "take down"?:
+- "Yes"
+During the ARG which company's CEO did the hero want to "take down"?:
 - Lumerico
 How many Heroes were available to play at launch?:
 - 21
@@ -19,8 +19,8 @@ How many competitive skill tiers are there?:
 How many glowing dots does Zenyatta have on his head?:
 - 9
 - nine
-How many seconds does Ana"s sleep dart last?:
-- '5.5'
+How many seconds does Ana's sleep dart last?:
+- "5.5"
 How much Total health does Ana have?:
 - 200
 How much Total health does Bastion have?:
@@ -53,7 +53,7 @@ How much Total health does Reinhardt have?:
 - 500
 How much Total health does Roadhog have?:
 - 600
-'How much Total health does Soldier: 76 have?':
+"How much Total health does Soldier: 76 have?":
 - 200
 How much Total health does Sombra have?:
 - 200
@@ -75,7 +75,7 @@ How much health does a large health pack heal?:
 - 250
 How much health does a small health pack heal?:
 - 75
-How much health per second does Zenyatta"s ultimate heal?:
+How much health per second does Zenyatta's ultimate heal?:
 - 300
 - three hundred
 How old is Ana?:
@@ -90,14 +90,14 @@ How old is Zenyatta?:
 In April of 2017, players could play a Historic Overwatch event. What was its name?:
 - Uprising
 - Omnic Uprising
-In Numbani where must the attacking team escort Doomfist"s gauntlet?:
+In Numbani where must the attacking team escort Doomfist's gauntlet?:
 - The Numbani Heritage Museum
 - Numbani Heritage Museum
-In the Beta, Junkrat"s ultimate was adapted from one designed for another character. Who was that?:
+In the Beta, Junkrat's ultimate was adapted from one designed for another character. Who was that?:
 - Bastion
-In the Summer Games, what is Mercy"s signature sport?:
+In the Summer Games, what is Mercy's signature sport?:
 - Badminton
-In the cinematic Infiltration which company"s CEO was going to be assassinated?:
+In the cinematic Infiltration which company's CEO was going to be assassinated?:
 - Volskaya Industries
 In the cinematic Infiltration who was secretly collaborated with the omnics?:
 - Katya Volskaya
@@ -112,7 +112,7 @@ In which country is Numbani?:
 In which month and year was Overwatch released?:
 - May 2016
 On what map is the attacking team tasked with escorting an EMP device?:
-- King"s Row
+- King's Row
 On which date did the Closed Beta for Overwatch start?:
 - 27 october
 - october 27
@@ -133,7 +133,7 @@ On which map was this screenshot taken? http://i.imgur.com/VFDOLXR.jpg:
 - Dorado
 On which map was this screenshot taken? http://i.imgur.com/XLgLEdh.jpg:
 - Kings Row
-- King"s Row
+- King's Row
 On which map was this screenshot taken? http://i.imgur.com/Yk8vqgn.jpg:
 - Hollywood
 On which map was this screenshot taken? http://i.imgur.com/YlMy2iE.jpg:
@@ -155,17 +155,17 @@ On which map was this screenshot taken? http://i.imgur.com/uMcjqeW.jpg:
 - Hollywood
 On which map was this screenshot taken? http://i.imgur.com/vxqkKQ0.jpg:
 - Kings Row
-- King"s Row
+- King's Row
 On which map was this screenshot taken? http://i.imgur.com/xuO8PDw.jpg:
 - Volskaya Industries
 - Volskaya
 Orignally when Overwatch was released players could choose to stack multiples of any hero on any team,it was later limited to 1 of each hero per team, and an arcade mode where heros tacking was again possble was added, what is this mode called?:
 - No Limits
 Over the design period for Overwatch, Bastion had several different ults before he got Tank mode how many including his current one did he have?:
-- '4: a mine, bouncing grenades, shooting though walls and tank mode'
+- "4: a mine, bouncing grenades, shooting though walls and tank mode"
 - 4
 The Overwatch short Alive, featuring Widowmaker and Tracer, was set on which map?:
-- King"s Row
+- King's Row
 - Kings Row
 The Overwatch short Dragons, featuring Genji and Hanzo, was set on which map?:
 - Hanamura
@@ -176,11 +176,11 @@ The Overwatch short Infiltration, featuring Sombra, Widomaker and Reaper, was se
 - Volskaya
 The Overwatch short Recall, featuring Winston and Reaper, was set on which map?:
 - Watchpoint Gibraltar
-- 'Watchpoint: Gibraltar'
+- "Watchpoint: Gibraltar"
 - Gibraltar
 The founding of Numbani is celebrated with which event?:
 - Unity Day
-What are Symmetra"s Ultimates called?:
+What are Symmetra's Ultimates called?:
 - Teleporter and Shield Generator
 - Teleporter & Shield Generator
 - Teleporter Shield Generator
@@ -211,245 +211,245 @@ What does D.Va say when she self destructs her mech?:
 What does D.Va say when she uses her ultimate?:
 - MEKA activated
 What does Lucio say when using his ultimate?:
-- Oh Let"s Break It Down
+- Oh Let's Break It Down
 - oh lets break it down
 What does Mercy say when using her ultimate?:
 - Heroes never die
 What does Pharah say when she uses her ultimate?:
 - Justice Rains From Above
 What does Tracer say when using her ultimate?:
-- Time"s up
+- Time's up
 - times up
 What game can be seen on the monitor in the security room of Hollywood?:
 - Hearthstone
-What is Ana"s Ultimate called?:
+What is Ana's Ultimate called?:
 - Nano Boost
-What is Ana"s full name:
+What is Ana's full name:
 - Ana Amari
-What is Bastion"s Ultimate called?:
-- 'Configuration: Tank'
+What is Bastion's Ultimate called?:
+- "Configuration: Tank"
 - Configuration:Tank
 - Configuration Tank
-What is Bastion"s full model ID?:
+What is Bastion's full model ID?:
 - SST Laboratories Siege Automaton E54
-What is D.VA"s real name?:
+What is D.VA's real name?:
 - Hana Song
-What is D.Va"s Ultimate called?:
+What is D.Va's Ultimate called?:
 - Self-Destruct
 - Self Destruct
-What is D.Va"s real name?:
+What is D.Va's real name?:
 - Hana Song
-What is Genji"s Ultimate called?:
+What is Genji's Ultimate called?:
 - Dragonblade
-What is Genji"s full name?:
+What is Genji's full name?:
 - Genji Shimada
-What is Hanzo"s Ultimate called?:
+What is Hanzo's Ultimate called?:
 - Dragonstrike
-What is Hanzo"s family name?:
+What is Hanzo's family name?:
 - Shimada
-What is Hanzo"s full name?:
+What is Hanzo's full name?:
 - Hanzo Shimada
-What is Junkrat"s Ultimate called?:
+What is Junkrat's Ultimate called?:
 - RIP-Tire
 - RIPtire
 - RIP Tire
-What is Junkrat"s real name?:
+What is Junkrat's real name?:
 - Jamison Fawkes
-What is Lucio"s "Cute Spray" achievement called?:
+What is Lucio's "Cute Spray" achievement called?:
 - Supersonic
-What is Lucio"s full name?:
+What is Lucio's full name?:
 - Lúcio Correia dos Santos
 - Lucio Correia dos Santos
-What is Lucio"s ultimate called?:
+What is Lucio's ultimate called?:
 - Sound Barrier
-What is Lúcio"s Ultimate called?:
+What is Lúcio's Ultimate called?:
 - Sound Barrier
-What is Lúcio"s full name?:
+What is Lúcio's full name?:
 - Lucio Correia dos Santos
-What is McCree"s Ultimate called?:
+What is McCree's Ultimate called?:
 - Deadeye
-What is McCree"s full name?:
+What is McCree's full name?:
 - Jesse McCree
-What is McCree"s ultimate called?:
+What is McCree's ultimate called?:
 - Deadeye
-What is Mei"s Ultimate called?:
+What is Mei's Ultimate called?:
 - Blizzard
-What is Mei"s full name?:
+What is Mei's full name?:
 - Mei-Ling Zhou
-What is Mei"s robot called?:
+What is Mei's robot called?:
 - Snowball
-What is Mercy"s Ultimate called?:
+What is Mercy's Ultimate called?:
 - Resurrect
-What is Mercy"s real name?:
+What is Mercy's real name?:
 - Angela Ziegler
-What is Orisa"s Ultimate called?:
+What is Orisa's Ultimate called?:
 - Supercharger
-What is Pharah"s Ultimate called?:
+What is Pharah's Ultimate called?:
 - Barrage
-What is Pharah"s real name?:
+What is Pharah's real name?:
 - Fareeha Amari
-What is Punch kid"s Name?:
+What is Punch kid's Name?:
 - Timmy
-What is Punch kid"s older brother"s name?:
+What is Punch kid's older brother's name?:
 - Brian
-What is Reaper"s Ultimate called?:
+What is Reaper's Ultimate called?:
 - Death Blossom
 What is Reapers ultimate called?:
 - Death Blossom
-What is Reinhardt"s Ultimate called?:
+What is Reinhardt's Ultimate called?:
 - Earthshatter
-What is Reinhardt"s full name?:
+What is Reinhardt's full name?:
 - Reinhardt Wilhelm
-What is Roadhog"s Ultimate called?:
+What is Roadhog's Ultimate called?:
 - Whole Hog
-What is Roadhog"s real name?:
+What is Roadhog's real name?:
 - Mako Rutledge
-'What is Soldier: 76"s Ultimate called?':
+"What is Soldier: 76's Ultimate called?":
 - Tactical Visor
-'What is Soldier: 76"s real name?':
+"What is Soldier: 76's real name?":
 - Jack Morrison
-What is Sombra"s Ultimate called?:
+What is Sombra's Ultimate called?:
 - EMP
-What is Sombra"s ultimate called?:
+What is Sombra's ultimate called?:
 - EMP
 What is Symmetra obssessed with?:
 - Order
-What is Symmetra"s real name?:
+What is Symmetra's real name?:
 - Satya Vaswani
-What is Torbjorn"s full name?:
+What is Torbjorn's full name?:
 - Torbjorn Lindholm
-What is Torbjorn"s ultimate called?:
+What is Torbjorn's ultimate called?:
 - Molten Core
-What is Torbjörn"s Ultimate called?:
+What is Torbjörn's Ultimate called?:
 - Molten Core
-What is Tracer"s Ultimate called?:
+What is Tracer's Ultimate called?:
 - Pulse Bomb
-What is Tracer"s real name?:
+What is Tracer's real name?:
 - Lena Oxton
-What is Widowmaker"s Ultimate called?:
+What is Widowmaker's Ultimate called?:
 - Infra-Sight
 - Infra Sight
 - InfraSight
-What is Widowmaker"s real name?:
+What is Widowmaker's real name?:
 - Amelie Lacroix
-What is Winston"s Ultimate called?:
+What is Winston's Ultimate called?:
 - Primal Rage
-What is Zarya"s Ultimate called?:
+What is Zarya's Ultimate called?:
 - Graviton Surge
-What is Zarya"s real name?:
+What is Zarya's real name?:
 - Aleksandra Zaryanova
-What is Zarya"s ultimate called?:
+What is Zarya's ultimate called?:
 - Graviton Surge
-What is Zenyatta"s Ultimate called?:
+What is Zenyatta's Ultimate called?:
 - Transcendence
-What is Zenyatta"s full name?:
+What is Zenyatta's full name?:
 - Tekharta Zenyatta
 What is a factory designed to manufacture Omnics called?:
 - Omnium
 What is the Undercover section of Overwatch called?:
 - Blackwatch
-What is the cooldown in seconds for Genji"s Dash?:
+What is the cooldown in seconds for Genji's Dash?:
 - 8
 - eight
-What is the cooldown in seconds for Hanzo"s Sonic Arrow?:
+What is the cooldown in seconds for Hanzo's Sonic Arrow?:
 - 20
 - twenty
-What is the cooldown in seconds for Mcree"s Roll?:
+What is the cooldown in seconds for Mcree's Roll?:
 - 8
 - eight
-What is the cooldown in seconds for Orisa"s Fortify?:
+What is the cooldown in seconds for Orisa's Fortify?:
 - 12
 - Twelve
 What is the cooldown in seconds for Reapers Shadow Step?:
 - 10
 - Ten
-What is the cooldown in seconds for Sombra"s Translocator?:
+What is the cooldown in seconds for Sombra's Translocator?:
 - 4
 - Four
-What is the cooldown in seconds for Tracer"s Recall?:
+What is the cooldown in seconds for Tracer's Recall?:
 - 12
 - twelve
 What is the highest competitive rank?:
 - Grandmaster
 What is the lowest competitive rank?:
 - Bronze
-What is the model name of D.Va"s mech?:
+What is the model name of D.Va's mech?:
 - MEKA
-What is the name of Ana"s "Pixel Spray" achivement?:
+What is the name of Ana's "Pixel Spray" achivement?:
 - Naptime
-What is the name of Ana"s default voice line?:
+What is the name of Ana's default voice line?:
 - Justice delivered
-What is the name of Ana"s ultimate?:
+What is the name of Ana's ultimate?:
 - Nano Boost
-What is the name of Bastion"s bird companion?:
+What is the name of Bastion's bird companion?:
 - Ganymede
-What is the name of Bastion"s bird?:
+What is the name of Bastion's bird?:
 - Ganymede
-What is the name of Bastion"s default voice line?:
+What is the name of Bastion's default voice line?:
 - Doo-woo
 - doowoo
 - doo woo
-What is the name of D.Va"s "Cute Spray" achievement?:
+What is the name of D.Va's "Cute Spray" achievement?:
 - Game over
-What is the name of D.Va"s default voice line?:
+What is the name of D.Va's default voice line?:
 - Love, D.Va
 - love d.va
-- ''
-What is the name of Genji"s default voice line?:
+- ""
+What is the name of Genji's default voice line?:
 - A Steady blade
-What is the name of Hanzo"s default voice line?:
+What is the name of Hanzo's default voice line?:
 - Expect nothing less
-What is the name of Junkrat"s default voice line?:
+What is the name of Junkrat's default voice line?:
 - tick-tock-tick-tock
 - tick tock tick tock
 - ticktockticktock
-What is the name of Lucio"s default voice line?:
+What is the name of Lucio's default voice line?:
 - To the rhythm
-What is the name of McCree"s default voice line?:
+What is the name of McCree's default voice line?:
 - Watch and learn
-What is the name of Mei"s default voice line?:
+What is the name of Mei's default voice line?:
 - Hang in there
-What is the name of Mercy"s default voice line?:
+What is the name of Mercy's default voice line?:
 - I have my eye on you
-What is the name of Pharah"s "Cute Spray" achievement?:
+What is the name of Pharah's "Cute Spray" achievement?:
 - Death From Above
-What is the name of Pharah"s default voice line?:
+What is the name of Pharah's default voice line?:
 - Security in my hands
-What is the name of Reaper"s default voice line?:
+What is the name of Reaper's default voice line?:
 - What are you looking at
-What is the name of Reinhardt"s default voice line?:
+What is the name of Reinhardt's default voice line?:
 - I salute you
-What is the name of Roadhog"s default voice line?:
+What is the name of Roadhog's default voice line?:
 - The apocalypse
-'What is the name of Soldier: 76"s default voice line?':
-- I"ve still got it
-'What is the name of Soldier: 76"s ultimate?':
+"What is the name of Soldier: 76's default voice line?":
+- I've still got it
+"What is the name of Soldier: 76's ultimate?":
 - Tactical Visor
-What is the name of Sombra"s default voice line?:
+What is the name of Sombra's default voice line?:
 - Playing fair
-What is the name of Symmetra"s default voice line?:
+What is the name of Symmetra's default voice line?:
 - Such a lack of imagination
-What is the name of Torbjorn"s default voice line?:
+What is the name of Torbjorn's default voice line?:
 - Hard work pays off
-What is the name of Tracer"s default voice line?:
+What is the name of Tracer's default voice line?:
 - You got it
-What is the name of Tracer"s ultimate?:
+What is the name of Tracer's ultimate?:
 - Pulse bomb
-What is the name of Widowmaker"s "Cute Spray" achievement?:
+What is the name of Widowmaker's "Cute Spray" achievement?:
 - Smooth as silk
-What is the name of Widowmaker"s default voice line?:
+What is the name of Widowmaker's default voice line?:
 - A single death
-What is the name of Winston"s default voice line?:
+What is the name of Winston's default voice line?:
 - Curious
-What is the name of Zarya"s default voice line?:
+What is the name of Zarya's default voice line?:
 - Strong as the mountain
-What is the name of Zenyatta"s default voice line?:
+What is the name of Zenyatta's default voice line?:
 - We are in harmony
 What is the name of the 4th web comic?:
 - A Better World
-What is the name of the 6th track on Lucio"s album?:
+What is the name of the 6th track on Lucio's album?:
 - Maximum Tempo
-What is the name of the Achievement that rewards Soldier 76"s "cute spray"?:
+What is the name of the Achievement that rewards Soldier 76's "cute spray"?:
 - Target Rich Environment
 What is the name of the Bastion skin gotten with the origins edition?:
 - Overgrown
@@ -477,7 +477,7 @@ What is the name of the omnic mercenary that appears in the comic "Mission State
 - Okoro
 What is the name of the rebel group Roadhog joined?:
 - Australian Liberation Front
-'What is the payload for Watchpoint: Gibraltar?':
+"What is the payload for Watchpoint: Gibraltar?":
 - A Satellite Drone
 - satellite drone
 What is the payload in Eichenwalde?:
@@ -486,17 +486,17 @@ What is the payload in Eichenwalde?:
 What name was given to the Halloween event in Overwatch?:
 - Halloween Terror
 What name was given to the Halloween themed Brawl, which featured waves of Zombie Omnics?:
-- Junkenstein"s Revenge
+- Junkenstein's Revenge
 - Junkensteins Revenge
-What was Lucio"s first album called?:
+What was Lucio's first album called?:
 - Synaesthesia Auditiva
-What was Tracer"s fighter jet called?:
+What was Tracer's fighter jet called?:
 - the Slipstream
 - slipstream
 What was Widowmaker afraid of as a girl?:
 - Spiders
 What was the first map the Overwatch team developed for the game?:
-- King"s Row
+- King's Row
 What was the first seasonal event in Overwatch called?:
 - The Summer Games
 - Summer Games
@@ -511,7 +511,7 @@ What was the name of the war between humans and omnics:
 - The Omnic Crisis
 What word is displayed during the Hollywood photo finish?:
 - Fin
-Where is LumériCo"s headquarters?:
+Where is LumériCo's headquarters?:
 - Dorado
 Where was McCree captured by Overwatch?:
 - Route 66
@@ -524,15 +524,15 @@ Which Overwatch hero used to be part of the "Deadlock Gang"?:
 - McCree
 Which character class has the most heroes?:
 - Offense
-Which character has the quote "What"s An Aimbot?"?:
+Which character has the quote "What's An Aimbot?"?:
 - Widowmaker
-Which character says "It"s high noon" when his/her ultimate is used?:
+Which character says "It's high noon" when his/her ultimate is used?:
 - McCree
-Which character"s ultimate has the highest DPS:
+Which character's ultimate has the highest DPS:
 - Roadhog
 Which country was the first to be affected by the Omnic Crisis?:
 - Russia
-'Which gang did Soldier: 76 fight in "Hero"?':
+"Which gang did Soldier: 76 fight in \"Hero\"?":
 - Los Muertos
 Which hero has a skin called "Breakaway"?:
 - Lucio
@@ -570,34 +570,34 @@ Which hero has the skin Augmented?:
 - Sombra
 Which hero has the skins Odette and Odile?:
 - Widowmaker
-Which hero has the voice line "You"re taking this very seriously."?:
+Which hero has the voice line "You're taking this very seriously."?:
 - Sombra
 Which hero has the voiceline "Young punks, get off my lawn"?:
 - Soldier 76
-Which hero is Ana"s daughter?:
+Which hero is Ana's daughter?:
 - Pharah
 Which hero is Reinhardt a fan of?:
 - D.Va
 Which hero is a fan of D.va?:
 - Lucio
-Which hero is a fan of Lucio"s music?:
+Which hero is a fan of Lucio's music?:
 - D.Va
-Which hero is a fan of Mei and reads "Mei"s Adventures"?:
+Which hero is a fan of Mei and reads "Mei's Adventures"?:
 - D.Va
-Which hero says "Haven"t I killed you somewhere before?":
+Which hero says "Haven't I killed you somewhere before?":
 - Reaper
 Which hero says "In Russia, Game Plays You"?:
 - Zarya
 Which hero says "Why Are You So Angry?":
 - Lucio
-Which hero"s release was hinted at via an ARG?:
+Which hero's release was hinted at via an ARG?:
 - Sombra
-Which hero"s ultimate is called "Barrage"?:
+Which hero's ultimate is called "Barrage"?:
 - Pharah
-Which hero"s ultimate is called "RIP-Tire"?:
+Which hero's ultimate is called "RIP-Tire"?:
 - Junkrat
-Which of these does the most damage? Genji"s shuriken, Winstons leap, Ana"s Rifle or Junkrats Grenade?:
-- Ana"s Rifle
+Which of these does the most damage? Genji's shuriken, Winstons leap, Ana's Rifle or Junkrats Grenade?:
+- Ana's Rifle
 - ana
 - rifle
 - anas rifle
@@ -637,7 +637,7 @@ Who helped Torbjorn design a prototype Biotic Rifle?:
 - Mercy
 Who helped Tracer with her chronal disassociation?:
 - Winston
-Who is Genji"s mentor?:
+Who is Genji's mentor?:
 - Zenyatta
 Who is considered "the most powerful woman in Russia"?:
 - Katya Volskaya
@@ -651,7 +651,7 @@ Who killed Mondatta?:
 - Widowmaker
 Who says "How Embarrassing!":
 - Winston
-Who says "I"m a one-man apocalypse"?:
+Who says "I'm a one-man apocalypse"?:
 - Roadhog
 Who was in charge of training Blackwatch agents?:
 - Reaper

--- a/redbot/trivia/lists/pokemon.yaml
+++ b/redbot/trivia/lists/pokemon.yaml
@@ -1,18 +1,18 @@
-'"A ball that is more effective as more turns are taken in battle." What kind of Pokéball is it?':
+"\"A ball that is more effective as more turns are taken in battle.\" What kind of PokÃ©ball is it?":
 - Timer ball
 - Timer
-'"A cozy ball that makes Pokémon more friendly." What Pokéball is this?':
+"\"A cozy ball that makes PokÃ©mon more friendly.\" What PokÃ©ball is this?":
 - Luxury ball
 - Luxury
-'"It can freely change its body"s color. The zigzag pattern on its belly doesn"t change, however." Who"s that Pokémon?':
+"\"It can freely change its body's color. The zigzag pattern on its belly doesn't change, however.\" Who's that PokÃ©mon?":
 - Kecleon
-'"It disguises itself as a tree to avoid attack. It hates water, so it will disappear if it starts raining." Who"s that Pokémon?':
+"\"It disguises itself as a tree to avoid attack. It hates water, so it will disappear if it starts raining.\" Who's that PokÃ©mon?":
 - Sudowoodo
-"\"It\"s found crawling on beaches and seafloors. The coral that grows on Corsola\x92s head is as good as a five-star banquet to this Pokémon.\" What pokémon is this?":
+"\"It's found crawling on beaches and seafloors. The coral that grows on Corsolaâ€™s head is as good as a five-star banquet to this PokÃ©mon.\" What pokÃ©mon is this?":
 - Mareanie
-'"This Pokémon is said to live in a world on the reverse side of ours, where common knowledge is distorted and strange." Who"s that Pokémon?':
+"\"This PokÃ©mon is said to live in a world on the reverse side of ours, where common knowledge is distorted and strange.\" Who's that PokÃ©mon?":
 - Giratina
-A glitch in Generation 1 allowed Pikachu or Eevee (Jolteon) to evolve after leveling up without an evolutionary stone, if what Pokémon finished the battle?:
+A glitch in Generation 1 allowed Pikachu or Eevee (Jolteon) to evolve after leveling up without an evolutionary stone, if what PokÃ©mon finished the battle?:
 - Growlithe
 Abilities were introduced in what generation?:
 - 3
@@ -21,21 +21,21 @@ As Rain is to water, Sandstorm is to ______?:
 - Rock
 Beast Balls have a catch rate multiplier of what when not used on an Ultra Beast?:
 - x0.1
-- '0.1'
+- "0.1"
 - 0.1x
 - 10%
 - 1/10
-Besides Ditto what other pokémon is capable of breeding, but cannot be obtained through breeding?:
+Besides Ditto what other pokÃ©mon is capable of breeding, but cannot be obtained through breeding?:
 - Manaphy
 Besides Fairy, what type can Hidden Power not become?:
 - Normal
 Besides Super Luck what ability increases your critical hit ratio?:
 - Merciless
-Can you name a Pokémon in the Tao Trio?:
+Can you name a PokÃ©mon in the Tao Trio?:
 - Reshiram
 - Zekrom
 - Kyurem
-Can you name one of Meloetta"s forms?:
+Can you name one of Meloetta's forms?:
 - Pirouette
 - Aria
 Cities in the Kanto Region take their name from what?:
@@ -53,7 +53,7 @@ Darmanitan gains what type in Zen Mode?:
 Dread, Earth, Pixie, Insect and Mind are all examples of what?:
 - Plates
 - Plate
-EP038 of the Pokémon anime was broadcasted once, then subsequently banned for reportedly causing what?:
+EP038 of the PokÃ©mon anime was broadcasted once, then subsequently banned for reportedly causing what?:
 - Epileptic Seizures
 - Seizures
 Eevee, Alomomola, and Girafarig are all what?:
@@ -63,20 +63,20 @@ Generation IV introduced Defog and what other HM?:
 - Rock Climb
 Guardian of Alola requires what item to use?:
 - Tapunium Z
-Happiness (friendship) is mainly needed to evolve what type of Pokémon?:
+Happiness (friendship) is mainly needed to evolve what type of PokÃ©mon?:
 - Baby Pokemon
 - Baby
 Happiny must be holding what to evolve?:
 - Oval Stone
-Hidden Power"s type is based off of a Pokémon"s what?:
+Hidden Power's type is based off of a PokÃ©mon's what?:
 - IV
 - IVS
 How do you evolve Clefairy?:
 - Moon Stone
 - Moon stone
-'How do you evolve Eevee into Umbreon in Pokémon XD: Gale of Darkness?':
+"How do you evolve Eevee into Umbreon in PokÃ©mon XD: Gale of Darkness?":
 - Moon Dust
-How many EV"s does a Iron, Zinc or Protein increase a stat by?:
+How many EV's does a Iron, Zinc or Protein increase a stat by?:
 - 10
 - ten
 How many HMs were in Generation 1?:
@@ -86,10 +86,10 @@ How many HMs were in Generation 1?:
 How many One Hit KO moves are there?:
 - 4
 - Four
-How many Pokémon are there in the national dex?:
+How many PokÃ©mon are there in the national dex?:
 - 802
 - eight hundred and two
-How many Pseudo-Legendary Pokémon are there?:
+How many Pseudo-Legendary PokÃ©mon are there?:
 - 8
 - Eight
 How many Rock-type Gym leaders are there in total (including all generations)?:
@@ -100,7 +100,7 @@ How many Unown forms are there?:
 How many boxes did you have in your PC in Generation 3?:
 - 14
 - fourteen
-How many different pokémon types are there?:
+How many different pokÃ©mon types are there?:
 - 18
 - Eighteen
 How many different types of Evolutionary Stones are there?:
@@ -109,13 +109,13 @@ How many different types of Evolutionary Stones are there?:
 How many evolutions does Eevee have?:
 - 8
 - Eight
-How many eyes do the Regi"s have?:
+How many eyes do the Regi's have?:
 - 7
 - Seven
 How many forms does Furfrou have?:
 - 10
 - Ten
-How many forms does Rotom have, excluding Pokédex Rotom?:
+How many forms does Rotom have, excluding PokÃ©dex Rotom?:
 - 7
 - seven
 How many forms does Vivillon have?:
@@ -124,13 +124,13 @@ How many forms does Vivillon have?:
 How many immunities does Normal/Ghost have?:
 - 3
 - three
-How many pokémon were introduced in Generation 1?:
+How many pokÃ©mon were introduced in Generation 1?:
 - 151
 - one hundred and fifty one
 How many resistances does Steel have?:
 - 10
 - Ten
-How many semi-pseudo Legendary Pokémon are there?:
+How many semi-pseudo Legendary PokÃ©mon are there?:
 - 7
 - seven
 How many spoons does Mega-Alakazam have?:
@@ -166,45 +166,45 @@ How much does a Choice Scarf increase your Speed by?:
 - 50%
 - half
 - fifty
-- '1.5'
+- "1.5"
 - 150%
 In Fire Red/Leaf Green, you encountered a legendary dog (Suicune, Raikou, Entei) based on your ________?:
-- Starter Pokémon
+- Starter PokÃ©mon
 - starter pokemon
 - starter
 In Generation 1, this move can be countered for infinite damage on the turn it breaks a Substitute. What is this move?:
 - Guillotine
 In Gold/Silver/Crystal/Heart Gold/Soul Silver, Team Rocket stole an item and hid it in the Cerulean City Gym. What is the name of this item?:
 - Machine Part
-In Ruby/Sapphire/Emerald Pokéblock feeders in the Safari Zone attract Pokémon based on their what?:
+In Ruby/Sapphire/Emerald PokÃ©block feeders in the Safari Zone attract PokÃ©mon based on their what?:
 - Nature
-In Ruby/Sapphire/Emerald you receieve an egg in Lavaridge town. Which Pokémon hatches from the egg?:
+In Ruby/Sapphire/Emerald you receieve an egg in Lavaridge town. Which PokÃ©mon hatches from the egg?:
 - Wynaut
 In what Generation did Flash become a TM?:
 - 4
 - IV
 - four
-International Police agent Anabel can be battled where in Pokémon Emerald?:
+International Police agent Anabel can be battled where in PokÃ©mon Emerald?:
 - Battle Tower
-Kyogre, Sharpedo and what other Pokémon have unique surfing sprites in Omega Ruby and Alpha Sapphire?:
+Kyogre, Sharpedo and what other PokÃ©mon have unique surfing sprites in Omega Ruby and Alpha Sapphire?:
 - Wailmer
-Mew, Celebi, Jirachi, Arceus, Keldeo, and Diancie are all examples of what kind of pokémon?:
+Mew, Celebi, Jirachi, Arceus, Keldeo, and Diancie are all examples of what kind of pokÃ©mon?:
 - Mythical pokemon
 - Mythical
-Most Professors in Pokémon games are named after what?:
+Most Professors in PokÃ©mon games are named after what?:
 - Trees
 - Tree
-Mow Rotom"s typing was originally Electric and what?:
+Mow Rotom's typing was originally Electric and what?:
 - Ghost
-Name a Ground move that can hit a Flying type Pokémon?:
+Name a Ground move that can hit a Flying type PokÃ©mon?:
 - Sand Attack
 - Thousand Arrows
-Name a Pokémon that has the ability Levitate and another ability?:
+Name a PokÃ©mon that has the ability Levitate and another ability?:
 - Bronzong
 - Bronzor
 - duskull
 - giratina
-Name a bug Pokémon that can learn Fly?:
+Name a bug PokÃ©mon that can learn Fly?:
 - Volcarona
 - Genesect
 Name a special attack priority move?:
@@ -220,9 +220,9 @@ Name one of the only two damaging moves whose animation plays out even if it has
 - selfdestruct
 Norman is the Gym Leader of which city?:
 - Petalburg
-'Of the following Pokémon, which one is NOT found in trophy garden in Diamond/Pearl/Platinum: Ditto, Chansey, Pikachu?':
+"Of the following PokÃ©mon, which one is NOT found in trophy garden in Diamond/Pearl/Platinum: Ditto, Chansey, Pikachu?":
 - Pikachu
-Parental Bond"s second hit is what percent of the first hit"s damage?:
+Parental Bond's second hit is what percent of the first hit's damage?:
 - 25%
 - quarter
 - 1/4
@@ -232,11 +232,11 @@ Pikashunium Z gives Pikachu what Z move?:
 - 10000000 volt thunderbolt
 - 10 million volt thunderbolt
 - 10MV thunderbolt
-Pokémon Generations featured a protagonist from every generation except VII and what?:
+PokÃ©mon Generations featured a protagonist from every generation except VII and what?:
 - IV
 - 4
 - four
-Pseudo-Legendary Pokémon require a base stat total of what?:
+Pseudo-Legendary PokÃ©mon require a base stat total of what?:
 - 600
 - six hundred
 RKS System will change your type if you are holding a what?:
@@ -245,7 +245,7 @@ RKS System will change your type if you are holding a what?:
 - memory disc
 Rayquaza must know what move in order to Mega evolve?:
 - Dragon Ascent
-Roark"s father is the Gym leader of what city?:
+Roark's father is the Gym leader of what city?:
 - Canalave city
 - canalave
 S.S. Aqua goes from Olivine City to where?:
@@ -254,16 +254,16 @@ S.S. Aqua goes from Olivine City to where?:
 Safari Balls have the same catch rate as which other ball?:
 - Great Ball
 - Greatball
-Sawsbuck"s forms are based off of what?:
+Sawsbuck's forms are based off of what?:
 - Seasons
 - season
 - the season
 - the seasons
-'Shadow Lugia in Pokémon XD: Gale of Darkness is also known as...?':
+"Shadow Lugia in PokÃ©mon XD: Gale of Darkness is also known as...?":
 - XD001
 Shelmet will only evolve if traded for a what?:
 - Karrablast
-Smogon is German for what pokémon?:
+Smogon is German for what pokÃ©mon?:
 - Koffing
 Snorlium Z upgrades which move?:
 - Giga Impact
@@ -281,23 +281,23 @@ The MissingNo. glitch in Red and Blue duplicates which item in your bag?:
 The Special/Physical split happened in what generation?:
 - 4
 - Four
-The Substitute doll was orignally based off of which Pokémon?:
+The Substitute doll was orignally based off of which PokÃ©mon?:
 - Rhydon
 The Unova Region is based off of what real life city?:
 - New York City
 - New York
 - NYC
-'The following Pokémon can be found in which city: Voltorb, Omanyte, Kangaskhan, Lapras?':
+"The following PokÃ©mon can be found in which city: Voltorb, Omanyte, Kangaskhan, Lapras?":
 - Fuchsia City
 - Fuchsia
-The grand prize for winning the lottery in Pokémon is what?:
+The grand prize for winning the lottery in PokÃ©mon is what?:
 - Master Ball
 - Masterball
 The individual base stats of all the Ultra Beasts are what?:
 - Prime Numbers
 - Prime
 - Primes
-This Gym leader specializes in what type of Pokémon http://imgur.com/a/hGp7I ?:
+This Gym leader specializes in what type of PokÃ©mon http://imgur.com/a/hGp7I ?:
 - Rock
 - rock type
 This Wormadam is Bug and what other type http://i.imgur.com/KN84zOV.png ?:
@@ -308,7 +308,7 @@ This is the symbol for what http://i.imgur.com/1kSfua0.png ?:
 To do the MissingNo. glitch in Gen 1, who must you talk to first?:
 - Old Man
 - Oldman
-To unlock the Regi"s caves you must have who in the front of your party?:
+To unlock the Regi's caves you must have who in the front of your party?:
 - Relicanth
 Was the Ghost type Special or Physical prior to Generation 4?:
 - Physical
@@ -324,7 +324,7 @@ What Egg Group does Ditto belong to?:
 - ditto group
 What Generation II item boosts Attack by 2 stages then confuses the holder?:
 - Berserk Gene
-What Generation first introduced shiny Pokémon?:
+What Generation first introduced shiny PokÃ©mon?:
 - 2
 - II
 - two
@@ -333,7 +333,7 @@ What Generation introduced Hidden Abilities?:
 - 5
 - five
 - black and white
-What Generation introduced the most new Pokémon?:
+What Generation introduced the most new PokÃ©mon?:
 - 5
 - Five
 - V
@@ -345,75 +345,75 @@ What Generation was Marill introduced in?:
 - 2
 - Two
 - II
-What Ground type Pokémon does Blue have as the champion in Generation I?:
+What Ground type PokÃ©mon does Blue have as the champion in Generation I?:
 - Rhydon
 What HM does Ash teach his Greninja in the anime?:
 - HM1
 - hm 1
 - Cut
 - 1
-What NPC Trainer has used the most unique Pokémon species in the series?:
+What NPC Trainer has used the most unique PokÃ©mon species in the series?:
 - N
-What NPC is noted as speaking "very fast", and has his text speed always set to fast?:
+What NPC is noted as speaking 'very fast', and has his text speed always set to fast?:
 - N
-What Pokémon can be bought for 9999 coins in Pokémon Red?:
+What PokÃ©mon can be bought for 9999 coins in PokÃ©mon Red?:
 - Porygon
-What Pokémon can evolve twice without leveling up?:
+What PokÃ©mon can evolve twice without leveling up?:
 - Porygon
-What Pokémon can learn every TM and HM?:
+What PokÃ©mon can learn every TM and HM?:
 - Mew
-What Pokémon does his guy want for his Talonflame http://imgur.com/a/L06JT ?:
+What PokÃ©mon does his guy want for his Talonflame http://imgur.com/a/L06JT ?:
 - Bewear
-What Pokémon does this guy give you http://imgur.com/a/4QGNl ?:
+What PokÃ©mon does this guy give you http://imgur.com/a/4QGNl ?:
 - Shuckle
-What Pokémon evolves at the highest level?:
+What PokÃ©mon evolves at the highest level?:
 - Zweilous
-What Pokémon evolves only in the rain?:
+What PokÃ©mon evolves only in the rain?:
 - Sliggoo
-What Pokémon game first introduced a playable female character?:
+What PokÃ©mon game first introduced a playable female character?:
 - Crystal
 - Pokemon Crystal
-What Pokémon has over a billion different sprites/models?:
+What PokÃ©mon has over a billion different sprites/models?:
 - Spinda
-What Pokémon has the lowest base stat total?:
+What PokÃ©mon has the lowest base stat total?:
 - Sunkern
-What Pokémon has the most forms?:
+What PokÃ©mon has the most forms?:
 - Unown
-What Pokémon has the most type immunities?:
+What PokÃ©mon has the most type immunities?:
 - Shedinja
-What Pokémon has the most unique TCG cards?:
+What PokÃ©mon has the most unique TCG cards?:
 - Unown
-What Pokémon is a boss in Subspace Emissary?:
+What PokÃ©mon is a boss in Subspace Emissary?:
 - Rayquaza
-What Pokémon is called the "Legendary Pokémon"?:
+What PokÃ©mon is called the 'Legendary PokÃ©mon'?:
 - Arcanine
-What Pokémon is codenamed UB-02 Beauty?:
+What PokÃ©mon is codenamed UB-02 Beauty?:
 - Pheromosa
-What Pokémon is fighting with Nidorino in the opening for Pokémon Blue and Red?:
+What PokÃ©mon is fighting with Nidorino in the opening for PokÃ©mon Blue and Red?:
 - Gengar
-What Pokémon is given to you here http://imgur.com/a/p2il2 ?:
+What PokÃ©mon is given to you here http://imgur.com/a/p2il2 ?:
 - Aerodactyl
-What Pokémon is known as "The Being of Knowledge"?:
+What PokÃ©mon is known as "The Being of Knowledge"?:
 - Uxie
-What Pokémon is known as the Trio Master of the Legendary Birds?:
+What PokÃ©mon is known as the Trio Master of the Legendary Birds?:
 - Lugia
-What Pokémon is the final ballon in Secret Super Training in Pokémon X or Y?:
+What PokÃ©mon is the final ballon in Secret Super Training in PokÃ©mon X or Y?:
 - Mega Aggron
 - Mega Tyranitar
 - Mega-Aggron
 - Mega-Tyranitar
-What Pokémon is the unofficial mother to Cubone and Marowak?:
+What PokÃ©mon is the unofficial mother to Cubone and Marowak?:
 - Kangaskhan
-What Pokémon is unique to this route(119) and can only be found by fishing http://imgur.com/a/8xj2G ?:
+What PokÃ©mon is unique to this route(119) and can only be found by fishing http://imgur.com/a/8xj2G ?:
 - Feebas
-What Pokémon is unique to this route(119) and can only be found in the grass http://imgur.com/a/8xj2G ?:
+What PokÃ©mon is unique to this route(119) and can only be found in the grass http://imgur.com/a/8xj2G ?:
 - Tropius
-What Pokémon requires you to turn your DS upside down to evolve?:
+What PokÃ©mon requires you to turn your DS upside down to evolve?:
 - Inkay
-What Pokémon that can evolve has the highest base stat total?:
+What PokÃ©mon that can evolve has the highest base stat total?:
 - Porygon2
 - Porygon 2
-What Pokémon type is the most common among legendary/mythical Pokémon?:
+What PokÃ©mon type is the most common among legendary/mythical PokÃ©mon?:
 - Psychic
 What Region is this http://i.imgur.com/1SDz8Vt.png ?:
 - Sinnoh
@@ -456,7 +456,7 @@ What berry reduces damage from Rock type attacks?:
 What city is this http://i.imgur.com/AGWh0QY.png ?:
 - Lilycove City
 - Lilycove
-What company makes the core-series Pokémon games?:
+What company makes the core-series PokÃ©mon games?:
 - GAME FREAK inc.
 - gamefreak inc.
 - gamefreak inc
@@ -480,7 +480,7 @@ What does IV stand for?:
 What does OU stand for?:
 - Overused
 - Over Used
-What does Pokémon stand for?:
+What does PokÃ©mon stand for?:
 - Pocket Monster
 What does TCG stand for?:
 - Trading Card Game
@@ -493,41 +493,41 @@ What does a Wide Lens boost?:
 - Accuracy
 What egg group do all babies belong to?:
 - Undiscovered
-What is Ash"s name in the Japanese anime?:
+What is Ash's name in the Japanese anime?:
 - Satoshi
-What is Blaine"s strongest Pokémon in Red/Blue/Yellow?:
+What is Blaine's strongest PokÃ©mon in Red/Blue/Yellow?:
 - Arcanine
-What is Blue"s starter Pokémon in Yellow Version?:
+What is Blue's starter PokÃ©mon in Yellow Version?:
 - Eevee
-What is Charjabug"s ability?:
+What is Charjabug's ability?:
 - Battery
-What is Exploud"s Hidden Ability?:
+What is Exploud's Hidden Ability?:
 - Scrappy
-What is Gary"s name in the Japanese anime?:
+What is Gary's name in the Japanese anime?:
 - Shigeru
-What is Giratina"s Hidden Ability?:
+What is Giratina's Hidden Ability?:
 - Telepathy
-What is Glalie"s Hidden Ability?:
+What is Glalie's Hidden Ability?:
 - Moody
-What is Heracross" Hidden Ability?:
+What is Heracross' Hidden Ability?:
 - Moxie
-What is Honchkrow"s Hidden Ability?:
+What is Honchkrow's Hidden Ability?:
 - Moxie
-What is Jirachi"s Signature Move?:
+What is Jirachi's Signature Move?:
 - Doom Desire
-What is Mewtwo"s birthday?:
+What is Mewtwo's birthday?:
 - February 6th
 - February 6
 - Feb 6th
 - Feb 6
 - 2/6
-What is Shuckle"s Hidden Ability?:
+What is Shuckle's Hidden Ability?:
 - Contrary
-What is Steven"s signature Pokémon as champion of Ruby/Sapphire?:
+What is Steven's signature PokÃ©mon as champion of Ruby/Sapphire?:
 - Metagross
 What is Super Effective against Poison besides Psychic and Ground in Generation 1?:
 - Bug
-What is a pseudo Legendary Pokémon that is NOT a dragon type?:
+What is a pseudo Legendary PokÃ©mon that is NOT a dragon type?:
 - Metagross or Tyranitar
 - Metagross
 - Tyranitar
@@ -542,7 +542,7 @@ What is the Hidden Ability of Durant?:
 - Traunt
 What is the base power of Explosion in generation 2-4 during damage calculation?:
 - 500
-What is the biggest Pokémon by height?:
+What is the biggest PokÃ©mon by height?:
 - Wailord
 What is the ferry called in Hoenn?:
 - S.S. Tidal
@@ -550,27 +550,27 @@ What is the ferry called in Hoenn?:
 What is the first badge of the Kanto Region?:
 - Boulder Badge
 - Boulder
-What is the first float in the Super Smash Bros. Melee stage Poké Floats?:
+What is the first float in the Super Smash Bros. Melee stage PokÃ© Floats?:
 - Squirtle
-What is the heaviest Pokémon?:
+What is the heaviest PokÃ©mon?:
 - Cosmoem
 - Celesteela
 What is the largest egg group?:
 - Field
 - Field Egg Group
-What is the last Pokémon in alphabetical order?:
+What is the last PokÃ©mon in alphabetical order?:
 - Zygarde
 What is the lowest Accuracy for any ghost move?:
 - 100%
 - 100
-What is the lowest level any Pokémon naturally evolves at?:
+What is the lowest level any PokÃ©mon naturally evolves at?:
 - 7
 - Seven
-What is the max IV a Pokémon can have in a stat?:
+What is the max IV a PokÃ©mon can have in a stat?:
 - 31
 What is the max happiness (friendship)?:
 - 255
-What is the max number of EVs a Pokémon can have?:
+What is the max number of EVs a PokÃ©mon can have?:
 - 510
 What is the most common ability that is exclusively a hidden ability?:
 - Rattled
@@ -578,19 +578,19 @@ What is the most common ability?:
 - Levitate
 What is the most common type?:
 - Water
-What is the most common typing across all fossil pokémon?:
+What is the most common typing across all fossil pokÃ©mon?:
 - Rock
 What is the most commonly gained type through Mega evolving?:
 - Dragon
-What is the name of Team Snagem"s leader?:
+What is the name of Team Snagem's leader?:
 - Gonzap
 What is the name of a gym leader who becomes an Elite Four member in the next generation?:
 - Koga or Iris
 - Koga
 - Iris
-What is the only Baby Pokémon with a branched evolution?:
+What is the only Baby PokÃ©mon with a branched evolution?:
 - Tyrogue
-What is the only Egg Group to contain a Pokémon of every type?:
+What is the only Egg Group to contain a PokÃ©mon of every type?:
 - Undiscovered Egg Group
 - Undiscovered
 - undiscovered group
@@ -606,31 +606,31 @@ What is the only HM with a unique type?:
 - Rock Smash
 What is the only Ice move with negative priority?:
 - Avalanche
-What is the only Pokémon exclusive Z-move that is a status move?:
+What is the only PokÃ©mon exclusive Z-move that is a status move?:
 - Extreme Evoboost
-What is the only Pokémon from Generation 6 that can Mega evolve?:
+What is the only PokÃ©mon from Generation 6 that can Mega evolve?:
 - Diancie
-What is the only Pokémon that learns Light of Ruin?:
+What is the only PokÃ©mon that learns Light of Ruin?:
 - Eternal Flower Floette
 - eternal floette
-What is the only Pokémon that recieved both a pre-evolution and evolution in the same generation?:
+What is the only PokÃ©mon that recieved both a pre-evolution and evolution in the same generation?:
 - Roselia
-What is the only Pokémon to have a lower base stat total than its pre-evolved form?:
+What is the only PokÃ©mon to have a lower base stat total than its pre-evolved form?:
 - Shedinja
-What is the only Pokémon to have more than one category?:
+What is the only PokÃ©mon to have more than one category?:
 - Hoopa
-What is the only Pokémon to lose the ability to breed upon evolving?:
+What is the only PokÃ©mon to lose the ability to breed upon evolving?:
 - Nidoran Female
 - female nidoran
 - f Nidoran
 - nidoran f
 - girl nidoran
 - nidoran girl
-What is the only Pokémon type to not yet have a Gym that specializes in it?:
+What is the only PokÃ©mon type to not yet have a Gym that specializes in it?:
 - Dark
-What is the only Pokémon whose branched evolutions both evolve further?:
+What is the only PokÃ©mon whose branched evolutions both evolve further?:
 - Wurmple
-What is the only Pokémon with the same base stat total as its pre-evolution?:
+What is the only PokÃ©mon with the same base stat total as its pre-evolution?:
 - Scizor
 What is the only ability that has 3 copies of it, but with different names?:
 - Mold Breaker
@@ -673,20 +673,20 @@ What is the only way Shaymin-Sky can revert back into Shaymin during a battle?:
 - Frozen
 - Freeze
 What is the priority of Extreme Speed?:
-- '+2'
+- "+2"
 - Two
 - 2
 What is the priority of Fake Out?:
-- '+3'
+- "+3"
 - Three
 - 3
 What is the priority of Protect?:
-- '+4'
+- "+4"
 - Four
 - 4
 What is the rarest mono typing?:
 - Flying
-What is the region in Pokémon Colosseum called?:
+What is the region in PokÃ©mon Colosseum called?:
 - Orre
 What is the signature move of Arceus?:
 - Judgment
@@ -701,16 +701,16 @@ What is the slowest move in the game?:
 What is the strongest Tier?:
 - Anything Goes
 - AG
-What item boosts binding move"s damage?:
+What item boosts binding move's damage?:
 - Binding Band
-What item boosts binding move"s turn length?:
+What item boosts binding move's turn length?:
 - Grip Claw
 - gripclaw
 What item do you need to evolve a Seadra?:
 - Dragon Scale
 - Dragonscale
 What item do you need to find Shaymin in Generation IV?:
-- Oak"s Letter
+- Oak's Letter
 - oaks letter
 - oak letter
 What item increases the amount of HP returned from HP-draining moves?:
@@ -721,7 +721,7 @@ What item is this http://i.imgur.com/0Hs5gwa.png ?:
 What item is this http://i.imgur.com/60CIAkJ.png ?:
 - Pokeblock Case
 What item is this http://i.imgur.com/ENr8xkN.png ?:
-- King"s Rock
+- King's Rock
 - Kings rock
 What item is this http://i.imgur.com/aE0K6WT.png ?:
 - Hyper Potion
@@ -754,7 +754,7 @@ What level does Cosmoem evolve?:
 - fiftythree
 What level does Wartortle evolve at?:
 - 36
-What move can be used outside of battle to heal your Pokémon?:
+What move can be used outside of battle to heal your PokÃ©mon?:
 - Soft-Boiled
 - Soft boiled
 - Softboiled
@@ -778,12 +778,12 @@ What must Gligar be holding to evolve?:
 - Razor Fang
 What must Sneasel be holding to evolve?:
 - Razor Claw
-What non-legendary Pokémon has the highest base attack?:
+What non-legendary PokÃ©mon has the highest base attack?:
 - Mega Heracross
-What pokémon has the ability Flower Gift?:
+What pokÃ©mon has the ability Flower Gift?:
 - Cherrim
 - Sunshine Cherrim
-What pokémon has the ability Fur Coat?:
+What pokÃ©mon has the ability Fur Coat?:
 - Furfrou
 - Persian Alola
 - alola persian
@@ -807,7 +807,7 @@ What stat does the ability Rattled raise upon activation?:
 What stone evolves a Floette?:
 - Shiny Stone
 - Shiny
-What suprising Pokémon can Skitty infamously breed with?:
+What suprising PokÃ©mon can Skitty infamously breed with?:
 - Wailord
 What town is Ash from?:
 - Pallet Town
@@ -841,32 +841,32 @@ What type is the rarest type?:
 What type is this card http://i.imgur.com/kmU1x27.jpg ?:
 - Colorless
 - colourless
-What type is this in Pokémon TCG http://i.imgur.com/N1qd6ra.png ?:
+What type is this in PokÃ©mon TCG http://i.imgur.com/N1qd6ra.png ?:
 - Dragon
-What type of Pokémon can always escape from trapping moves and abilities?:
+What type of PokÃ©mon can always escape from trapping moves and abilities?:
 - Ghost
 What type was added to Alolan Raichu?:
 - Psychic
-'What unreleased Pokémon was first featured in Pokémon: The First Movie - Mewtwo Strikes Back?':
+"What unreleased PokÃ©mon was first featured in PokÃ©mon: The First Movie - Mewtwo Strikes Back?":
 - Donphan
-What virus can Pokémon catch?:
+What virus can PokÃ©mon catch?:
 - Pokerus
-What was Blizzard"s accuracy in Generation 1?:
+What was Blizzard's accuracy in Generation 1?:
 - 90%
 - ninety
 - 90
-What was the first Pokémon created?:
+What was the first PokÃ©mon created?:
 - Rhydon
-What was the first game to include happiness (friendship) for Pokémon?:
+What was the first game to include happiness (friendship) for PokÃ©mon?:
 - Pokemon Yellow
 - Yellow
-What was the first pokémon to have gender differences?:
+What was the first pokÃ©mon to have gender differences?:
 - Nidoran
 What was the only Dragon type move in Generation 1?:
 - Dragon Rage
-What year was the first Pokémon game released?:
+What year was the first PokÃ©mon game released?:
 - 1996
-Where can Mewtwo be found in Pokémon Red and Blue?:
+Where can Mewtwo be found in PokÃ©mon Red and Blue?:
 - Cerulean Cave
 Where can Red be battled in Generation 2?:
 - Mt. Silver
@@ -876,19 +876,19 @@ Where do you find Groudon/Kyogre?:
 - origin cave
 Where is the only place to find a Liechi Berry in Hoenn?:
 - Mirage Island
-Which Baby Pokémon has the highest base stats total?:
+Which Baby PokÃ©mon has the highest base stats total?:
 - Munchlax
-Which Bug type Pokémon gains an additional typing upon Mega evolution?:
+Which Bug type PokÃ©mon gains an additional typing upon Mega evolution?:
 - Pinsir
-Which Generation 2 Pokémon has the lowest base Speed stat?:
+Which Generation 2 PokÃ©mon has the lowest base Speed stat?:
 - Shuckle
-Which Generation 4 Pokémon has the lowest base Speed stat?:
+Which Generation 4 PokÃ©mon has the lowest base Speed stat?:
 - Munchlax
-Which Generation 7 Pokémon has the lowest base Speed stat?:
+Which Generation 7 PokÃ©mon has the lowest base Speed stat?:
 - Pyukumuku
-Which Pokémon excluding Smeargle, can learn the most one-hit KO moves?:
+Which PokÃ©mon excluding Smeargle, can learn the most one-hit KO moves?:
 - Lapras
-Which Pokémon game(s) have multiple difficulty levels?:
+Which PokÃ©mon game(s) have multiple difficulty levels?:
 - Black and White 2
 - White and black 2
 - Black 2 and white 2
@@ -897,29 +897,29 @@ Which Pokémon game(s) have multiple difficulty levels?:
 - BW2
 - black white 2
 - white black 2
-Which Pokémon had the highest base Attack stat in Generation 1 and 2 (there are two, name one)?:
+Which PokÃ©mon had the highest base Attack stat in Generation 1 and 2 (there are two, name one)?:
 - Dragonite
 - Tyranitar
-Which Pokémon has the highest base HP of all Fire-type Pokémon?:
+Which PokÃ©mon has the highest base HP of all Fire-type PokÃ©mon?:
 - Entei
-Which Pokémon is found at Sky Pillar?:
+Which PokÃ©mon is found at Sky Pillar?:
 - Rayquaza
-Which Pokémon is the only Ground type Psuedo-Legendary?:
+Which PokÃ©mon is the only Ground type Psuedo-Legendary?:
 - Garchomp
-Which Pokémon is the only Semi-Pseudo Legendary from Kalos?:
+Which PokÃ©mon is the only Semi-Pseudo Legendary from Kalos?:
 - Noivern
-Which Pokémon joined Lucario as the second Steel and Fighting type?:
+Which PokÃ©mon joined Lucario as the second Steel and Fighting type?:
 - Cobalion
-Which Pokémon was originally intended to be the mascot (which is now Pikachu)?:
+Which PokÃ©mon was originally intended to be the mascot (which is now Pikachu)?:
 - Clefairy
 Which Psuedo-Legendary has more than one immunity?:
 - Hydreigon
 Which Psuedo-Legendary has the highest Special Defense stat?:
 - Goodra
-Which Psuedo-Legendary"s pre-evolution changes its type upon evolution to the final stage?:
+Which Psuedo-Legendary's pre-evolution changes its type upon evolution to the final stage?:
 - Dragonite
 - Tyranitar
-Which Shadow Pokémon was owned by Evice (final boss) in Pokémon Colosseum?:
+Which Shadow PokÃ©mon was owned by Evice (final boss) in PokÃ©mon Colosseum?:
 - Tyranitar
 Which game can you catch the most legendaries in?:
 - Omega Ruby and Alpha Sapphire
@@ -933,16 +933,16 @@ Which generation did not introduce any new fossils?:
 - 7
 - Seven
 Which of the following is not a real forme of Florges http://i.imgur.com/frZl8LY.png ?:
-- '#2'
+- "#2"
 - 2
 Which of the following is not a real forme of Vivillon http://i.imgur.com/pnOTZMS.png ?:
-- '#6'
+- "#6"
 - 6
-'Which one of the following is NOT defined as a baby pokémon: Budew, Riolu, Tyrogue, Chingling, Eevee, Togepi?':
+"Which one of the following is NOT defined as a baby pokÃ©mon: Budew, Riolu, Tyrogue, Chingling, Eevee, Togepi?":
 - Eevee
-Which starter from Generation II cannot be found in a Pokéball in Super Smash Bros. Melee?:
+Which starter from Generation II cannot be found in a PokÃ©ball in Super Smash Bros. Melee?:
 - Totodile
-Which starter type always comes first in the Pokédex?:
+Which starter type always comes first in the PokÃ©dex?:
 - Grass
 Who has the highest base HP stat?:
 - Blissey
@@ -959,13 +959,13 @@ Who has the highest base special defense stat?:
 Who has the highest base speed stat?:
 - Deoxys Speed
 - Deoxys S
-Who is the "God" pokémon?:
+Who is the 'God' pokÃ©mon?:
 - Arceus
 Who is the Elite Four Champion in Generation 1?:
 - Blue
 Who is the Elite Four Champion in Generation 2?:
 - Lance
-Who is the Elite Four member who makes an appearance in both Kanto"s and Johto"s Pokémon league as Elite Four only?:
+Who is the Elite Four member who makes an appearance in both Kanto's and Johto's PokÃ©mon league as Elite Four only?:
 - Bruno
 Who is the Gym leader of this Gym http://i.imgur.com/uAFrxDh.png ?:
 - Morty
@@ -977,9 +977,9 @@ Who is the antagonistic team in Generation 6?:
 - Flare
 Who is the champion of the Hoenn region in Ruby/Sapphire?:
 - Steven
-Who is the fastest non-legendary Pokémon?:
+Who is the fastest non-legendary PokÃ©mon?:
 - Ninjask
-Who is the first pokémon in the National Dex?:
+Who is the first pokÃ©mon in the National Dex?:
 - Bulbasaur
 Who is the leader of Team Rocket?:
 - Giovanni
@@ -988,51 +988,51 @@ Who is the only Flying type with Levitate?:
 - rotom fan
 - fan-rotom
 - rotom-fan
-Who is the only Generation 5 Mega Pokémon?:
+Who is the only Generation 5 Mega PokÃ©mon?:
 - Audino
-Who is the only Pokémon besides Ditto that learns Transform?:
+Who is the only PokÃ©mon besides Ditto that learns Transform?:
 - Mew
-Who is the only Pokémon that is a Fighting and Ice type?:
+Who is the only PokÃ©mon that is a Fighting and Ice type?:
 - Crabominable
-Who is the only Pokémon that is a Poison and Dragon type?:
+Who is the only PokÃ©mon that is a Poison and Dragon type?:
 - Dragalge
-'Who is the only Pokémon to have a Pokédex number of #000?':
+"Who is the only PokÃ©mon to have a PokÃ©dex number of #000?":
 - Victini
 - MissingNo.
-Who is the only legendary pokémon that can be either gender?:
+Who is the only legendary pokÃ©mon that can be either gender?:
 - Heatran
-Who is the tallest Steel Pokémon?:
+Who is the tallest Steel PokÃ©mon?:
 - Steelix
 Who is this http://i.imgur.com/yW5VlAy.png ?:
 - Ethan
 Who is tied with Mega Mewtwo X & Y with the highest base stat total?:
 - Mega Rayquaza
-Who runs and maintains the Pokémon Bank?:
+Who runs and maintains the PokÃ©mon Bank?:
 - Brigette
-Who uses the infamous catch phrase "Smell ya later"?:
+Who uses the infamous catch phrase 'Smell ya later'?:
 - Blue
-Who was the only Dragon type Pokémon introduced in Generation 2?:
+Who was the only Dragon type PokÃ©mon introduced in Generation 2?:
 - Kingdra
 Who won the Sun/Moon Nuzlocke challenge?:
 - Grant
 - Gearhead
 - gearhead7
-Who"s that Pokémon http://i.imgur.com/9r7j6vX.png ?:
+Who's that PokÃ©mon http://i.imgur.com/9r7j6vX.png ?:
 - Pikachu
-Who"s that Pokémon http://i.imgur.com/VdqNOJR.png ?:
+Who's that PokÃ©mon http://i.imgur.com/VdqNOJR.png ?:
 - Kingler
-Who"s that Trainer http://i.imgur.com/9aQmUCo.png ?:
+Who's that Trainer http://i.imgur.com/9aQmUCo.png ?:
 - Kris
-Who"s that Trainer http://i.imgur.com/BotTQX0.png ?:
+Who's that Trainer http://i.imgur.com/BotTQX0.png ?:
 - Hilbert
-Who"s that Trainer http://i.imgur.com/FHr6z9u.png ?:
+Who's that Trainer http://i.imgur.com/FHr6z9u.png ?:
 - Koga
-Who"s that Trainer http://i.imgur.com/XT9YYCA.png ?:
+Who's that Trainer http://i.imgur.com/XT9YYCA.png ?:
 - Whitney
-Whose Pokémon storage system (PC) are you using in Generation 3?:
+Whose PokÃ©mon storage system (PC) are you using in Generation 3?:
 - Lanette
 - Lanettes
-- Lanette"s
+- Lanette's
 Yo! Champ in the ______!?:
 - Making
 Z Bug move is called what?:
@@ -1044,7 +1044,7 @@ Z Ice move is called what?:
 Z weather moves raise what stat?:
 - Speed
 - Spe
-Zorua/Zorark"s illusion ability let"s the take the name and appearance of which Pokémon in your party?:
+Zorua/Zorark's illusion ability let's the take the name and appearance of which PokÃ©mon in your party?:
 - 6th
 - last
 - 6

--- a/redbot/trivia/lists/slogans.yaml
+++ b/redbot/trivia/lists/slogans.yaml
@@ -9,17 +9,17 @@ A better life, a better world:
 - Panasonic
 A diamond is forever.:
 - DeBeers
-All the news that"s fit to print.:
+All the news that's fit to print.:
 - The New York Times
 Allergy Tested. 100% Fragrance Free.:
 - Clinique
 Always there in a pinch.:
 - Skoal
-America"s most watched network:
+America's most watched network:
 - CBS
 American by Birth. Rebel by Choice.:
 - Harley Davidson
-Are you CN what we"re sayin":
+Are you CN what we're sayin':
 - Cartoon Network
 Army Strong:
 - US Army
@@ -33,8 +33,8 @@ Babies are our business.:
 - Gerber
 Be more:
 - PBS
-Because I"m worth it.:
-- L"Oreal
+Because I'm worth it.:
+- L'Oreal
 Because so much is riding on your tires.:
 - Michelin
 Behold the power of cheese.:
@@ -43,11 +43,11 @@ Believe in your Smellf.:
 - Old Spice
 Best Possible Start:
 - Fisher-Price
-Betcha Can"t Eat Just One:
-- Lay"s
+Betcha Can't Eat Just One:
+- Lay's
 - Lays
 Better Ingredients. Better Pizza.:
-- Papa John"s
+- Papa John's
 Better Matters:
 - Verizon
 Better by Adobe.:
@@ -61,14 +61,14 @@ Better to light a candle than curse the darkness.:
 Between love and madness lies obsession.:
 - Calvin Klein
 Break out of the ordinary.:
-- Nestle"s Butterfinger
+- Nestle's Butterfinger
 - Butterfinger
 Break through.:
 - Cadillac
 Breakfast of Champions:
 - Wheaties
 Bring out the best:
-- Hellmann"s
+- Hellmann's
 - Best Foods
 Bring your challenges:
 - Prudential Financial
@@ -94,17 +94,17 @@ Do more.:
 - American Express
 Do the Dew:
 - Mountain Dew
-Does she or doesn"t she?:
+Does she or doesn't she?:
 - Clairol
-Don"t be evil.:
+Don't be evil.:
 - Google
-Don"t get mad. Get Glad.:
+Don't get mad. Get Glad.:
 - The Glad Products Company
 - GLAD
-Don"t just travel. Travel right.:
+Don't just travel. Travel right.:
 - Expedia.com
 - expedia
-Don"t leave home without it.:
+Don't leave home without it.:
 - American Express
 Driving Matters.:
 - Mazda
@@ -113,7 +113,7 @@ Easy. Breezy. Beautiful.:
 Eat fresh.:
 - Subway
 Eat like you mean it.:
-- Carl"s Jr.
+- Carl's Jr.
 Eat more chikin:
 - Chick-fil-A
 - chickfila
@@ -139,9 +139,9 @@ Expert service. Unbeatable price.:
 Fair and balanced.:
 - Fox News
 Famously fresh.:
-- Planter"s Peanuts
-- Planter"s
-Finger Lickin" Good.:
+- Planter's Peanuts
+- Planter's
+Finger Lickin' Good.:
 - Kentucky Fried Chicken
 - KFC
 Flavor of Now:
@@ -161,8 +161,8 @@ For the person who has everything, we have everything else.:
 For virtually spotless dishes.:
 - Cascade
 Funny name. Serious sandwich.:
-- Schlotzky"s Deli
-- Schlotzky"s
+- Schlotzky's Deli
+- Schlotzky's
 Gear up for great:
 - Office Depot
 Get Your Own Box.:
@@ -187,12 +187,12 @@ Hello boys.:
 - Wonderbra
 I am what I am.:
 - Reebok
-I can"t believe I ate the whole thing.:
+I can't believe I ate the whole thing.:
 - Alka-Seltzer
-I"d walk a mile for a camel.:
+I'd walk a mile for a camel.:
 - Camel
-I"m Lovin" It.:
-- McDonald"s
+I'm Lovin' It.:
+- McDonald's
 - McDonalds
 Imagination at work.:
 - General Electric Company
@@ -202,8 +202,8 @@ Imagine it. Done.:
 - Unisys
 Impossible is nothing.:
 - Adidas
-In here, it"s always fridays.:
-- T.G.I. Friday"s
+In here, it's always fridays.:
+- T.G.I. Friday's
 - TGI Fridays
 - TGIFridays
 Ingredients for life.:
@@ -217,14 +217,14 @@ Invent.:
 - HP
 It takes a licking and keeps on ticking.:
 - Timex
-It"s a whole new neighborhood:
-- Applebee"s
-It"s good to talk:
+It's a whole new neighborhood:
+- Applebee's
+It's good to talk:
 - British Telecom
 - BT
-It"s in there.:
+It's in there.:
 - Prego
-It"s time for clarity.:
+It's time for clarity.:
 - KPMG
 Just Do It.:
 - Nike
@@ -244,13 +244,13 @@ Legendary reliability.:
 - APC
 Let your fingers do the walking.:
 - Yellow Pages
-Let"s go places:
+Let's go places:
 - Toyota
 License to Grill:
-- Chili"s
-Life"s Messy. Clean it Up.:
+- Chili's
+Life's Messy. Clean it Up.:
 - Bissell
-Life"s better when we"re connected.:
+Life's better when we're connected.:
 - Bank of America
 Like a rock.:
 - Chevy Trucks
@@ -261,7 +261,7 @@ Live in your world. Play in ours.:
 - PlayStation
 Live richly.:
 - Citi
-M"m! M"m! Good!:
+M'm! M'm! Good!:
 - Campbell Soup Company
 Made from the best stuff on Earth.:
 - Snapple
@@ -289,20 +289,20 @@ Must see TV:
 My life. My card.:
 - American Express
 Never Stop Improving:
-- Lowe"s
+- Lowe's
 Never follow.:
 - Audi
 No FT, no comment:
 - Financial Times
 No rules. Just right.:
 - Outback Steakhouse
-Nothin" says lovin" like somethin" from the oven.:
+Nothin' says lovin' like somethin' from the oven.:
 - Pillsbury
 Nothing runs like a Deere:
 - John Deere
-Now that"s better.:
-- Wendy"s
-Now that"s positive energy:
+Now that's better.:
+- Wendy's
+Now that's positive energy:
 - Energizer
 Obey your thirst:
 - Sprite
@@ -311,7 +311,7 @@ Open Happiness:
 Our business is the American dream.:
 - FannieMae
 Perfect.:
-- Reese"s
+- Reese's
 Pizza! Pizza!:
 - Little Caesars Pizza
 - Little Caesars
@@ -322,7 +322,7 @@ Pleasing people the world over.:
 Power, beauty and soul.:
 - Aston Martin
 Quality never goes out of style.:
-- Levi"s
+- Levi's
 Reach out and touch someone.:
 - AT&T
 Save Money. Live Better.:
@@ -336,7 +336,7 @@ See what we mean.:
 Share moments. Share life.:
 - Kodak
 Slicing up freshness.:
-- Arby"s
+- Arby's
 Slightly ahead of its time.:
 - Panasonic
 Snap! Crackle! Pop!:
@@ -351,7 +351,7 @@ Something to smile about.:
 - Quaker Oatmeal
 Stronger than dirt.:
 - Ajax
-Success. It"s a Mind Game.:
+Success. It's a Mind Game.:
 - Tag Heuer
 Take it all off.:
 - Noxzema
@@ -434,19 +434,19 @@ The ultimate driving machine.:
 - Bayerische Motoren Werke
 The uncola.:
 - 7-Up
-The world"s favorite airline:
+The world's favorite airline:
 - British Airways
-The world"s local bank:
+The world's local bank:
 - HSBC
-The world"s online marketplace.:
+The world's online marketplace.:
 - eBay
 There is no substitute.:
 - Porsche
-There"s no equal.:
-- Sweet "N Low
+There's no equal.:
+- Sweet 'N Low
 - sweet n low
-They"re g-r-r-r-eat!:
-- Kellog"s Frosted Flakes
+They're g-r-r-r-eat!:
+- Kellog's Frosted Flakes
 - Frosted Flakes
 Think Different:
 - Apple
@@ -471,11 +471,11 @@ Wake up and drive.:
 - Mitsubishi
 We answer to a higher authority.:
 - Hebrew National
-We didn"t invent the chicken. Just the chicken sandwich.:
+We didn't invent the chicken. Just the chicken sandwich.:
 - Chick-fil-A
 - chickfila
 We have the meats.:
-- Arby"s
+- Arby's
 We know money.:
 - AIG
 We live in financial times.:
@@ -489,15 +489,15 @@ We try harder.:
 - Avis
 We turn on ideas.:
 - Seagate
-We"re behind you every step of the way.:
+We're behind you every step of the way.:
 - Huggies
-We"re cooking now.:
-- Denny"s
-We"re moving beyond documents.:
+We're cooking now.:
+- Denny's
+We're moving beyond documents.:
 - Xerox
 What can Brown do for you?:
 - UPS
-What"s in your wallet?:
+What's in your wallet?:
 - Capital One
 When banks compete, you win.:
 - LendingTree
@@ -512,35 +512,35 @@ When you care enough to send the very best:
 When youre crazy for chicken.:
 - El Pollo Loco
 Where a kid can be a kid:
-- Chuck E. Cheese"s
+- Chuck E. Cheese's
 Where do you want to go today?:
 - Microsoft
-Where food"s the star:
-- Hardee"s
+Where food's the star:
+- Hardee's
 Where the pets go.:
 - Petco
-Where"s the cream filling?:
+Where's the cream filling?:
 - Hostess Cakes
 - Hostess
 Will you be ready?:
 - Cialis
 Works like a dream.:
 - Ambien
-World"s Greatest Hamburgers:
+World's Greatest Hamburgers:
 - Fuddruckers
 Yellow. The new Brown.:
 - DHL
 You can trust your car to the men who wear the star.:
 - Texaco
-You"ll love the way we fly.:
+You'll love the way we fly.:
 - Delta Airlines
 - Delta
-You"re in good hands with Allstate.:
+You're in good hands with Allstate.:
 - Allstate Insurance
 - Allstate
-You"re not you when you"re hungry.:
+You're not you when you're hungry.:
 - Snickers
-You"ve got questions, we"ve got answers.:
+You've got questions, we've got answers.:
 - Radio Shack
 Your vision. Our future.:
 - Olympus

--- a/redbot/trivia/lists/starwars.yaml
+++ b/redbot/trivia/lists/starwars.yaml
@@ -1,8 +1,8 @@
-According to C-3PO, Why wouldn"t Han recognize him in TFA?:
+According to C-3PO, Why wouldn't Han recognize him in TFA?:
 - Red Arm
 - The Red Arm
 Are Jedha and Scarif destroyed?:
-- 'No'
+- "No"
 Can you name the Rodian Bounty Hunter who confronts Han Solo about his overdue payment to Jabba?:
 - Greedo
 Can you name the company that manufactures the Z-6 Jetpack commonly associated with Mandalorian culture?:
@@ -11,21 +11,21 @@ Can you name the company that manufactures the Z-6 Jetpack commonly associated w
 Can you name the leader of the Onderon Resistance against the newly formed Empire at the conclusion of the Clone Wars?:
 - Saw Gerrera
 - Gerrera
-'Finish The Quote: Always 2 there are ______':
+"Finish The Quote: Always 2 there are ______":
 - a master and an apprentice
-'Finish The Quote: I find your lack of faith ____':
+"Finish The Quote: I find your lack of faith ____":
 - disturbing
-'Finish The Quote: I love you. ____.':
+"Finish The Quote: I love you. ____.":
 - I know
-'Finish The Quote: May the ___ be with you.':
+"Finish The Quote: May the ___ be with you.":
 - force
-'Finish The Quote: Not even the ___ survived.':
+"Finish The Quote: Not even the ___ survived.":
 - Younglings
-'Finish The Quote: This is how liberty dies___':
+"Finish The Quote: This is how liberty dies___":
 - with thunderous applause
-'Finish The Quote: Why, you stuck up, half-witted, scruffy-looking____':
+"Finish The Quote: Why, you stuck up, half-witted, scruffy-looking____":
 - Nerf herder
-'Finish The Quote: You underestimate my ___':
+"Finish The Quote: You underestimate my ___":
 - power
 How did Rogue One recreate Tarkin?:
 - CGI
@@ -96,28 +96,28 @@ In Legends canon what race is Grand Admiral Thrawn?:
 - Chiss
 In Legends canon who was the secret lover of Grand Moff Tarkin?:
 - Admiral Daala
-In The Force Awakens, what is Finn"s Stormtrooper ID?:
+In The Force Awakens, what is Finn's Stormtrooper ID?:
 - FN-2187
 Name the homeworld of the ancient Sith species?:
 - Moraband
 - Korriban
 The designation of the garbage compactor on the first Death Star where the Dianoga assaulted the escaping rebels was?:
 - 3263827
-The first article of the Resol"nare (Six Actions) of the Mandalorian Codex demands that warriors wear what?:
+The first article of the Resol'nare (Six Actions) of the Mandalorian Codex demands that warriors wear what?:
 - armor
 The name of the Imperial Officer that was choked by Darth Vader on the Death Star for his lack of faith was?:
 - General Cassio Tagge
 - Tagge
 - Cassio Tagge
-'True or False: Darth Vader was born on the same day as Luke and Leia.':
-- 'True'
-'True or False: George Lucas left a dragon skeleton in a Tunisian Desert':
-- 'True'
+"True or False: Darth Vader was born on the same day as Luke and Leia.":
+- "True"
+"True or False: George Lucas left a dragon skeleton in a Tunisian Desert":
+- "True"
 - T
-'True or False: Most of the Inquisitors were temple guards.':
-- 'True'
-'True or False: Tatooine was filmed in Tunisia.':
-- 'True'
+"True or False: Most of the Inquisitors were temple guards.":
+- "True"
+"True or False: Tatooine was filmed in Tunisia.":
+- "True"
 - T
 What City-Planet is the center of all politics in the Republic?:
 - Coruscant
@@ -142,7 +142,7 @@ What Troopers accompany Krennic?:
 What ability did Emperor Palpatine and Count Dooku have?:
 - Sith Lightning
 - Lightning
-What ancient Wookie hero is Chewbacca"s namesake?:
+What ancient Wookie hero is Chewbacca's namesake?:
 - Bacca
 What battle does Lando joke about his participation being a factor in securing the rank of General in the Alliance?:
 - Battle of Taanab
@@ -152,52 +152,52 @@ What clone died in the Droid Attack Of Kamino?:
 - ninety-nine
 - ninety nine
 - ninetynine
-What color are Asajj Ventress" lightsabers?:
+What color are Asajj Ventress' lightsabers?:
 - Red
-What color are Darth Maul"s lightsabers?:
+What color are Darth Maul's lightsabers?:
 - Red
 What color detailing did Captain Rex have on his uniform?:
 - Blue
-What color is Ahsoka Tano"s First Lightsaber?:
+What color is Ahsoka Tano's First Lightsaber?:
 - Green
-What color is Anakin Skywalker"s lightsaber?:
+What color is Anakin Skywalker's lightsaber?:
 - blue
-What color is Count Dooku"s Lightsaber?:
+What color is Count Dooku's Lightsaber?:
 - red
-What color is Darth Sidious" Lightsaber?:
+What color is Darth Sidious' Lightsaber?:
 - red
-What color is Darth Vader"s Lightsaber?:
+What color is Darth Vader's Lightsaber?:
 - red
-"What color is Ezraâ\x80\x99s Lightsaber?":
+What color is Ezraâ€™s Lightsaber?:
 - Blue
 - Geeen
-"What color is Ezraâ\x80\x99s new lightsaber in season 3?":
+What color is Ezraâ€™s new lightsaber in season 3?:
 - Green
-What color is Kid-Ad Mundi"s Lightsaber?:
+What color is Kid-Ad Mundi's Lightsaber?:
 - Blue
-What color is Kylo Ren"s lightsaber?:
+What color is Kylo Ren's lightsaber?:
 - Red
-What color is Luke Skywalker"s first lightsaber?:
+What color is Luke Skywalker's first lightsaber?:
 - blue
-What color is Luke Skywalker"s second lightsaber?:
+What color is Luke Skywalker's second lightsaber?:
 - green
 What color is Luminara Unduli Lightsaber?:
 - Green
-What color is Mace Windu"s Lightsaber?:
+What color is Mace Windu's Lightsaber?:
 - Purple
-What color is Obi-Wan"s Lightsaber?:
+What color is Obi-Wan's Lightsaber?:
 - Blue
-What color is Qui-Gon Jin"s lightsaber?:
+What color is Qui-Gon Jin's lightsaber?:
 - green
-What color is Rey"s lightsaber?:
+What color is Rey's lightsaber?:
 - blue
-What color is Yoda"s lightsaber?:
+What color is Yoda's lightsaber?:
 - green
 What color uniforms did First Generation clones wear?:
 - White
-What color were Ahsoka Tano"s Dual Lightsabers?:
+What color were Ahsoka Tano's Dual Lightsabers?:
 - White
-What color were uniforms did the Emperor"s royal guards wear?:
+What color were uniforms did the Emperor's royal guards wear?:
 - Red
 What command told the clones to capture the Chancellor?:
 - Order 65
@@ -223,7 +223,7 @@ What does Darth Vader disallow the assembled bounty hunters to do in their pursu
 - disintegrations
 What does Luke tell Uncle Owen he wants to pick up at Toche Station?:
 - power converters
-"What does Sabine find in Maulâ\x80\x99s home on dathomir?":
+What does Sabine find in Maulâ€™s home on dathomir?:
 - The Dark Saber
 - Dark Saber
 What force being shows itself in rebels season 3?:
@@ -231,12 +231,12 @@ What force being shows itself in rebels season 3?:
 - Bendu
 What forest moon is the second Death Star orbiting?:
 - Endor
-What is Captain Rex"s Clone number?:
+What is Captain Rex's Clone number?:
 - CT-7567
 - 7567
 - ct7567
 - ct 7567
-What is Emperor Palpatine"s sith name?:
+What is Emperor Palpatine's sith name?:
 - Darth Sidious
 - Sidious
 - Sid
@@ -257,20 +257,20 @@ What is the last name of the father-daughter pair who had a hand in the design o
 - Blissex
 What is the literal interpretation of the words TerÃ¤s KÃ¤si?:
 - steel hands
-What is the name of Anakin Skywalker"s Mother?:
+What is the name of Anakin Skywalker's Mother?:
 - Shmi Skywalker
 - Shmi
-What is the name of Anakin Skywalker"s astromech droid?:
+What is the name of Anakin Skywalker's astromech droid?:
 - R2-D2
 - R2d2
 - R2 D2
-What is the name of Boba Fett"s Ship?:
+What is the name of Boba Fett's Ship?:
 - Slave 1
-What is the name of Obi-Wan Kenobi"s Astromech droid?:
+What is the name of Obi-Wan Kenobi's Astromech droid?:
 - R4-P17
 - R4p17
 - R4 P17
-'What is the name of Star Wars: Episode VIII?':
+"What is the name of Star Wars: Episode VIII?":
 - The Last Jedi
 What is the name of the Anthology Film set to release in December of 2016?:
 - Rogue One
@@ -292,7 +292,7 @@ What is the name of the Leader of the Gungans?:
 - Nass
 What is the name of the blue bounty hunter in the first season of Clone Wars?:
 - Cad Bane
-What is the name of the cyborg in charge of Cloud City"s administrative functions during Lando Calrissian"s tenure as governor?:
+What is the name of the cyborg in charge of Cloud City's administrative functions during Lando Calrissian's tenure as governor?:
 - Lobot
 What is the name of the first (known) female stormtrooper?:
 - Captain Phasma
@@ -360,8 +360,8 @@ What planet was the Rebel Base on in "Return of the Jedi"?:
 What planet was the Rebel Base on in "The Empire Strikes Back"?:
 - Hoth
 What planet was the Resistance Base on in "The Force Awakens"?:
-- D"Quar
-What planet was the sight of Obi-Wan"s failure of Anakin?:
+- D'Quar
+What planet was the sight of Obi-Wan's failure of Anakin?:
 - Mustafar
 What race is Grand Admiral Thrawn?:
 - Chiss
@@ -388,17 +388,17 @@ What system was blown up by StarKiller Base?:
 What title did Cassian hold?:
 - Fulcrum
 What was 2187?:
-- Leia"s Cell
-What was Biggs Darklighter"s comm designation during the Battle of Yavin?:
+- Leia's Cell
+What was Biggs Darklighter's comm designation during the Battle of Yavin?:
 - Red Three
 - red 3
-What was Emperor Palpatine"s First name?:
+What was Emperor Palpatine's First name?:
 - Sheev
 What was Han Solo frozen in?:
 - Carbonite
-What was Jabba"s "pet"?:
+What was Jabba's "pet"?:
 - Rancor
-What was Luke Skywalker"s comm designation during the Battle of Yavin?:
+What was Luke Skywalker's comm designation during the Battle of Yavin?:
 - Red Five
 - red 5
 What was Rex in command of?:
@@ -423,18 +423,18 @@ What was the cartel family who ruled over Tatooine?:
 - Hutt Cartel
 What was the cloning planet in Episode II, Attack of the Clones?:
 - Kamino
-'What was the name of Anakin Skywalker"s Apprentice in Star Wars: The Clone Wars?':
+"What was the name of Anakin Skywalker's Apprentice in Star Wars: The Clone Wars?":
 - Ashoka
 - Ashoka Tano
-What was the name of Darth Vader"s flagship from the Battle of Hoth to the Battle of Endor?:
+What was the name of Darth Vader's flagship from the Battle of Hoth to the Battle of Endor?:
 - Executor
-'What was the name of General Grievous" Superweapon in Star Wars: The Clone Wars?':
+"What was the name of General Grievous' Superweapon in Star Wars: The Clone Wars?":
 - Malevolence
-What was the name of Jabba"s Right-Hand Man?:
+What was the name of Jabba's Right-Hand Man?:
 - Bib-Fortuna
 - Bib Fortuna
 - Fortuna
-'What was the name of the Bounty Hunter sent to the Jedi Temple to steal a holocron in Star Wars: The Clone Wars?':
+"What was the name of the Bounty Hunter sent to the Jedi Temple to steal a holocron in Star Wars: The Clone Wars?":
 - Cad Bane
 - Cad
 - Bane
@@ -451,9 +451,9 @@ What was the name of the Sith Assassin in The Clone Wars?:
 What was the name of the bar that Ben & Luke met Han Solo?:
 - Mos Eisley
 - Mos Eisley Cantina
-- Chalmun"s
-- Chalmun"s Cantina
-- Chalmun"s Spaceport Cantina
+- Chalmun's
+- Chalmun's Cantina
+- Chalmun's Spaceport Cantina
 What was the name of the male lead in Rogue One?:
 - Cassian
 What was the name of the protocol droid made by Anakin Skywalker?:
@@ -466,7 +466,7 @@ What was the original title of "Return of the Jedi"?:
 - Revenge of the Jedi
 What were the name of the mobile sphere-like droids that could pop up into a turret?:
 - Droidekas
-Where are C-3P0"s ears located?:
+Where are C-3P0's ears located?:
 - neck
 - his neck
 Where did 3/5ths of the Domino Squad die?:
@@ -496,7 +496,7 @@ Where was Arc Trooper Echo fatally injured and captured to be used against the R
 - The Citadel
 Where was Saw Gerrera hiding?:
 - Jedha
-'Where was the secret Jedi temple in Star Wars: Rebels?':
+"Where was the secret Jedi temple in Star Wars: Rebels?":
 - Lothal
 Where were the droid factories located in Episode II, Attack of the Clones?:
 - Geonosis
@@ -571,19 +571,19 @@ Who is Fulcrum in season 1 of rebels?:
 Who is Fulcrum in season 3 of rebels?:
 - Agent Kallus
 - Kallus
-"Who is Galen Ersoâ\x80\x99s Daughter?":
+Who is Galen Ersoâ€™s Daughter?:
 - Jyn Erso
 - Jyn
-Who is Hera Syndulla"s father?:
+Who is Hera Syndulla's father?:
 - Cham Syndulla
 - Cham
 Who is Jango Fett in relation to Jaster Mereel?:
 - adopted son
 - son
-Who is Kanan Jarrus" apprentice?:
+Who is Kanan Jarrus' apprentice?:
 - Ezra
 - Ezra Bridger
-Who is Kylo Ren"s Father?:
+Who is Kylo Ren's Father?:
 - Han Solo
 - Han
 - Solo
@@ -635,7 +635,7 @@ Who learned a path to immortality?:
 - Anakin
 - Vader
 - Darth Vader
-Who modernized the Resol"nare (Six Actions) of the Mandalorian Codex for modern use prior to the Clone Wars?:
+Who modernized the Resol'nare (Six Actions) of the Mandalorian Codex for modern use prior to the Clone Wars?:
 - Jaster Mereel
 - Mereel
 Who played Ben Kenobi?:
@@ -688,7 +688,7 @@ Who said "He was too dangerous to be kept alive"?:
 - The Emperor
 - Mace Windu
 - Windu
-Who said the line "It"s a Trap?":
+Who said the line "It's a Trap?":
 - Ackbar
 - Admiral Ackbar
 Who shot first?:
@@ -702,7 +702,7 @@ Who succeeds Admiral Ozzel as the Imperial fleet commander after the jump into t
 - Admiral Piet
 - Captain Piet
 - piet
-'Who voiced Darth Bane in Star Wars: The Clone Wars?':
+"Who voiced Darth Bane in Star Wars: The Clone Wars?":
 - Mark Hamill
 - Hamill
 Who voiced Darth Vader?:
@@ -710,20 +710,20 @@ Who voiced Darth Vader?:
 - Jones
 Who voiced Yoda and controlled the puppet yoda in the original trilogy?:
 - Frank Oz
-'Who voices Obi-Wan Kenobi in Star Wars: The Clone Wars?':
+"Who voices Obi-Wan Kenobi in Star Wars: The Clone Wars?":
 - James Arnold Taylor
 - James Taylor
 - Taylor
-Who was Count Dooku"s Original Master?:
+Who was Count Dooku's Original Master?:
 - Yoda
-Who was Darth Maul"s mother?:
+Who was Darth Maul's mother?:
 - Nightsister Talzin
 - Talzin
 - Mother Talzin
 Who was Darth Tyranus?:
 - Count Dooku
 - Dooku
-Who was Luke"s gunner during The Battle of Hoth?:
+Who was Luke's gunner during The Battle of Hoth?:
 - Dak Ralter
 - Dak
 Who was The Grand Inquisitor before he became an agent of the Sith?:
@@ -731,7 +731,7 @@ Who was The Grand Inquisitor before he became an agent of the Sith?:
 - temple guard
 Who was in charge of the death star before Tarkin?:
 - Krennic
-Who was supposed to take Dooku"s place as the sith lord?:
+Who was supposed to take Dooku's place as the sith lord?:
 - Jar Jar Binks
 - Binks
 - Jar Jar

--- a/redbot/trivia/lists/warcraft.yaml
+++ b/redbot/trivia/lists/warcraft.yaml
@@ -1,25 +1,25 @@
-'"I serve a new master now, mortals!" is yelled by which Firelands boss?':
+"\"I serve a new master now, mortals!\" is yelled by which Firelands boss?":
 - Alysrazor
-'"I think I made an angry poo poo. It gonna blow!" is a classic line from which Icecrown Citadel boss?':
+"\"I think I made an angry poo poo. It gonna blow!\" is a classic line from which Icecrown Citadel boss?":
 - Rotface
-'"I will freeze you from within until all that remains is an icy husk!" This is yelled by which boss in Icecrown Citadel?':
+"\"I will freeze you from within until all that remains is an icy husk!\" This is yelled by which boss in Icecrown Citadel?":
 - The Lich King
 - lich king
-'"You call on da beast, you gonna get more dan you bargain for!", is a quote by which shapeshifting boss?':
+"\"You call on da beast, you gonna get more dan you bargain for!\", is a quote by which shapeshifting boss?":
 - Nalorakk
-'...So Thousand Needles is flooded. During what campaign did that happen?':
+"...So Thousand Needles is flooded. During what campaign did that happen?":
 - Cataclysm
-'Achievement: Get killed by Deathwing.':
+"Achievement: Get killed by Deathwing.":
 - Stood in the Fire
-'Achievement: Kill 100,000 critters.':
+"Achievement: Kill 100,000 critters.":
 - Crittergeddon
-'Achievement: Obtain a vanity pet.':
+"Achievement: Obtain a vanity pet.":
 - Can I keep him
-'Achievement: There are even more critters in Pandaria. They also need /love. (To All the ________ I Once Caressed)':
+"Achievement: There are even more critters in Pandaria. They also need /love. (To All the ________ I Once Caressed)":
 - Squirrels
-'Achievement: Win a need roll on a superior or better item above item level 185 by rolling 100.':
+"Achievement: Win a need roll on a superior or better item above item level 185 by rolling 100.":
 - Needy
-After falling to Grommash"s blade, who did Gul"dan reanimate to serve the Burning Legion?:
+After falling to Grommash's blade, who did Gul'dan reanimate to serve the Burning Legion?:
 - Mannoroth
 Archaeology was the fourth of the core professions to be introduced. It was added during which expansion?:
 - Cataclysm
@@ -32,20 +32,20 @@ Arthas loved who?:
 - Lady Jaina Proudmoore
 - Jaina Proudmoore
 - Jaina
-Arthas"s death knights were trained in a floating citadel that was taken by force when many of them rebelled against the Lich King. What was the fortress"s name?:
+Arthas's death knights were trained in a floating citadel that was taken by force when many of them rebelled against the Lich King. What was the fortress's name?:
 - Acherus
 As a Moonkin spec, what Eclipse should you begin spamming Wrath?:
 - Solar Eclipse
 - Solar
 At level 46, what instance are you probably doing?:
-- Zul"Farrak
+- Zul'Farrak
 - zulfarrak
 Before serving the Lich King in undeath, Sapphiron served whom?:
 - Malygos
 Before she was raised from the dead by Arthas to serve the Scourge, Sindragosa was part of what dragonflight?:
 - Blue dragonflight
 - Blue
-Before the Well of Eternity was destroyed, Illidan filled seven vials with its water. One of these vials were acquired by Dath"Remar and used to create what?:
+Before the Well of Eternity was destroyed, Illidan filled seven vials with its water. One of these vials were acquired by Dath'Remar and used to create what?:
 - Sunwell
 - The Sunwell
 Before the original Horde formed, a highly contagious sickness began spreading rapidly among the orcs. What did the orcs call it?:
@@ -57,7 +57,7 @@ Brown is the default color for which class?:
 Crusader is a product of which profession?:
 - Enchanting
 Dalaran once rested in Silverpine Forest before being transported to Northrend, True or False?:
-- 'False'
+- "False"
 Dark Blue is the default color for which class?:
 - Shaman
 - Shamans
@@ -70,27 +70,27 @@ Discovering all zones award what title?:
 Eredun is the language of what race?:
 - eredar
 - demon
-Everyone put on your Onyxia Scale Cloaks! If you don"t, you could be afflicted by what?:
+Everyone put on your Onyxia Scale Cloaks! If you don't, you could be afflicted by what?:
 - Shadowflame
 Felwood is a level 45-50 zone, True or False?:
-- 'True'
+- "True"
 Finish this Ragnaros quote, "Too soon! You have awakened me too soon, ______!":
 - Executus
 Gaining exalted status with the Golden Lotus grant access to what mount?:
 - Riding Crane
 - Crane
-Gaining exalted status with the Kurenai & Mag"har grant access to what mount?:
+Gaining exalted status with the Kurenai & Mag'har grant access to what mount?:
 - Talbuk
-Gaining exalted status with the Sha"tari Skyguard grant access to what mount?:
+Gaining exalted status with the Sha'tari Skyguard grant access to what mount?:
 - Nether Ray
-Gul"dan raised what ancient city from the seafloor some years ago?:
+Gul'dan raised what ancient city from the seafloor some years ago?:
 - Suramar
 Hakkar the Houndmaster, Mannoroth the Destructor and Archimonde the Defiler fought together in what war?:
 - War of the Ancients
 High Priest Thekal dropped the Raptor Mount? (T/F):
-- 'False'
+- "False"
 - F
-How many fragments is Val"anyr broken into?:
+How many fragments is Val'anyr broken into?:
 - 30
 - thirty
 How many minions does the fourth boss of Molten Core, Garr, have?:
@@ -112,13 +112,13 @@ How many resources does a team need in Arathi Basin to win?:
 - sixteen hundred
 - one thousand six hundred
 - one thousand and six hundred
-If an item or piece of equipment is considered "epic", what color represents it?:
+If an item or piece of equipment is considered 'epic', what color represents it?:
 - Purple
 In "Mists of Pandaria", you can become what newly introduced class?:
 - Monk
 In lore, who was apprenticed to Medivh the prophet?:
 - Khadgar
-In the 25 man raid "The Eye" how many orbs did Kael"Thas have?:
+In the 25 man raid "The Eye" how many orbs did Kael'Thas have?:
 - 3
 - three
 In the Windrunner family there were 4 siblings, 3 sisters and 1 brother, name him.:
@@ -141,7 +141,7 @@ Leading the Cavalry is an achievement you get for collecting fifty mounts, but w
 - Albino Drake
 Mannoroth once took commands from an elf, what was the name of this elf?:
 - Azshara
-Med"an is half-human, quarter orc and quarter _______?:
+Med'an is half-human, quarter orc and quarter _______?:
 - Draenei
 Medivh (the last Guardian of Tirisfal) chooses to shapeshift into which form?:
 - Raven
@@ -152,12 +152,12 @@ Name one of the three young twilight drakes guarding twilight dragon eggs in the
 - Vesperon
 - Shadron
 Name one of the two leaders of the New Council of Tirisfal.:
-- Med"an
+- Med'an
 - Jaina Proudmoore
 - Jaina
 - med an
 - medan
-'Name that NPC: "I"m gonna light you up, sweet cheeks!"':
+"Name that NPC: \"I'm gonna light you up, sweet cheeks!\"":
 - Millhouse Manastorm
 - Millhouse
 - MillhouseManastorm
@@ -165,13 +165,13 @@ Name the artist or song that is the inspiration for the male goblin dance.:
 - Soulja boy
 - crank that
 Name the homeworld of the ethereals.:
-- K"aresh
+- K'aresh
 - K aresh
 - Karesh
 Name the leader of Darnassus.:
 - Tyrande
 Name the scrapped battleground from Classic WoW?:
-- Azshara"s Crater
+- Azshara's Crater
 - azshara
 - azshara crater
 Of what race were the naga before they mutated?:
@@ -188,16 +188,16 @@ Onyxia used to spy on  Stormwind in  the guise of a chief advisor. What did she 
 Originally the Draenei did not exist when the Burning Crusade was being thought up. What race was originally planned to be Alliance but eventually canned?:
 - Pandaren
 - Panda
-'Quote: All that you know will fade..':
+"Quote: All that you know will fade..":
 - Yogg-Saron
-- Yogg"saron
+- Yogg'saron
 - yoggsaron
 - yogg saron
-'Quote: Men, women and children... None were spared the master"s wrath. Your death will be no different.':
+"Quote: Men, women and children... None were spared the master's wrath. Your death will be no different.":
 - Falric
-'Quote: The final shred of light fades, and with it, your PITIFUL, MORTAL, EXISTENCE!':
+"Quote: The final shred of light fades, and with it, your PITIFUL, MORTAL, EXISTENCE!":
 - Ultraxion
-'Quote: We are the Forsaken. We will slaughter anyone who stands in our way.':
+"Quote: We are the Forsaken. We will slaughter anyone who stands in our way.":
 - Sylvanas Windrunner
 - Sylvanas
 Ragnaros is voiced by whom?:
@@ -217,46 +217,46 @@ The Death Knight class has its own special weapon enchanting ability called ____
 - Runeforging
 The First Aid profession starts you off making bandages of what material?:
 - Linen
-The Ironforge library features a replica of an unusually large ram"s skeleton. What was the name of this legendary ram?:
+The Ironforge library features a replica of an unusually large ram's skeleton. What was the name of this legendary ram?:
 - Toothgnasher
 The Last boss of Icecrown Citadels Scarlet Halls is named Princess...?:
-- Lana"thel
+- Lana'thel
 - Lana thel
 - Lanathel
 - lana-thel
 The Maelstrom is a product of what great event?:
 - Sundering
 - The Sundering
-The Prophet Skeram is the first boss of The Temple of Ahn"Qiraj, he has a single target attack that dishes out gobs of nature damage when he is not being tanked in melee range. What is it?:
+The Prophet Skeram is the first boss of The Temple of Ahn'Qiraj, he has a single target attack that dishes out gobs of nature damage when he is not being tanked in melee range. What is it?:
 - Earth Shock
 - earthshock
 The Sunreavers are a group of blood elves who represent the horde in Dalaran. They get their name from their leader Archmage ________Sunreaver?:
 - Aethas
-'The Tauren racial mount is the:':
+"The Tauren racial mount is the:":
 - Kodo
-'The achivement "And They Would All Go Down Together" reads: Defeat the 4 Horsemen in Naxxramas on Normal Difficulty, ensuring that they all die within __ seconds of each other.':
+"The achivement \"And They Would All Go Down Together\" reads: Defeat the 4 Horsemen in Naxxramas on Normal Difficulty, ensuring that they all die within __ seconds of each other.":
 - 15
 - fifteen
 The acronym GM refers to?:
 - Game Master
-The best arena players in season 11 were rewarded with what mount? (C________c Gladiator"s Twilight Drake):
+The best arena players in season 11 were rewarded with what mount? (C________c Gladiator's Twilight Drake):
 - Cataclysmic
 The curse of flesh was the cause behind the creation of the dwarves, True or False?:
-- 'True'
+- "True"
 The entrance to Blackwing Lair is found inside what instance?:
 - Upper Blackrock Spire
 The group Sons of Lothar got its name from what brave warrior?:
 - Anduin Lothar
-'The highly sought-after Tome of Polymorph: Turtle drops from what boss?':
-- Gahz"ranka
+"The highly sought-after Tome of Polymorph: Turtle drops from what boss?":
+- Gahz'ranka
 - gahz ranka
 - gahzranka
 - gahz-ranka
-The original death knights were created by Gul"dan for whom?:
+The original death knights were created by Gul'dan for whom?:
 - Orgrim Doomhammer
 The outlands faction in Nagrand that is allied with the Horde is called?:
-- The Mag"har
-- Mag"har
+- The Mag'har
+- Mag'har
 - mag har
 - maghar
 The races of the nerubians, qiraji and the mantid were once one people, they were the ____?:
@@ -286,36 +286,36 @@ To ride with 280% increased movement speed you need what riding proficiency?:
 - Artisan
 Tomb of Sargeras was previously a temple for whom?:
 - Elune
-'What Alliance race is missing: [Stoneform], [Escape Artist], [Shadowmeld], [Every Man for Himself], [Gift of the Naaru]...':
+"What Alliance race is missing: [Stoneform], [Escape Artist], [Shadowmeld], [Every Man for Himself], [Gift of the Naaru]...":
 - Worgen
 What Death Knight specialization have a permanent Ghoul pet?:
 - Unholy
-'What Horde race is missing: [Blood Fury], [Berserking], [Magic Resistance], [Touch of the Grave], [War Stomp]..."':
+"What Horde race is missing: [Blood Fury], [Berserking], [Magic Resistance], [Touch of the Grave], [War Stomp]...\"":
 - Goblin
 What are basic foot soldiers of the Horde called?:
 - Grunt
 What are orcish workers and gatherers called?:
 - Peon
-'What class specialization give access to the ability: Emancipate':
+"What class specialization give access to the ability: Emancipate":
 - Retribution
-'What class specialization give access to the ability: Flames of Xoroth':
+"What class specialization give access to the ability: Flames of Xoroth":
 - Destruction
-'What class specialization give access to the ability: Ironbark':
+"What class specialization give access to the ability: Ironbark":
 - Restoration
 - Resto
-'What class specialization give access to the ability: Overpower':
+"What class specialization give access to the ability: Overpower":
 - Arms
-'What class specialization give access to the ability: Premeditation':
+"What class specialization give access to the ability: Premeditation":
 - Subtlety
-What creature says "YOU NO TAKE CANDLE!"?:
+What creature says 'YOU NO TAKE CANDLE!'?:
 - Kobold
 What dance style is the inspiration for the female dwarf dance?:
 - The Riverdance
 - Riverdance
-What does [Bal"a dash] mean in Thalassian?:
+What does [Bal'a dash] mean in Thalassian?:
 - Greetings
 - hello
-What does [Lok"tar ogar] mean in Orcish?:
+What does [Lok'tar ogar] mean in Orcish?:
 - Victory or Death
 What does [Medivh] mean in Thalassian?:
 - Keeper of Secrets
@@ -332,10 +332,10 @@ What faction gives you a quest involving the almighty Booterang?:
 What famous addon announces boss abilities in raids?:
 - Deadly Boss Mods
 - DBM
-What is Lil Timmy"s title?:
+What is Lil Timmy's title?:
 - Boy with kittens
 - Kittens
-What is Rexxar"s father"s name?:
+What is Rexxar's father's name?:
 - Leoroxx
 What is the Arms Warrior artifact weapon?:
 - Stromkar
@@ -349,14 +349,14 @@ What is the Retribution Paladin artifact weapon?:
 - Ashbringer
 What is the Rogues main AOE ability called when a circle appears around them and small daggers fly outward from their body?:
 - Fan of Knives
-What is the approximate location of Newman"s Landing in Stormwind? (North,East,West,South):
+What is the approximate location of Newman's Landing in Stormwind? (North,East,West,South):
 - West
 - W
 What is the attempted World Tree in Northrend?:
 - Vordrassil
 What is the capital city of the Naga?:
 - Nazjatar
-What is the charismatic gnome Chromie"s real name?:
+What is the charismatic gnome Chromie's real name?:
 - Chronormu
 What is the highest level you can get to in "The Wrath of the Lich King"?:
 - 80
@@ -375,11 +375,11 @@ What is the mount Uncle Bigpocket sells for 120,000g called? (______ __________ 
 - Grand Expedition
 What is the mount called that drops from mythic Blackhand:
 - Ironhoof destroyer
-What is the name of Tirion Fordring"s gray stallion?:
+What is the name of Tirion Fordring's gray stallion?:
 - Mirador
-What is the name of the Innkeeper in Stormwind"s Trade District?:
+What is the name of the Innkeeper in Stormwind's Trade District?:
 - Allison
-What is the name of the Lich King"s sword?:
+What is the name of the Lich King's sword?:
 - Frostmourne
 What is the name of the Shaman Tier 1 set?:
 - Earthfury
@@ -420,23 +420,23 @@ What is the name of the song that is the inspiration for the female human dance?
 What is the name of the song that is the inspiration for the male pandaren dance?:
 - Party Rock Anthem
 - Party Rock
-What is the name of the staff Med"an used to defeat Cho"gall with?:
+What is the name of the staff Med'an used to defeat Cho'gall with?:
 - Atiesh
 What is the name of the thirteenth rank in the Horde PvP system?:
 - Warlord
 What is the name of the tribe that founded the nation Stromgarde?:
 - Arathi
 What is the original name given to the blood elves?:
-- Sin"dorei
+- Sin'dorei
 - sin dorei
 - sindorei
 What is the racial enemy of the tauren?:
 - Centaurs
-What is the tier 10 armor set that is designed for Death Knight"s?:
+What is the tier 10 armor set that is designed for Death Knight's?:
 - Scourgelord
-What is the tier 10 armor set that is designed for Paladin"s?:
+What is the tier 10 armor set that is designed for Paladin's?:
 - Lightsworn
-What is the tier 18 armor set that is designed for Rogue"s?:
+What is the tier 18 armor set that is designed for Rogue's?:
 - Felblade
 What is the tier 6 armor set designed for Warlocks?:
 - Malefic
@@ -455,15 +455,15 @@ What mount can Gretta the Arbiter award as a quest reward? (White ____ ____):
 - Polar Bear
 What mount can drop from Ultraxion in Dragon Soul? (________ 12-B):
 - Experiment
-What mount can drop from the Madness of Deathwing boss event in Dragon Soul? (Life-Binder"s ________):
+What mount can drop from the Madness of Deathwing boss event in Dragon Soul? (Life-Binder's ________):
 - Handmaiden
 What mount can drop in Sethekk Halls?:
 - Raven Lord
-'What mount is awarded by the achievement: [Glory of the Icecrown Raider (10)] (__________ Frostbrood Vanquisher)':
+"What mount is awarded by the achievement: [Glory of the Icecrown Raider (10)] (__________ Frostbrood Vanquisher)":
 - Bloodbathed
-'What mount is awarded by the achievement: [Guild Glory of the Cataclysm Raider]':
+"What mount is awarded by the achievement: [Guild Glory of the Cataclysm Raider]":
 - Dark Phoenix
-'What mount is awarded by the achievement: [Pandaren Ambassador]':
+"What mount is awarded by the achievement: [Pandaren Ambassador]":
 - Pandaren Kite
 - Kite
 What non-combat vanity pet is completely unattainable by Horde players?:
@@ -475,7 +475,7 @@ What profession is able to make Flask of Titans?:
 What profession uses the fish Oily Blackmouth?:
 - Alchemy
 What raid instance is located in Stranglethorn Vale?:
-- Zul"Gurub
+- Zul'Gurub
 - Zul Gurub
 - zulgurub
 - zul-gurub
@@ -485,7 +485,7 @@ What staff is also known as "the squidstick"?:
 - Terestians Stranglestaff
 - Stranglestaff
 - Terestian
-What tier 11 armor set is designed for Priest"s?:
+What tier 11 armor set is designed for Priest's?:
 - Mercuria
 What title does killing the Lich King on 25 Heroic give?:
 - The Light of Dawn
@@ -496,38 +496,38 @@ What type of weapon did Malfurion craft for Broxigar the Red?:
 - Axe
 What was Illidian Stormrage known as?:
 - The Betrayer
-What was teh name of Highlord Mograine"s sword?:
+What was teh name of Highlord Mograine's sword?:
 - Ashbringer
 What was the Black Temple called before it got taken by demons?:
 - Karabor
-What was the name of Ner"zhul"s late wife?:
+What was the name of Ner'zhul's late wife?:
 - Rulkan
 What was the name of the first troll Thrall met when he arrived on Kalimdor for the first time?:
-- Sen"jin
+- Sen'jin
 - Sen jin
 - senjin
-What was the original Hyjal Worlds Tree"s name?:
+What was the original Hyjal Worlds Tree's name?:
 - Nordrassil
 What world boss was walking around in Azshara?:
 - Azuregos
 What zone contains the settlement of Darkshire?:
 - Duskwood
-What"s the name of Thrall"s wolf companion?:
+What's the name of Thrall's wolf companion?:
 - Snowsong
-What"s the name of the mountain that borders Burning Steppes and Searing Gorge?:
+What's the name of the mountain that borders Burning Steppes and Searing Gorge?:
 - Blackrock
 When Deathwing was an aspect what was he the aspect of?:
 - Earth
-When Ner"zhul as the Lich King merged with Arthas, it all became clear, that Ner"zhul was ___:
+When Ner'zhul as the Lich King merged with Arthas, it all became clear, that Ner'zhul was ___:
 - Gay
 When a warlock summons their dreadsteed, which world does it come from?:
 - Xoroth
-When fishing in "World of Warcraft", you may come across an item called "The 1 Ring". What rarity type is this item?:
+When fishing in "World of Warcraft", you may come across an item called 'The 1 Ring'. What rarity type is this item?:
 - uncommon
 Where can Lucifron be fought?:
 - Molten Core
 Where do the Drakkari live?:
-- Zul"Drak
+- Zul'Drak
 - zul drak
 - zuldrak
 - zul-drak
@@ -535,15 +535,15 @@ Where is Coldridge Valley located?:
 - Dun Morogh
 Where is Karazhan?:
 - Deadwind Pass
-Where is it possible to get your "Sea Legs" and the ability to breathe under the sea?:
-- Vashj"ir
+Where is it possible to get your 'Sea Legs' and the ability to breathe under the sea?:
+- Vashj'ir
 - vashj ir
 - vashjir
 Where is the Cleft of Shadow located?:
 - Orgrimmar
-Where is the High Elven Quel"Lithien Lodge?:
+Where is the High Elven Quel'Lithien Lodge?:
 - Eastern Plaguelands
-Where is the ogre Chok"sul?:
+Where is the ogre Chok'sul?:
 - Loch Modan
 Where would you find Old Blanchy?:
 - Westfall
@@ -557,13 +557,13 @@ Which Elemental Lord was represented by water?:
 - Neptulon
 Which Molten Core boss has two hounds guarding him?:
 - Golemagg
-'Which Pit Lord says: "Illidan is an arrogant fool! I will crush him and reclaim Outland as my own!"?':
+"Which Pit Lord says: \"Illidan is an arrogant fool! I will crush him and reclaim Outland as my own!\"?":
 - Magtheridon
 Which Sha is located in the Shado-Pan Monastery?:
 - Hatred
 Which Vanilla boss yells "TASTE THE FLAMES OF SULFURON!"?:
 - Ragnaros
-Which boss at the start of the battle yells out, "New toys? For me? I promise I won"t break them this time"?:
+Which boss at the start of the battle yells out, "New toys? For me? I promise I won't break them this time"?:
 - XT-002 Deconstructor
 - xt002
 - deconstructor
@@ -575,7 +575,7 @@ Which boss requires your raid to bring along a fishing pole?:
 - The Lurker Below
 - The Lurker
 - Lurker Below
-'Which boss says: "The Menagerie is for guests only"?':
+"Which boss says: \"The Menagerie is for guests only\"?":
 - The Curator
 - Curator
 Which dungeon was featured in the Leeroy Jenkins video?:
@@ -587,25 +587,25 @@ Which expansion introduced Pet Battles?:
 - mop
 Which former bully now five man dungeon boss yells out "Blades of Light!"?:
 - Herod
-Which of Lady Gaga"s songs is the inspiration for the female worgen dance?:
+Which of Lady Gaga's songs is the inspiration for the female worgen dance?:
 - Pokerface
 Which of the following is the only raid in world of warcraft where you can play a game of  chess?:
 - Karazhan
 Which race crash landed into Azeroth?:
 - Draenei
-Which race has the racial ability "Aberration"?:
+Which race has the racial ability 'Aberration'?:
 - Worgen
-Which race has the racial ability "Command"?:
+Which race has the racial ability 'Command'?:
 - Orc
-Which race has the racial ability "Cultivation"?:
+Which race has the racial ability 'Cultivation'?:
 - Tauren
-Which race has the racial ability "Diplomacy"?:
+Which race has the racial ability 'Diplomacy'?:
 - Human
 Which race was the first mortal race on Azeroth?:
 - Trolls
 Which raid instance made an appearance in original WoW, and in the Wrath of the Lich King Expansion?:
 - Naxxramas
-Which titan blessed Alexstrasza"s younger sister Ysera, with a portion of nature"s influence?:
+Which titan blessed Alexstrasza's younger sister Ysera, with a portion of nature's influence?:
 - Eonar
 Who Did Illidan Fight In Order To Claim The Title Of Ruler of Outlands?:
 - Magtheridon
@@ -618,7 +618,7 @@ Who did Thrall name Orgrimmar after?:
 - doomhammer
 Who did the Titans imprison deep within Ulduar to save Azeroth?:
 - Yogg-Saron
-- Yogg"saron
+- Yogg'saron
 - yoggsaron
 - yogg saron
 Who is The king of Utgarde?:
@@ -630,7 +630,7 @@ Who is the King of Stormwind?:
 Who is the Mushan world boss in Pandaria?:
 - Galleon
 Who is the current leader of the Darkspear Troll tribe?:
-- Vol"jin
+- Vol'jin
 - Vol jin
 - voljin
 - vol-jin
@@ -649,17 +649,17 @@ Who is the first boss of Serpentshrine Caverns?:
 - Hydross
 Who is the first boss of Siege of Orgrimmar?:
 - Immerseus
-Who is the first boss of Temple of Ahn"Qiraj?:
+Who is the first boss of Temple of Ahn'Qiraj?:
 - Skeram
 Who is the last boss of Heart of Fear?:
-- Shek"zeer
+- Shek'zeer
 - shek zeer
 - shekzeer
 Who is the main leader of Darkmoon Faire?:
 - Silas Darkmoon
 Who is the major deity worshipped by the Night Elves?:
 - Elune
-Who is the partner of "Romulo" found in Karazhan?:
+Who is the partner of 'Romulo' found in Karazhan?:
 - Julianne
 Who is the storm watcher in the Vault of Archavon?:
 - Emalon
@@ -667,29 +667,29 @@ Who killed Cenarius in the Third War?:
 - Grom Hellscream
 - grom
 Who lost the Horde the Second War?:
-- Gul"dan
+- Gul'dan
 - Guldan
-Who says "FACE THE WRATH OF THE SOULFLAYER!"?:
+Who says 'FACE THE WRATH OF THE SOULFLAYER!'?:
 - Hakkar
-Who says "If the world is to live free from the tyranny of fear, they must never know what was done here today!"?:
+Who says 'If the world is to live free from the tyranny of fear, they must never know what was done here today!'?:
 - Bolvar Fordragon
 - Bolvar
-Who says "No, old friend. You"ve freed us all."?:
+Who says 'No, old friend. You've freed us all.'?:
 - Thrall
 Who sent Garrosh back in time?:
 - Kairoz
 Who was The Thunder King found in Throne of Thunder?:
 - Lei Shen
-Who was Varian Wrynn"s father?:
+Who was Varian Wrynn's father?:
 - King Llane
 - Llane
 Who was elected 25 000 years ago as chief lieutenant of Sargeras?:
-- Kil"Jaeden
+- Kil'Jaeden
 - kiljaeden
 - kil jaeden
 Who was the Dreadlord who enslaved Garithos?:
 - Detheroc
-Who was the Head Priestess of Elune before the War of the Ancients and Tyrande"s mentor?:
+Who was the Head Priestess of Elune before the War of the Ancients and Tyrande's mentor?:
 - Dejahna
 Who was the creator of the Burning Legion?:
 - Sargeras
@@ -700,31 +700,31 @@ Who was the first Warchief of the Horde?:
 Who was the first satyr to be created?:
 - Xavius
 Who was the former king of Azjol-Nerub?:
-- Anub"arak
+- Anub'arak
 - Anub arak
 - anubarak
 Who was the main leader of Cult of the Damned?:
-- Kel"Thuzad
+- Kel'Thuzad
 - Kel Thuzad
 - kelthuzad
-Who"s the oldest of the Windrunner sisters?:
+Who's the oldest of the Windrunner sisters?:
 - Alleria
-'Whos missing: Skywall, Firelands, Abyssal Maw...':
+"Whos missing: Skywall, Firelands, Abyssal Maw...":
 - Deepholm
 You were grinding in Western Plaguelands when you found Wildheart Bracers, which class would want this?:
 - Druid
-You"re now level 63 in Zangarmarsh, you find a Glowcap which you can collect off the ground, but you have no quest for it, where do you turn it in?:
+You're now level 63 in Zangarmarsh, you find a Glowcap which you can collect off the ground, but you have no quest for it, where do you turn it in?:
 - Sporeggars
-'[Draenor] means [Exile"s Refuge] in what language?':
+"[Draenor] means [Exile's Refuge] in what language?":
 - Draenei
-'[Mithril Spurs] can be made with what profession?':
+"[Mithril Spurs] can be made with what profession?":
 - Blacksmith
-'[Subdued Abyssal Seahorse] is awarded from what quest?':
+"[Subdued Abyssal Seahorse] is awarded from what quest?":
 - Abyssal Ride
 - The Abyssal Ride
-'[Un"Goro] means [God Lands] in what tongue?':
+"[Un'Goro] means [God Lands] in what tongue?":
 - Qiraji
 who is the Dragon ruler of the Blackrock Mountain?:
 - Nefarion
-who was formerly Jaina Proudmoore"s beloved, before he turned to the Scourge?:
+who was formerly Jaina Proudmoore's beloved, before he turned to the Scourge?:
 - Arthas

--- a/redbot/trivia/lists/whosthatpokemon.yaml
+++ b/redbot/trivia/lists/whosthatpokemon.yaml
@@ -1,302 +1,302 @@
-Who"s that pokemon? http://i.imgur.com/7tOA2x1.jpg:
-- Farfetch"d
-Who"s that pokemon? http://i.imgur.com/pMc81mO.jpg:
+Who's that pokemon? http://i.imgur.com/7tOA2x1.jpg:
+- Farfetch'd
+Who's that pokemon? http://i.imgur.com/pMc81mO.jpg:
 - Venusaur
-Who"s that pokemon? http://oi39.tinypic.com/10scfg3.jpg:
+Who's that pokemon? http://oi39.tinypic.com/10scfg3.jpg:
 - Ekans
-Who"s that pokemon? http://oi39.tinypic.com/10yncbn.jpg:
+Who's that pokemon? http://oi39.tinypic.com/10yncbn.jpg:
 - Ninetales
-Who"s that pokemon? http://oi39.tinypic.com/14k9npt.jpg:
+Who's that pokemon? http://oi39.tinypic.com/14k9npt.jpg:
 - Marowak
-Who"s that pokemon? http://oi39.tinypic.com/14mbekj.jpg:
+Who's that pokemon? http://oi39.tinypic.com/14mbekj.jpg:
 - Clefairy
-Who"s that pokemon? http://oi39.tinypic.com/15czi9y.jpg:
+Who's that pokemon? http://oi39.tinypic.com/15czi9y.jpg:
 - Butterfree
-Who"s that pokemon? http://oi39.tinypic.com/21j3x3p.jpg:
+Who's that pokemon? http://oi39.tinypic.com/21j3x3p.jpg:
 - Onix
-Who"s that pokemon? http://oi39.tinypic.com/21kzct3.jpg:
+Who's that pokemon? http://oi39.tinypic.com/21kzct3.jpg:
 - Tentacruel
-Who"s that pokemon? http://oi39.tinypic.com/2cbin5.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2cbin5.jpg:
 - Ditto
-Who"s that pokemon? http://oi39.tinypic.com/2ebdfg5.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2ebdfg5.jpg:
 - Hitmonchan
-Who"s that pokemon? http://oi39.tinypic.com/2hictnm.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2hictnm.jpg:
 - Nidorino
-Who"s that pokemon? http://oi39.tinypic.com/2i0aeu0.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2i0aeu0.jpg:
 - Caterpie
-Who"s that pokemon? http://oi39.tinypic.com/2ito5sw.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2ito5sw.jpg:
 - Rhyhorn
-Who"s that pokemon? http://oi39.tinypic.com/2lua0qv.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2lua0qv.jpg:
 - Mankey
-Who"s that pokemon? http://oi39.tinypic.com/2qt97om.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2qt97om.jpg:
 - Golduck
-Who"s that pokemon? http://oi39.tinypic.com/2r54xhw.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2r54xhw.jpg:
 - Nidoking
-Who"s that pokemon? http://oi39.tinypic.com/2wg7zpd.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2wg7zpd.jpg:
 - Dodrio
-Who"s that pokemon? http://oi39.tinypic.com/2zflb41.jpg:
+Who's that pokemon? http://oi39.tinypic.com/2zflb41.jpg:
 - Magnemite
-Who"s that pokemon? http://oi39.tinypic.com/33cupts.jpg:
+Who's that pokemon? http://oi39.tinypic.com/33cupts.jpg:
 - Wigglytuff
-Who"s that pokemon? http://oi39.tinypic.com/6nro84.jpg:
+Who's that pokemon? http://oi39.tinypic.com/6nro84.jpg:
 - Nidorina
-Who"s that pokemon? http://oi39.tinypic.com/ngo6fa.jpg:
+Who's that pokemon? http://oi39.tinypic.com/ngo6fa.jpg:
 - Cubone
-Who"s that pokemon? http://oi39.tinypic.com/qoyjh0.jpg:
+Who's that pokemon? http://oi39.tinypic.com/qoyjh0.jpg:
 - Magikarp
-Who"s that pokemon? http://oi39.tinypic.com/ws8tis.jpg:
+Who's that pokemon? http://oi39.tinypic.com/ws8tis.jpg:
 - Weezing
-Who"s that pokemon? http://oi40.tinypic.com/108i4uq.jpg:
+Who's that pokemon? http://oi40.tinypic.com/108i4uq.jpg:
 - Venonat
-Who"s that pokemon? http://oi40.tinypic.com/11114zk.jpg:
+Who's that pokemon? http://oi40.tinypic.com/11114zk.jpg:
 - Haunter
-Who"s that pokemon? http://oi40.tinypic.com/25jl91d.jpg:
+Who's that pokemon? http://oi40.tinypic.com/25jl91d.jpg:
 - Electrode
-Who"s that pokemon? http://oi40.tinypic.com/29vfknd.jpg:
+Who's that pokemon? http://oi40.tinypic.com/29vfknd.jpg:
 - Fearow
-Who"s that pokemon? http://oi40.tinypic.com/2b9qgp.jpg:
+Who's that pokemon? http://oi40.tinypic.com/2b9qgp.jpg:
 - Snorlax
-Who"s that pokemon? http://oi40.tinypic.com/2e5pkzn.jpg:
+Who's that pokemon? http://oi40.tinypic.com/2e5pkzn.jpg:
 - Jynx
-Who"s that pokemon? http://oi40.tinypic.com/2m4xfn4.jpg:
+Who's that pokemon? http://oi40.tinypic.com/2m4xfn4.jpg:
 - Alakazam
-Who"s that pokemon? http://oi40.tinypic.com/2mh7ccm.jpg:
+Who's that pokemon? http://oi40.tinypic.com/2mh7ccm.jpg:
 - Gyarados
-Who"s that pokemon? http://oi40.tinypic.com/2nbaukz.jpg:
+Who's that pokemon? http://oi40.tinypic.com/2nbaukz.jpg:
 - Flareon
-Who"s that pokemon? http://oi40.tinypic.com/2s7979l.jpg:
+Who's that pokemon? http://oi40.tinypic.com/2s7979l.jpg:
 - Bellsprout
-Who"s that pokemon? http://oi40.tinypic.com/2vdgugm.jpg:
+Who's that pokemon? http://oi40.tinypic.com/2vdgugm.jpg:
 - Slowpoke
-Who"s that pokemon? http://oi40.tinypic.com/2zel479.jpg:
+Who's that pokemon? http://oi40.tinypic.com/2zel479.jpg:
 - Articuno
-Who"s that pokemon? http://oi40.tinypic.com/30vklc9.jpg:
+Who's that pokemon? http://oi40.tinypic.com/30vklc9.jpg:
 - Charmeleon
-Who"s that pokemon? http://oi40.tinypic.com/34znmfd.jpg:
+Who's that pokemon? http://oi40.tinypic.com/34znmfd.jpg:
 - Charmander
-Who"s that pokemon? http://oi40.tinypic.com/35i96pw.jpg:
+Who's that pokemon? http://oi40.tinypic.com/35i96pw.jpg:
 - Arbok
-Who"s that pokemon? http://oi40.tinypic.com/ff26mv.jpg:
+Who's that pokemon? http://oi40.tinypic.com/ff26mv.jpg:
 - Vaporeon
-Who"s that pokemon? http://oi40.tinypic.com/fjlpwk.jpg:
+Who's that pokemon? http://oi40.tinypic.com/fjlpwk.jpg:
 - Wartortle
-Who"s that pokemon? http://oi40.tinypic.com/i36hb7.jpg:
+Who's that pokemon? http://oi40.tinypic.com/i36hb7.jpg:
 - Koffing
-Who"s that pokemon? http://oi40.tinypic.com/nwyply.jpg:
+Who's that pokemon? http://oi40.tinypic.com/nwyply.jpg:
 - Diglett
-Who"s that pokemon? http://oi40.tinypic.com/vdeh4p.jpg:
+Who's that pokemon? http://oi40.tinypic.com/vdeh4p.jpg:
 - Slowbro
-Who"s that pokemon? http://oi40.tinypic.com/vdhdh1.jpg:
+Who's that pokemon? http://oi40.tinypic.com/vdhdh1.jpg:
 - Eevee
-Who"s that pokemon? http://oi41.tinypic.com/119xq8l.jpg:
+Who's that pokemon? http://oi41.tinypic.com/119xq8l.jpg:
 - Kakuna
-Who"s that pokemon? http://oi41.tinypic.com/11t0nrc.jpg:
+Who's that pokemon? http://oi41.tinypic.com/11t0nrc.jpg:
 - Poliwag
-Who"s that pokemon? http://oi41.tinypic.com/148qdyu.jpg:
+Who's that pokemon? http://oi41.tinypic.com/148qdyu.jpg:
 - Psyduck
-Who"s that pokemon? http://oi41.tinypic.com/15drnfl.jpg:
+Who's that pokemon? http://oi41.tinypic.com/15drnfl.jpg:
 - Kabutops
-Who"s that pokemon? http://oi41.tinypic.com/1608uq8.jpg:
+Who's that pokemon? http://oi41.tinypic.com/1608uq8.jpg:
 - Muk
-Who"s that pokemon? http://oi41.tinypic.com/1q2xz9.jpg:
+Who's that pokemon? http://oi41.tinypic.com/1q2xz9.jpg:
 - Pidgeot
-Who"s that pokemon? http://oi41.tinypic.com/20foxso.jpg:
+Who's that pokemon? http://oi41.tinypic.com/20foxso.jpg:
 - Charizard
-Who"s that pokemon? http://oi41.tinypic.com/21biqkw.jpg:
+Who's that pokemon? http://oi41.tinypic.com/21biqkw.jpg:
 - Staryu
-Who"s that pokemon? http://oi41.tinypic.com/21o7nr9.jpg:
+Who's that pokemon? http://oi41.tinypic.com/21o7nr9.jpg:
 - Bulbasaur
-Who"s that pokemon? http://oi41.tinypic.com/244cqw0.jpg:
+Who's that pokemon? http://oi41.tinypic.com/244cqw0.jpg:
 - Electabuzz
-Who"s that pokemon? http://oi41.tinypic.com/280jji1.jpg:
+Who's that pokemon? http://oi41.tinypic.com/280jji1.jpg:
 - Tentacool
-Who"s that pokemon? http://oi41.tinypic.com/28kpvkw.jpg:
+Who's that pokemon? http://oi41.tinypic.com/28kpvkw.jpg:
 - Aerodactyl
-Who"s that pokemon? http://oi41.tinypic.com/29olkyg.jpg:
+Who's that pokemon? http://oi41.tinypic.com/29olkyg.jpg:
 - Growlithe
-Who"s that pokemon? http://oi41.tinypic.com/2gtymfs.jpg:
+Who's that pokemon? http://oi41.tinypic.com/2gtymfs.jpg:
 - Ivysaur
-Who"s that pokemon? http://oi41.tinypic.com/2upftvo.jpg:
+Who's that pokemon? http://oi41.tinypic.com/2upftvo.jpg:
 - Nidoran
-Who"s that pokemon? http://oi41.tinypic.com/2uxv2ja.jpg:
+Who's that pokemon? http://oi41.tinypic.com/2uxv2ja.jpg:
 - Mewtwo
-Who"s that pokemon? http://oi41.tinypic.com/2yvklzr.jpg:
+Who's that pokemon? http://oi41.tinypic.com/2yvklzr.jpg:
 - Moltres
-Who"s that pokemon? http://oi41.tinypic.com/2zpt7q8.jpg:
+Who's that pokemon? http://oi41.tinypic.com/2zpt7q8.jpg:
 - Krabby
-Who"s that pokemon? http://oi41.tinypic.com/2zxw0sy.jpg:
+Who's that pokemon? http://oi41.tinypic.com/2zxw0sy.jpg:
 - Chansey
-Who"s that pokemon? http://oi41.tinypic.com/33nf7lc.jpg:
+Who's that pokemon? http://oi41.tinypic.com/33nf7lc.jpg:
 - Lickitung
-Who"s that pokemon? http://oi41.tinypic.com/6jmv0g.jpg:
+Who's that pokemon? http://oi41.tinypic.com/6jmv0g.jpg:
 - Grimer
-Who"s that pokemon? http://oi41.tinypic.com/a4r0k9.jpg:
+Who's that pokemon? http://oi41.tinypic.com/a4r0k9.jpg:
 - Jolteon
-Who"s that pokemon? http://oi41.tinypic.com/ajxvdu.jpg:
+Who's that pokemon? http://oi41.tinypic.com/ajxvdu.jpg:
 - Goldeen
-Who"s that pokemon? http://oi41.tinypic.com/avl850.jpg:
+Who's that pokemon? http://oi41.tinypic.com/avl850.jpg:
 - Spearow
-Who"s that pokemon? http://oi41.tinypic.com/f44hhl.jpg:
+Who's that pokemon? http://oi41.tinypic.com/f44hhl.jpg:
 - Venomoth
-Who"s that pokemon? http://oi41.tinypic.com/fe1729.jpg:
+Who's that pokemon? http://oi41.tinypic.com/fe1729.jpg:
 - Rhydon
-Who"s that pokemon? http://oi41.tinypic.com/ic0f12.jpg:
+Who's that pokemon? http://oi41.tinypic.com/ic0f12.jpg:
 - Vulpix
-Who"s that pokemon? http://oi41.tinypic.com/k2jyvo.jpg:
+Who's that pokemon? http://oi41.tinypic.com/k2jyvo.jpg:
 - Lapras
-Who"s that pokemon? http://oi41.tinypic.com/m9na5l.jpg:
+Who's that pokemon? http://oi41.tinypic.com/m9na5l.jpg:
 - Exeggcute
-Who"s that pokemon? http://oi41.tinypic.com/qs9qw5.jpg:
+Who's that pokemon? http://oi41.tinypic.com/qs9qw5.jpg:
 - Raichu
-Who"s that pokemon? http://oi41.tinypic.com/s49u8h.jpg:
+Who's that pokemon? http://oi41.tinypic.com/s49u8h.jpg:
 - Dragonair
-Who"s that pokemon? http://oi41.tinypic.com/v5y39d.jpg:
+Who's that pokemon? http://oi41.tinypic.com/v5y39d.jpg:
 - Golbat
-Who"s that pokemon? http://oi41.tinypic.com/x51g5l.jpg:
+Who's that pokemon? http://oi41.tinypic.com/x51g5l.jpg:
 - Tauros
-Who"s that pokemon? http://oi41.tinypic.com/zksb52.jpg:
+Who's that pokemon? http://oi41.tinypic.com/zksb52.jpg:
 - Zubat
-Who"s that pokemon? http://oi41.tinypic.com/zup2z5.jpg:
+Who's that pokemon? http://oi41.tinypic.com/zup2z5.jpg:
 - Gengar
-Who"s that pokemon? http://oi42.tinypic.com/14t7h9f.jpg:
+Who's that pokemon? http://oi42.tinypic.com/14t7h9f.jpg:
 - Dragonite
-Who"s that pokemon? http://oi42.tinypic.com/14udh8k.jpg:
+Who's that pokemon? http://oi42.tinypic.com/14udh8k.jpg:
 - Omanyte
-Who"s that pokemon? http://oi42.tinypic.com/153322f.jpg:
+Who's that pokemon? http://oi42.tinypic.com/153322f.jpg:
 - Machamp
-Who"s that pokemon? http://oi42.tinypic.com/1scs5g.jpg:
+Who's that pokemon? http://oi42.tinypic.com/1scs5g.jpg:
 - Mew
-Who"s that pokemon? http://oi42.tinypic.com/1z53p1x.jpg:
+Who's that pokemon? http://oi42.tinypic.com/1z53p1x.jpg:
 - Kadabra
-Who"s that pokemon? http://oi42.tinypic.com/24pvv2o.jpg:
+Who's that pokemon? http://oi42.tinypic.com/24pvv2o.jpg:
 - Machoke
-Who"s that pokemon? http://oi42.tinypic.com/28bb0go.jpg:
+Who's that pokemon? http://oi42.tinypic.com/28bb0go.jpg:
 - Dewgong
-Who"s that pokemon? http://oi42.tinypic.com/2i8dh5s.jpg:
+Who's that pokemon? http://oi42.tinypic.com/2i8dh5s.jpg:
 - Pinsir
-Who"s that pokemon? http://oi42.tinypic.com/2n1rpzk.jpg:
+Who's that pokemon? http://oi42.tinypic.com/2n1rpzk.jpg:
 - Voltorb
-Who"s that pokemon? http://oi42.tinypic.com/2rmtf1f.jpg:
+Who's that pokemon? http://oi42.tinypic.com/2rmtf1f.jpg:
 - Cloyster
-Who"s that pokemon? http://oi42.tinypic.com/2vlsnqe.jpg:
+Who's that pokemon? http://oi42.tinypic.com/2vlsnqe.jpg:
 - Starmie
-Who"s that pokemon? http://oi42.tinypic.com/2z4h7jr.jpg:
+Who's that pokemon? http://oi42.tinypic.com/2z4h7jr.jpg:
 - Arcanine
-Who"s that pokemon? http://oi42.tinypic.com/2zzki90.jpg:
+Who's that pokemon? http://oi42.tinypic.com/2zzki90.jpg:
 - Primeape
-Who"s that pokemon? http://oi42.tinypic.com/309sv4l.jpg:
+Who's that pokemon? http://oi42.tinypic.com/309sv4l.jpg:
 - Zapdos
-Who"s that pokemon? http://oi42.tinypic.com/332p8pe.jpg:
+Who's that pokemon? http://oi42.tinypic.com/332p8pe.jpg:
 - Beedrill
-Who"s that pokemon? http://oi42.tinypic.com/33bpctj.jpg:
+Who's that pokemon? http://oi42.tinypic.com/33bpctj.jpg:
 - Doduo
-Who"s that pokemon? http://oi42.tinypic.com/3507xg0.jpg:
+Who's that pokemon? http://oi42.tinypic.com/3507xg0.jpg:
 - Nidoran
-Who"s that pokemon? http://oi42.tinypic.com/b6qcec.jpg:
+Who's that pokemon? http://oi42.tinypic.com/b6qcec.jpg:
 - Jigglypuff
-Who"s that pokemon? http://oi42.tinypic.com/fdgbuq.jpg:
+Who's that pokemon? http://oi42.tinypic.com/fdgbuq.jpg:
 - Scyther
-Who"s that pokemon? http://oi42.tinypic.com/r0e5o6.jpg:
+Who's that pokemon? http://oi42.tinypic.com/r0e5o6.jpg:
 - Ponyta
-Who"s that pokemon? http://oi42.tinypic.com/rjfic7.jpg:
+Who's that pokemon? http://oi42.tinypic.com/rjfic7.jpg:
 - Magneton
-Who"s that pokemon? http://oi42.tinypic.com/sg28ld.jpg:
+Who's that pokemon? http://oi42.tinypic.com/sg28ld.jpg:
 - Victreebel
-Who"s that pokemon? http://oi42.tinypic.com/ta34e9.jpg:
+Who's that pokemon? http://oi42.tinypic.com/ta34e9.jpg:
 - Tangela
-Who"s that pokemon? http://oi42.tinypic.com/vqu1ir.jpg:
+Who's that pokemon? http://oi42.tinypic.com/vqu1ir.jpg:
 - Dugtrio
-Who"s that pokemon? http://oi43.tinypic.com/15dwiva.jpg:
+Who's that pokemon? http://oi43.tinypic.com/15dwiva.jpg:
 - Weedle
-Who"s that pokemon? http://oi43.tinypic.com/15z1l4m.jpg:
+Who's that pokemon? http://oi43.tinypic.com/15z1l4m.jpg:
 - Golem
-Who"s that pokemon? http://oi43.tinypic.com/1zfkehg.jpg:
+Who's that pokemon? http://oi43.tinypic.com/1zfkehg.jpg:
 - Nidoqueen
-Who"s that pokemon? http://oi43.tinypic.com/21dh8hv.jpg:
+Who's that pokemon? http://oi43.tinypic.com/21dh8hv.jpg:
 - Gastly
-Who"s that pokemon? http://oi43.tinypic.com/21m7ou9.jpg:
+Who's that pokemon? http://oi43.tinypic.com/21m7ou9.jpg:
 - Graveler
-Who"s that pokemon? http://oi43.tinypic.com/296ocxg.jpg:
+Who's that pokemon? http://oi43.tinypic.com/296ocxg.jpg:
 - Pidgeotto
-Who"s that pokemon? http://oi43.tinypic.com/2ljg4dl.jpg:
+Who's that pokemon? http://oi43.tinypic.com/2ljg4dl.jpg:
 - Parasect
-Who"s that pokemon? http://oi43.tinypic.com/2nisho6.jpg:
+Who's that pokemon? http://oi43.tinypic.com/2nisho6.jpg:
 - Gloom
-Who"s that pokemon? http://oi43.tinypic.com/2qlhd1e.jpg:
+Who's that pokemon? http://oi43.tinypic.com/2qlhd1e.jpg:
 - Poliwrath
-Who"s that pokemon? http://oi43.tinypic.com/2r548qt.jpg:
+Who's that pokemon? http://oi43.tinypic.com/2r548qt.jpg:
 - Clefable
-Who"s that pokemon? http://oi43.tinypic.com/2rf7cba.jpg:
+Who's that pokemon? http://oi43.tinypic.com/2rf7cba.jpg:
 - Shellder
-Who"s that pokemon? http://oi43.tinypic.com/2v12548.jpg:
+Who's that pokemon? http://oi43.tinypic.com/2v12548.jpg:
 - Persian
-Who"s that pokemon? http://oi43.tinypic.com/2vx3zm1.jpg:
+Who's that pokemon? http://oi43.tinypic.com/2vx3zm1.jpg:
 - Pidgey
-Who"s that pokemon? http://oi43.tinypic.com/2yphtmd.jpg:
+Who's that pokemon? http://oi43.tinypic.com/2yphtmd.jpg:
 - Abra
-Who"s that pokemon? http://oi43.tinypic.com/95q7et.jpg:
+Who's that pokemon? http://oi43.tinypic.com/95q7et.jpg:
 - Kingler
-Who"s that pokemon? http://oi43.tinypic.com/n1uejr.jpg:
+Who's that pokemon? http://oi43.tinypic.com/n1uejr.jpg:
 - Paras
-Who"s that pokemon? http://oi43.tinypic.com/nzkqjs.jpg:
+Who's that pokemon? http://oi43.tinypic.com/nzkqjs.jpg:
 - Rattata
-Who"s that pokemon? http://oi43.tinypic.com/vi305t.jpg:
+Who's that pokemon? http://oi43.tinypic.com/vi305t.jpg:
 - Hitmonlee
-Who"s that pokemon? http://oi43.tinypic.com/xoiqea.jpg:
+Who's that pokemon? http://oi43.tinypic.com/xoiqea.jpg:
 - Exeggutor
-Who"s that pokemon? http://oi44.tinypic.com/15q3kgn.jpg:
+Who's that pokemon? http://oi44.tinypic.com/15q3kgn.jpg:
 - Metapod
-Who"s that pokemon? http://oi44.tinypic.com/209hsmv.jpg:
+Who's that pokemon? http://oi44.tinypic.com/209hsmv.jpg:
 - Geodude
-Who"s that pokemon? http://oi44.tinypic.com/20uo2s3.jpg:
+Who's that pokemon? http://oi44.tinypic.com/20uo2s3.jpg:
 - Poliwhirl
-Who"s that pokemon? http://oi44.tinypic.com/21jp3eu.jpg:
+Who's that pokemon? http://oi44.tinypic.com/21jp3eu.jpg:
 - Sandslash
-Who"s that pokemon? http://oi44.tinypic.com/23t1spf.jpg:
+Who's that pokemon? http://oi44.tinypic.com/23t1spf.jpg:
 - Blastoise
-Who"s that pokemon? http://oi44.tinypic.com/29uoz05.jpg:
+Who's that pokemon? http://oi44.tinypic.com/29uoz05.jpg:
 - Omastar
-Who"s that pokemon? http://oi44.tinypic.com/29xvy3o.jpg:
+Who's that pokemon? http://oi44.tinypic.com/29xvy3o.jpg:
 - Horsea
-Who"s that pokemon? http://oi44.tinypic.com/2cdahdl.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2cdahdl.jpg:
 - Machop
-Who"s that pokemon? http://oi44.tinypic.com/2cnf3i1.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2cnf3i1.jpg:
 - Seaking
-Who"s that pokemon? http://oi44.tinypic.com/2cpaufr.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2cpaufr.jpg:
 - Meowth
-Who"s that pokemon? http://oi44.tinypic.com/2ecfyg4.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2ecfyg4.jpg:
 - Vileplume
-Who"s that pokemon? http://oi44.tinypic.com/2gsh2sg.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2gsh2sg.jpg:
 - Drowzee
-Who"s that pokemon? http://oi44.tinypic.com/2i6gtxh.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2i6gtxh.jpg:
 - Dratini
-Who"s that pokemon? http://oi44.tinypic.com/2qizs5j.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2qizs5j.jpg:
 - Hypno
-Who"s that pokemon? http://oi44.tinypic.com/2qv9k5h.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2qv9k5h.jpg:
 - Raticate
-Who"s that pokemon? http://oi44.tinypic.com/2s1ul48.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2s1ul48.jpg:
 - Kabuto
-Who"s that pokemon? http://oi44.tinypic.com/2vtably.jpg:
+Who's that pokemon? http://oi44.tinypic.com/2vtably.jpg:
 - Pikachu
-Who"s that pokemon? http://oi44.tinypic.com/307p9nb.jpg:
+Who's that pokemon? http://oi44.tinypic.com/307p9nb.jpg:
 - Porygon
-Who"s that pokemon? http://oi44.tinypic.com/33u4t2d.jpg:
+Who's that pokemon? http://oi44.tinypic.com/33u4t2d.jpg:
 - Kangaskhan
-Who"s that pokemon? http://oi44.tinypic.com/34hbf51.jpg:
+Who's that pokemon? http://oi44.tinypic.com/34hbf51.jpg:
 - Squirtle
-Who"s that pokemon? http://oi44.tinypic.com/50fdjs.jpg:
+Who's that pokemon? http://oi44.tinypic.com/50fdjs.jpg:
 - Rapidash
-Who"s that pokemon? http://oi44.tinypic.com/5pqtf7.jpg:
+Who's that pokemon? http://oi44.tinypic.com/5pqtf7.jpg:
 - Seel
-Who"s that pokemon? http://oi44.tinypic.com/70yxb7.jpg:
+Who's that pokemon? http://oi44.tinypic.com/70yxb7.jpg:
 - Oddish
-Who"s that pokemon? http://oi44.tinypic.com/mb74nn.jpg:
+Who's that pokemon? http://oi44.tinypic.com/mb74nn.jpg:
 - Magmar
-Who"s that pokemon? http://oi44.tinypic.com/mw9r3a.jpg:
+Who's that pokemon? http://oi44.tinypic.com/mw9r3a.jpg:
 - Mr. Mime
-Who"s that pokemon? http://oi44.tinypic.com/nmeyk7.jpg:
+Who's that pokemon? http://oi44.tinypic.com/nmeyk7.jpg:
 - Sandshrew
-Who"s that pokemon? http://oi44.tinypic.com/qpfn95.jpg:
+Who's that pokemon? http://oi44.tinypic.com/qpfn95.jpg:
 - Seadra
-Who"s that pokemon? http://oi44.tinypic.com/sbhim0.jpg:
+Who's that pokemon? http://oi44.tinypic.com/sbhim0.jpg:
 - Weepinbell

--- a/redbot/trivia/lists/worldcapitals.yaml
+++ b/redbot/trivia/lists/worldcapitals.yaml
@@ -3,7 +3,7 @@ Name of the capitals of South Africa?:
 - Cape Town
 - capetown
 - Bloemfontein
-Name one of Bolivia"s capitals?:
+Name one of Bolivia's capitals?:
 - La Paz
 - Sucre
 What is the capital of Afghanistan?:
@@ -17,18 +17,18 @@ What is the capital of Andorra?:
 What is the capital of Angola?:
 - Luanda
 What is the capital of Antigua and Barbuda?:
-- Saint John"s
+- Saint John's
 - saint johns
 - st johns
 - st. johns
-- st john"s
-- st. john"s
+- st john's
+- st. john's
 - saintjohns
-- saintjohn"s
+- saintjohn's
 - stjohns
-- stjohn"s
+- stjohn's
 - st.johns
-- st.john"s
+- st.john's
 What is the capital of Argentina?:
 - Buenos Aires
 What is the capital of Armenia?:
@@ -86,7 +86,7 @@ What is the capital of Canada?:
 What is the capital of Central African Republic?:
 - Bangui
 What is the capital of Chad?:
-- N"Djamena
+- N'Djamena
 - ndjamena
 - n djamena
 What is the capital of Chile?:
@@ -101,7 +101,7 @@ What is the capital of Comoros?:
 What is the capital of Costa Rica:
 - San Jose
 - Sanjose
-What is the capital of Cote d"Ivoire?:
+What is the capital of Cote d'Ivoire?:
 - Yamoussoukro
 What is the capital of Croatia?:
 - Zagreb
@@ -155,12 +155,12 @@ What is the capital of Ghana?:
 What is the capital of Greece?:
 - Athens
 What is the capital of Grenada?:
-- St. George"s
+- St. George's
 - st georges
-- st george"s
-- st.george"s
+- st george's
+- st.george's
 - stgeorges
-- stgeorge"s
+- stgeorge's
 What is the capital of Guatemala?:
 - Guatemala City
 What is the capital of Guinea-Bissau?:
@@ -395,7 +395,7 @@ What is the capital of Togo?:
 - Lomé
 - lome
 What is the capital of Tonga?:
-- Nuku"alofa
+- Nuku'alofa
 - nukualofa
 What is the capital of Trinidad and Tobago?:
 - Port of Spain
@@ -428,7 +428,7 @@ What is the capital of Venezuela?:
 What is the capital of Vietnam?:
 - Hanoi
 What is the capital of Yemen?:
-- Sana"a
+- Sana'a
 - sanaa
 - sana a
 What is the capital of Zambia?:

--- a/redbot/trivia/lists/worldflags.yaml
+++ b/redbot/trivia/lists/worldflags.yaml
@@ -58,7 +58,7 @@ What country is represented by this flag? https://i.imgur.com/8F5aqVG.png:
 - Germany
 What country is represented by this flag? https://i.imgur.com/8LFhQVn.png:
 - North Korea
-- People"s Republic of Korea
+- People's Republic of Korea
 What country is represented by this flag? https://i.imgur.com/8OzbswS.png:
 - Armenia
 What country is represented by this flag? https://i.imgur.com/AKvyrB8.png:
@@ -82,7 +82,7 @@ What country is represented by this flag? https://i.imgur.com/BgdKIb2.png:
 - Mozambique
 What country is represented by this flag? https://i.imgur.com/BqwHKYv.png:
 - Malta
-- Hvid Rød
+- Hvid RÃ¸d
 What country is represented by this flag? https://i.imgur.com/C3kWeQw.png:
 - Bahrain
 What country is represented by this flag? https://i.imgur.com/CEetl8W.png:
@@ -156,7 +156,7 @@ What country is represented by this flag? https://i.imgur.com/Os7kijz.png:
 - Mexico
 What country is represented by this flag? https://i.imgur.com/PJpxYhW.png:
 - China
-- People"s Republic of China
+- People's Republic of China
 What country is represented by this flag? https://i.imgur.com/PTjhJ38.png:
 - Zambia
 What country is represented by this flag? https://i.imgur.com/PmWAhic.png:
@@ -166,7 +166,7 @@ What country is represented by this flag? https://i.imgur.com/QclX66O.png:
 What country is represented by this flag? https://i.imgur.com/QpwAZCH.png:
 - Belgium
 What country is represented by this flag? https://i.imgur.com/R36hcy9.png:
-- Cote d"Ivoire
+- Cote d'Ivoire
 - Ivory Coast
 What country is represented by this flag? https://i.imgur.com/RLgBmmx.png:
 - Finland

--- a/redbot/trivia/lists/worldmap.yaml
+++ b/redbot/trivia/lists/worldmap.yaml
@@ -140,7 +140,7 @@ What country is highlighted on this map? https://i.imgur.com/GvlNpbw.png:
 - Iran
 What country is highlighted on this map? https://i.imgur.com/Gxo6qKW.png:
 - North Korea
-- Democratic People"s Republic of Korea
+- Democratic People's Republic of Korea
 What country is highlighted on this map? https://i.imgur.com/J0RBGiH.png:
 - Turkey
 What country is highlighted on this map? https://i.imgur.com/JebFraA.png:
@@ -339,7 +339,7 @@ What country is highlighted on this map? https://i.imgur.com/jxPvm6J.png:
 What country is highlighted on this map? https://i.imgur.com/kBdjnEv.png:
 - Mexico
 What country is highlighted on this map? https://i.imgur.com/kHtsSx9.png:
-- Cote d"Ivoire
+- Cote d'Ivoire
 - Ivory Coast
 What country is highlighted on this map? https://i.imgur.com/lHMAntb.png:
 - Pakistan


### PR DESCRIPTION
Prior to this PR, double quotes were occuring where apostrophes should have been. This was a side-effect of how YAML dumps strings which contain quotes which need to be escaped. I've rewritten my txt-to-yaml script to remedy this, and these are the new lists.

There were also a couple of odd characters like double primes and replacement chars in the lists which have now been replaced.

I'm going to try and get my script up on PyPi so anyone who needs to convert old txt files which aren't in this repo can do so.