### PR TITLE
[Trivia] add .travis.yml + a test for the lists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: trusty
+language: python
+python:
+  - "3.5.3"
+  - "3.6.1"
+install:
+  - echo "pytest>3" >> requirements.txt
+  - echo "pyyaml" >> requirements.txt
+  - pip install -r requirements.txt
+  - pip install -e .
+script:
+  - python -m pytest
+cache: pip
+notifications:
+  email: false

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,0 +1,26 @@
+import redbot.trivia
+import yaml
+
+
+def test_trivia_lists():
+    problem_lists = []
+    list_names = redbot.trivia.lists()
+    for l in list_names:
+        with l.open() as f:
+            try:
+                dict_ = yaml.load(f)
+            except yaml.error.YAMLError as e:
+                problem_lists.append((l.stem, "The list failed to load"))
+            else:
+                for key in list(dict_.keys()):
+                    if key == "CONFIG":
+                        if not isinstance(dict_[key], dict):
+                            problem_lists.append((l.stem, "CONFIG is not a dict"))
+                    else:
+                        if not isinstance(dict_[key], list):
+                            problem_lists.append((l.stem, "The answers for '{}' are not a list".format(key)))
+    if problem_lists:
+        msg = ""
+        for l in problem_lists:
+            msg += "{}: {}\n".format(l[0], l[1])
+        raise TypeError("The following lists contain errors:\n{}".format(msg))


### PR DESCRIPTION
This will allow for automated testing of the lists.

Main things it checks for:
- That the list can be loaded with `yaml.load`
  - this will cause `(list_name, "The list failed to load")` to be appended to the list of problem lists if a failure occurs
- That the value of the `CONFIG` key is a `dict` (only really relevant if `CONFIG` is present)
  - This will cause `(list_name, "CONFIG is not a dict")` to be appended to the list of problem lists if a failure occurs
- That the value of all other keys is a `list`
  - This will cause `(list_name, "The answers for '{insert question here}' are not a list")` to be appended to the list of problem lists if a failure occurs

If a list has a problem, a tuple `(list_name, reason)` gets appended to a list to be handled after all lists have been checked. This means that if a list has multiple problems, it will appear multiple times in the error output. It will also check every list before outputting an error rather than stopping at the first error it finds