### PR TITLE
Actually package the lists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 def get_lists():
-    base_dir = Path('redbot/trivia/lists')
+    base_dir = Path('redbot/ext/trivia/lists')
     parents = base_dir.parents
     return [str(p.relative_to(parents[0])) for p in base_dir.glob("*.yaml")]
 


### PR DESCRIPTION
One thing I missed when modifying the namespace package was modifying the path to the lists. This PR fixes that. Admittedly, this does mean the current release 1.1.0 is completely useless.